### PR TITLE
CDDA merge (2/x): Tailor SDL_Sound for DOSBox's internal use

### DIFF
--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -32,11 +32,6 @@
 #  include <config.h>
 #endif
 
-#ifdef _MSC_VER
-// Avoid warning about use of strncpy
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <SDL.h>
 #include <SDL_thread.h>
 #include "SDL_sound.h"
@@ -283,8 +278,7 @@ void __Sound_SetError(const char *str)
     } /* if */
 
     err->error_available = 1;
-    strncpy(err->error_string, str, sizeof (err->error_string));
-    err->error_string[sizeof (err->error_string) - 1] = '\0';
+    snprintf(err->error_string, sizeof (err->error_string), "%s", str);
 } /* __Sound_SetError */
 
 

--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -609,7 +609,7 @@ Sound_Sample *Sound_NewSampleFromMem(const Uint8 *data,
     BAIL_IF_MACRO(data == NULL, ERR_INVALID_ARGUMENT, NULL);
     BAIL_IF_MACRO(size == 0, ERR_INVALID_ARGUMENT, NULL);
 
-    rw = SDL_RWFromMem( (void*)data, size);
+    rw = SDL_RWFromConstMem(data, size);
     /* !!! FIXME: rw = RWops_FromMem(data, size);*/
     BAIL_IF_MACRO(rw == NULL, SDL_GetError(), NULL);
 

--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -32,13 +32,13 @@
 #  include <config.h>
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#ifdef _MSC_VER
+// Avoid warning about use of strncpy
+#define _CRT_SECURE_NO_WARNINGS
+#endif
 
-#include "SDL.h"
-#include "SDL_thread.h"
+#include <SDL.h>
+#include <SDL_thread.h>
 #include "SDL_sound.h"
 
 #define __SDL_SOUND_INTERNAL__
@@ -48,21 +48,11 @@
 /* The various decoder drivers... */
 
 /* All these externs may be missing; we check SOUND_SUPPORTS_xxx before use. */
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MPG123;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MIKMOD;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MODPLUG;
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_WAV;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_AIFF;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_AU;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_OGG;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_VOC;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_RAW;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_SHN;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MIDI;
+extern const Sound_DecoderFunctions __Sound_DecoderFunctions_VORBIS;
+extern const Sound_DecoderFunctions __Sound_DecoderFunctions_OPUS;
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_FLAC;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_QuickTime;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_SPEEX;
-extern const Sound_DecoderFunctions __Sound_DecoderFunctions_CoreAudio;
+extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MP3;
 
 typedef struct
 {
@@ -72,66 +62,11 @@ typedef struct
 
 static decoder_element decoders[] =
 {
-#if (defined SOUND_SUPPORTS_MPG123)
-    { 0, &__Sound_DecoderFunctions_MPG123 },
-#endif
-
-#if (defined SOUND_SUPPORTS_MODPLUG)
-    { 0, &__Sound_DecoderFunctions_MODPLUG },
-#endif
-
-#if (defined SOUND_SUPPORTS_MIKMOD)
-    { 0, &__Sound_DecoderFunctions_MIKMOD },
-#endif
-
-#if (defined SOUND_SUPPORTS_WAV)
     { 0, &__Sound_DecoderFunctions_WAV },
-#endif
-
-#if (defined SOUND_SUPPORTS_AIFF)
-    { 0, &__Sound_DecoderFunctions_AIFF },
-#endif
-
-#if (defined SOUND_SUPPORTS_AU)
-    { 0, &__Sound_DecoderFunctions_AU },
-#endif
-
-#if (defined SOUND_SUPPORTS_OGG)
-    { 0, &__Sound_DecoderFunctions_OGG },
-#endif
-
-#if (defined SOUND_SUPPORTS_VOC)
-    { 0, &__Sound_DecoderFunctions_VOC },
-#endif
-
-#if (defined SOUND_SUPPORTS_RAW)
-    { 0, &__Sound_DecoderFunctions_RAW },
-#endif
-
-#if (defined SOUND_SUPPORTS_SHN)
-    { 0, &__Sound_DecoderFunctions_SHN },
-#endif
-
-#if (defined SOUND_SUPPORTS_FLAC)
+    { 0, &__Sound_DecoderFunctions_VORBIS },
+    { 0, &__Sound_DecoderFunctions_OPUS },
     { 0, &__Sound_DecoderFunctions_FLAC },
-#endif
-
-#if (defined SOUND_SUPPORTS_MIDI)
-    { 0, &__Sound_DecoderFunctions_MIDI },
-#endif
-
-#if (defined SOUND_SUPPORTS_QUICKTIME)
-    { 0, &__Sound_DecoderFunctions_QuickTime },
-#endif
-
-#if (defined SOUND_SUPPORTS_SPEEX)
-    { 0, &__Sound_DecoderFunctions_SPEEX },
-#endif
-
-#if (defined SOUND_SUPPORTS_COREAUDIO)
-    { 0, &__Sound_DecoderFunctions_CoreAudio },
-#endif
-
+    { 0, &__Sound_DecoderFunctions_MP3 },
     { 0, NULL }
 };
 
@@ -653,6 +588,10 @@ Sound_Sample *Sound_NewSampleFromFile(const char *filename,
     BAIL_IF_MACRO(filename == NULL, ERR_INVALID_ARGUMENT, NULL);
 
     ext = strrchr(filename, '.');
+
+
+    SNDDBG(("Sound_NewSampleFromFile ext = `%s`", ext));
+
     rw = SDL_RWFromFile(filename, "rb");
     /* !!! FIXME: rw = RWops_FromFile(filename, "rb");*/
     BAIL_IF_MACRO(rw == NULL, SDL_GetError(), NULL);
@@ -676,7 +615,7 @@ Sound_Sample *Sound_NewSampleFromMem(const Uint8 *data,
     BAIL_IF_MACRO(data == NULL, ERR_INVALID_ARGUMENT, NULL);
     BAIL_IF_MACRO(size == 0, ERR_INVALID_ARGUMENT, NULL);
 
-    rw = SDL_RWFromMem(data, size);
+    rw = SDL_RWFromMem( (void*)data, size);
     /* !!! FIXME: rw = RWops_FromMem(data, size);*/
     BAIL_IF_MACRO(rw == NULL, SDL_GetError(), NULL);
 

--- a/src/libs/decoders/SDL_sound.h
+++ b/src/libs/decoders/SDL_sound.h
@@ -176,7 +176,7 @@ typedef struct
     Sound_AudioInfo actual;  /**< Actual audio format of sample. */
     void *buffer;  /**< Decoded sound data lands in here. */
     Uint32 buffer_size;  /**< Current size of (buffer), in bytes (Uint8). */
-    Sound_SampleFlags flags;  /**< Flags relating to this sample. */
+    Uint32 flags;  /**< Flags relating to this sample. */
 } Sound_Sample;
 
 
@@ -717,9 +717,12 @@ SNDDECLSPEC int SDLCALL Sound_Rewind(Sound_Sample *sample);
  */
 SNDDECLSPEC int SDLCALL Sound_Seek(Sound_Sample *sample, Uint32 ms);
 
+
 #ifdef __cplusplus
 }
+#endif
 
+/*
 inline Sound_SampleFlags operator|(Sound_SampleFlags a, Sound_SampleFlags b)
 {return static_cast<Sound_SampleFlags>(static_cast<int>(a) | static_cast<int>(b));}
 
@@ -732,6 +735,7 @@ inline Sound_SampleFlags operator& (Sound_SampleFlags a, Sound_SampleFlags b)
 inline Sound_SampleFlags& operator&= (Sound_SampleFlags& a, Sound_SampleFlags b)
 { return (Sound_SampleFlags&)((int&)a &= (int)b); }
 #endif
+*/
 
 #endif  /* !defined _INCLUDE_SDL_SOUND_H_ */
 

--- a/src/libs/decoders/SDL_sound.h
+++ b/src/libs/decoders/SDL_sound.h
@@ -45,7 +45,8 @@
  *   - .MP3  (MPEG-1 Layer 3 support, via libmpg123.)
  *   - .MID  (MIDI music converted to Waveform data, internal.)
  *   - .MOD  (MOD files, via MikMod and ModPlug.)
- *   - .OGG  (Ogg files, via Ogg Vorbis libraries.)
+ *   - .OGG  (Ogg Vorbis files, via the Vorbis libraries.)
+ *   - .OPUS (Ogg Opus files, via the Opus libraries.)
  *   - .SPX  (Speex files, via libspeex.)
  *   - .SHN  (Shorten files, internal.)
  *   - .RAW  (Raw sound data in any format, internal.)
@@ -64,8 +65,8 @@
 #ifndef _INCLUDE_SDL_SOUND_H_
 #define _INCLUDE_SDL_SOUND_H_
 
-#include "SDL.h"
-#include "SDL_endian.h"
+#include <SDL.h>
+#include <SDL_endian.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,17 +109,16 @@ extern "C" {
  */
 typedef enum
 {
-    SOUND_SAMPLEFLAG_NONE    = 0,       /**< No special attributes. */
+    SOUND_SAMPLEFLAG_NONE    = 0x0, /**< No special attributes. */
 
-        /* these are set at sample creation time... */
-    SOUND_SAMPLEFLAG_CANSEEK = 1,       /**< Sample can seek to arbitrary points. */
+    /* these are set at sample creation time... */
+    SOUND_SAMPLEFLAG_CANSEEK = 0x1, /**< Sample can seek to arbitrary points. */
 
-        /* these are set during decoding... */
-    SOUND_SAMPLEFLAG_EOF     = 1 << 29, /**< End of input stream. */
-    SOUND_SAMPLEFLAG_ERROR   = 1 << 30, /**< Unrecoverable error. */
-    SOUND_SAMPLEFLAG_EAGAIN  = 1 << 31  /**< Function would block, or temp error. */
+    /* these are set during decoding... */
+    SOUND_SAMPLEFLAG_EOF     = 0x2, /**< End of input stream. */
+    SOUND_SAMPLEFLAG_ERROR   = 0x4, /**< Unrecoverable error. */
+    SOUND_SAMPLEFLAG_EAGAIN  = 0x8  /**< Function would block, or temp error. */
 } Sound_SampleFlags;
-
 
 /**
  * \struct Sound_AudioInfo
@@ -729,6 +729,18 @@ SNDDECLSPEC int SDLCALL Sound_Seek(Sound_Sample *sample, Uint32 ms);
 
 #ifdef __cplusplus
 }
+
+inline Sound_SampleFlags operator|(Sound_SampleFlags a, Sound_SampleFlags b)
+{return static_cast<Sound_SampleFlags>(static_cast<int>(a) | static_cast<int>(b));}
+
+inline Sound_SampleFlags& operator|= (Sound_SampleFlags& a, Sound_SampleFlags b)
+{ return (Sound_SampleFlags&)((int&)a |= static_cast<int>(b)); }
+
+inline Sound_SampleFlags operator& (Sound_SampleFlags a, Sound_SampleFlags b)
+{ return (Sound_SampleFlags)((int)a & (int)b); }
+
+inline Sound_SampleFlags& operator&= (Sound_SampleFlags& a, Sound_SampleFlags b)
+{ return (Sound_SampleFlags&)((int&)a &= (int)b); }
 #endif
 
 #endif  /* !defined _INCLUDE_SDL_SOUND_H_ */

--- a/src/libs/decoders/SDL_sound.h
+++ b/src/libs/decoders/SDL_sound.h
@@ -39,22 +39,12 @@
  *  which is a powerful, free, and cross-platform multimedia library. It can
  *  be found at http://www.libsdl.org/
  *
- * Support is in place or planned for the following sound formats:
- *   - .WAV  (Microsoft WAVfile RIFF data, internal.)
- *   - .VOC  (Creative Labs' Voice format, internal.)
- *   - .MP3  (MPEG-1 Layer 3 support, via libmpg123.)
- *   - .MID  (MIDI music converted to Waveform data, internal.)
- *   - .MOD  (MOD files, via MikMod and ModPlug.)
- *   - .OGG  (Ogg Vorbis files, via the Vorbis libraries.)
- *   - .OPUS (Ogg Opus files, via the Opus libraries.)
- *   - .SPX  (Speex files, via libspeex.)
- *   - .SHN  (Shorten files, internal.)
- *   - .RAW  (Raw sound data in any format, internal.)
- *   - .AU   (Sun's Audio format, internal.)
- *   - .AIFF (Audio Interchange format, internal.)
- *   - .FLAC (Lossless audio compression, via libFLAC.)
- *
- *   (...and more to come...)
+ * Support is in place for the following sound formats:
+ *   - .WAV/.W64 (Microsoft WAVfile RIFF and Sony Wave64 data, via the dr_wav single-header codec)
+ *   - .MP3  (MPEG-1 Layer 3 support via the dr_mp3 single-header decoder)
+ *   - .OGG  (Ogg Vorbis support via the std_vorbis single-header decoder)
+ *   - .OPUS (Ogg Opus support via the Opusfile and SpeexDSP libraries)
+ *   - .FLAC (Free Lossless Audio Codec support via the dr_flac single-header decoder)
  *
  * Please see the file LICENSE.txt in the source's root directory.
  *

--- a/src/libs/decoders/SDL_sound_internal.h
+++ b/src/libs/decoders/SDL_sound_internal.h
@@ -33,7 +33,7 @@
 #error Do not include this header from your applications.
 #endif
 
-#include "SDL.h"
+#include <SDL.h>
 
 /* SDL 1.2.4 defines this, but better safe than sorry. */
 #if (!defined(__inline__))

--- a/src/libs/decoders/audio_convert.c
+++ b/src/libs/decoders/audio_convert.c
@@ -31,9 +31,7 @@
 #  include <config.h>
 #endif
 
-#include "SDL.h"
 #include "SDL_sound.h"
-
 #define __SDL_SOUND_INTERNAL__
 #include "SDL_sound_internal.h"
 


### PR DESCRIPTION
This PR makes several minor changes to SDL_Sound for our use within DOSBox:
 - Removes extraneous (and unused) includes
 - Cleans up many compiler warnings
 - Fixes SDL include statements (uses proper `#include <file.h>` directives given the prior `#include "file.h"` directives should only be used when including a project's own header files instead of `-Ipath` provided system headers)
 - Eliminates extraneous codecs

Many of these were made after building SDL_Sound under various compilers and operating systems and hitting various issues.  It currently builds clean without errors or warnings on all our workflow compilers and versions.