### PR TITLE
Update package repositories before build

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install g++-9 libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev
       - name: Build
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install g++-8 libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev
       - name: Build
@@ -54,6 +56,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-16.04]
     steps:
       - uses: actions/checkout@v1
+      - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev
       - name: Build
@@ -72,6 +75,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev
       - name: Build
@@ -93,6 +97,7 @@ jobs:
     runs-on: macOS-10.14
     steps:
       - uses: actions/checkout@v1
+      - run: brew update
       - name: "Install packages"
         run: brew install automake libpng sdl sdl_net sdl_sound
       - name: Build

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev python3-setuptools
       - name: "Install scan-build (Python version)"


### PR DESCRIPTION
Without updating of package repos, build can fail due to circumstances
unrelated to the code.  This fixes e.g. experimental SDL2 builds.