### PR TITLE
Log environment on CI machines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - name: "Log environment"
+        run: ./scripts/log-env.sh
       - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install g++-9 libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev
@@ -34,6 +36,8 @@ jobs:
         os: [ubuntu-18.04, ubuntu-16.04]
     steps:
       - uses: actions/checkout@v1
+      - name: "Log environment"
+        run: ./scripts/log-env.sh
       - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev
@@ -53,6 +57,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - name: "Log environment"
+        run: ./scripts/log-env.sh
       - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev
@@ -75,6 +81,8 @@ jobs:
     runs-on: macOS-10.14
     steps:
       - uses: actions/checkout@v1
+      - name: "Log environment"
+        run: ./scripts/log-env.sh
       - run: brew update
       - name: "Install packages"
         run: brew install automake libpng sdl sdl_net sdl_sound
@@ -94,6 +102,9 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v1
+      - name: "Log environment"
+        shell: pwsh
+        run: .\scripts\log-env.ps1
       - name: "Install packages"
         shell: pwsh
         run: |
@@ -113,6 +124,9 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v1
+      - name: "Log environment"
+        shell: pwsh
+        run: .\scripts\log-env.ps1
       - name: "Install packages"
         shell: pwsh
         run: |

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - name: "Log environment"
+        run: ./scripts/log-env.sh
       - run: sudo apt update
       - name: "Install packages"
         run: sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev python3-setuptools

--- a/scripts/log-env.ps1
+++ b/scripts/log-env.ps1
@@ -1,0 +1,13 @@
+# To use this script in GitHub Actions job:
+#
+#  - name: "Log environment"
+#    shell: pwsh
+#    run: .\scripts\log-env.ps1
+#
+# This script works only on Windows.
+# see also script: log-env.sh
+
+Set-PSDebug -Trace 1
+systeminfo
+gci env:
+Set-PSDebug -Trace 0

--- a/scripts/log-env.sh
+++ b/scripts/log-env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# To use this script in GitHub Actions job:
+#
+#  - name: "Log environment"
+#    shell: bash
+#    run: ./scripts/log-env.sh
+#
+# Line "shell: bash" is optional for Linux and MacOS,
+# but required for Windows; see also script: log-env.ps1
+
+set -x
+uname -a
+uname -s
+uname -m
+env


### PR DESCRIPTION
log-env.sh is cross-platform (works on Linux, MacOS and Windows)

log-env.ps1 is Windows-only and requirs specifying pwsh shell, but
provides some Windows-specific information, that might be useful e.g.
for MSVC builds.