### PR TITLE
Simplify package listing script and standardize workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,48 +1,48 @@
-name: "Linux builds"
+name: Linux builds
 on: push
 jobs:
 
-  build_ubuntu_gcc9:
-    name: "GCC 9 (ubuntu-18.04)"
+  build_ubuntu_clang_8:
+    name: Clang 8 (ubuntu-18.04)
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - name: "Log environment"
-        run: ./scripts/log-env.sh
+      - name: Log environment
+        run:  ./scripts/log-env.sh
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh --compiler-version 9)
+        run:  sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt --compiler clang --compiler-version 8)
       - name: Build
-        run: ./scripts/build.sh --compiler-version 9 --lto
-      - name: "Summarize warnings"
-        run: ./scripts/count-warnings.py build.log
+        run:  ./scripts/build.sh --compiler clang --compiler-version 8 --lto
+      - name: Summarize warnings"
+        run:  ./scripts/count-warnings.py build.log
 
-  build_ubuntu_gcc_defaults:
-    name: "GCC"
+  build_ubuntu_matrix_gcc:
+    name: GCC
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-16.04]
     steps:
       - uses: actions/checkout@v1
-      - name: "Log environment"
-        run: ./scripts/log-env.sh
+      - name: Log environment
+        run:  ./scripts/log-env.sh
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh)
+        run:  sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt)
       - name: Build
         run: ./scripts/build.sh
-      - name: "Summarize warnings"
-        run: ./scripts/count-warnings.py build.log
+      - name: Summarize warnings
+        run:  ./scripts/count-warnings.py build.log
 
-  build_ubuntu_clang_8:
-    name: "Clang 8 (ubuntu-18.04)"
+  build_ubuntu_gcc9:
+    name: GCC 9 (ubuntu-18.04)
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - name: "Log environment"
-        run: ./scripts/log-env.sh
+      - name: Log environment
+        run:  ./scripts/log-env.sh
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh --compiler clang --compiler-version 8)
+        run:  sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt --compiler-version 9)
       - name: Build
-        run: ./scripts/build.sh --compiler clang --compiler-version 8 --lto
-      - name: "Summarize warnings"
-        run: ./scripts/count-warnings.py build.log
+        run:  ./scripts/build.sh --compiler-version 9 --lto
+      - name: Summarize warnings
+        run:  ./scripts/count-warnings.py build.log

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,16 +1,59 @@
-name: "macOS builds"
+name: macOS builds
 on: push
 jobs:
-  build_macos_clang:
-    name: "Clang (macOS-10.14)"
+  build_macos_xcode_clang:
+    name: Clang 10 (Xcode)
     runs-on: macOS-10.14
     steps:
       - uses: actions/checkout@v1
-      - name: "Log environment"
-        run: ./scripts/log-env.sh
+      - name: Log environment
+        run:  ./scripts/log-env.sh
       - name: Install dependencies
-        run: brew install $(./scripts/list-build-dependencies.sh --compiler clang)
+        run:  brew install $(./scripts/list-build-dependencies.sh -p brew --compiler clang)
       - name: Build
-        run: ./scripts/build.sh --compiler clang --lto
-      - name: "Summarize warnings"
-        run: python3 ./scripts/count-warnings.py build.log
+        run:  ./scripts/build.sh --compiler clang --lto
+      - name: Summarize warnings
+        run:  python3 ./scripts/count-warnings.py build.log
+
+
+#  build_macos_brew_gcc9:
+#    name: GCC 9 (Homebrew)
+#    runs-on: macOS-10.14
+#    steps:
+#      - uses: actions/checkout@v1
+#      - name: Log environment
+#        run:  ./scripts/log-env.sh
+#      - name: Install dependencies
+#        run:  brew install $(./scripts/list-build-dependencies.sh -p brew --compiler-version 9)
+#      - name: Build
+#        run:  echo ./scripts/build.sh --compiler-version 9 --lto
+#      - name: Summarize warnings
+#        run:  echo python3 ./scripts/count-warnings.py build.log
+
+
+#  build_macos_macports_gcc9:
+#    name: GCC 9 (MacPorts)
+#    runs-on: macOS-10.14
+#    steps:
+#      - uses: actions/checkout@v1
+#      - name: Install MacPorts
+#        run: |
+#          # xcode-select --install || true
+#          # sudo xcodebuild -license || true
+#          git clone --quiet --depth=1 https://github.com/macports/macports-base.git
+#          cd macports-base
+#          ./configure
+#          make -j"$(sysctl -n hw.physicalcpu || echo 4)"
+#          sudo make install
+#
+#      - name: Install dependencies
+#        run: |
+#          PATH="/opt/local/sbin:/opt/local/bin:${PATH}"
+#          sudo port -q selfupdate || true
+#          sudo port -q install $(./scripts/list-build-dependencies.sh -p macports --compiler-version 9)
+#
+#      - name: Build
+#        run:  echo ./scripts/build.sh --compiler-version mp-9 --bin-path /opt/local/bin
+#      - name: Summarize warnings
+#        run:  echo python3 ./scripts/count-warnings.py build.log
+

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,19 +3,18 @@ name: Static code analysis
 on: [push]
 
 jobs:
-
   build_clang_static_analyser:
-    name: "Clang static analyzer"
+    name: Clang static analyzer
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - name: "Log environment"
-        run: ./scripts/log-env.sh
-      - run: sudo apt update
-      - name: "Install packages"
-        run: sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev python3-setuptools
-      - name: "Install scan-build (Python version)"
-        run: sudo pip3 install scan-build beautifulsoup4 html5lib
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - run:  sudo apt update
+      - name: Install packages
+        run:  sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev python3-setuptools
+      - name: Install scan-build (Python version)
+        run:  sudo pip3 install scan-build beautifulsoup4 html5lib
       - name: Build
         run: |
           # build steps
@@ -25,7 +24,7 @@ jobs:
           ./configure
           intercept-build make -j "$(nproc)"
       - name: Analyze
-        run: analyze-build -v -o report --html-title="dosbox-staging (${GITHUB_SHA:0:8})"
+        run:  analyze-build -v -o report --html-title="dosbox-staging (${GITHUB_SHA:0:8})"
       - uses: actions/upload-artifact@master
         with:
           name: report

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,23 +1,96 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 
-name: "Windows builds"
+name: Windows builds
 on: push
 jobs:
 
-  build_msvc_debug:
-    name: "MSVC 14 Debug (win-2019)"
+  build_msys2_clang_32:
+    name: Clang 8 i686 (MSYS2)
     runs-on: windows-2019
+    env:
+      CHERE_INVOKING: yes
     steps:
       - uses: actions/checkout@v1
-      - name: "Log environment"
+      - name: Install msys2 environment
+        run:  choco install msys2 --no-progress
+      - name: Log environment
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
+      - name: Install dependencies
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 --compiler clang --bit-depth 32 | xargs pacman -S --noconfirm"
+      - name: Build
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --compiler clang --bit-depth 32 --bin-path /mingw32/bin"
+      - name: Summarize warnings
+        run:  .\scripts\count-warnings.py build.log
+
+  build_msys2_clang_64:
+    name: Clang 8 x86_64 (MSYS2)
+    runs-on: windows-2019
+    env:
+      CHERE_INVOKING: yes
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install msys2 environment
+        run:  choco install msys2 --no-progress
+      - name: Log environment
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
+      - name: Install dependencies
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 --compiler clang | xargs pacman -S --noconfirm"
+      - name: Build
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --compiler clang --bin-path /mingw64/bin"
+      - name: Summarize warnings
+        run:  .\scripts\count-warnings.py build.log
+
+  build_msys2_gcc_32:
+    name: GCC 9 i686 (MSYS2)
+    runs-on: windows-2019
+    env:
+      CHERE_INVOKING: yes
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install msys2 environment
+        run:  choco install msys2 --no-progress
+      - name: Log environment
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
+      - name: Install dependencies
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 --bit-depth 32 | xargs pacman -S --noconfirm"
+      - name: Build
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --bit-depth 32 --bin-path /mingw32/bin"
+      - name: Summarize warnings
+        run:  .\scripts\count-warnings.py build.log
+
+
+  build_msys2_gcc_64:
+    name: GCC 9 x86_64 (MSYS2)
+    runs-on: windows-2019
+    env:
+      CHERE_INVOKING: yes
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install msys2 environment
+        run:  choco install msys2 --no-progress
+      - name: Log environment
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
+      - name: Install dependencies
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 | xargs pacman -S --noconfirm"
+      - name: Build
+        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --bin-path /mingw64/bin"
+      - name: Summarize warnings
+        run:  .\scripts\count-warnings.py build.log
+
+  build_msvc_debug:
+    name: MSVC Debug x86 (win-2019)
+    runs-on: windows-2019
+    steps:
+      - uses:  actions/checkout@v1
+      - name:  Log environment
         shell: pwsh
-        run: .\scripts\log-env.ps1
-      - name: "Install packages"
+        run:   .\scripts\log-env.ps1
+      - name:  Install packages
         shell: pwsh
         run: |
           vcpkg install libpng sdl1 sdl1-net
           vcpkg integrate install
-      - name: "Build"
+      - name:  Build
         shell: pwsh
         env:
           PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
@@ -26,21 +99,20 @@ jobs:
           cd visualc_net
           MSBuild -m dosbox.sln -p:Configuration=Debug
 
-
   build_msvc_release:
-    name: "MSVC 14 Release (win-2019)"
+    name: MSVC Release x86 (win-2019)
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v1
-      - name: "Log environment"
+      - uses:  actions/checkout@v1
+      - name:  Log environment
         shell: pwsh
-        run: .\scripts\log-env.ps1
-      - name: "Install packages"
+        run:   .\scripts\log-env.ps1
+      - name:  Install packages
         shell: pwsh
         run: |
           vcpkg install libpng sdl1 sdl1-net
           vcpkg integrate install
-      - name: "Build"
+      - name:  Build
         shell: pwsh
         env:
           PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
@@ -50,93 +122,3 @@ jobs:
           MSBuild -m dosbox.sln -p:Configuration=Release
 
 
-  build_msys2_gcc_64:
-    name: MSYS2 GCC-9 x86_64
-    runs-on: windows-2019
-    env:
-      CHERE_INVOKING: yes
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-
-      - name: "Log environment"
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh | xargs pacman -S --noconfirm"
-
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --bin-path /mingw64/bin"
-
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log
-
-
-  build_msys2_gcc_32:
-    name: MSYS2 GCC-9 i686
-    runs-on: windows-2019
-    env:
-      CHERE_INVOKING: yes
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-
-      - name: "Log environment"
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh --bit-depth 32 | xargs pacman -S --noconfirm"
-
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --bit-depth 32 --bin-path /mingw32/bin"
-
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log
-
-
-  build_msys2_clang_64:
-    name: MSYS2 Clang-8 x86_64
-    runs-on: windows-2019
-    env:
-      CHERE_INVOKING: yes
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-
-      - name: "Log environment"
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh --compiler clang | xargs pacman -S --noconfirm"
-
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --compiler clang --bin-path /mingw64/bin"
-
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log
-
-
-  build_msys2_clang_32:
-    name: MSYS2 Clang-8 i686
-    runs-on: windows-2019
-    env:
-      CHERE_INVOKING: yes
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-
-      - name: "Log environment"
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh --compiler clang --bit-depth 32 | xargs pacman -S --noconfirm"
-
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --compiler clang --bit-depth 32 --bin-path /mingw32/bin"
-
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ aclocal.m4
 autom4te.cache
 config.h
 config.h.in
+config.h.in~
 config.log
 config.status
 config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ distclean-local:
 	-rm compile
 	-rm config.guess
 	-rm config.h.in
+	-rm config.h.in~
 	-rm config.log
 	-rm config.sub
 	-rm configure

--- a/scripts/build.md
+++ b/scripts/build.md
@@ -1,33 +1,30 @@
-# DOSBox build script
+# DOSBox Build Script
 
-A helper-script that builds DOSBox with varying compilers, release types, and versions
-on MacOS, Linux, and Windows.
+A script that builds DOSBox with your choice of compiler, release types, and
+additional optimization options on MacOS, Linux, and Windows.
 
-A second script, **list-build-dependencies.sh** prints a list of package and library
-dependencies used to build and link DOSBox, customized for your hardware, operating system,
-and selected compiler and its version.  You can use this script's output to install
-those necessary packages.
+If this is the first time you are attempting to build DOSBox, then you need to
+first install the development tools and DOSBox's development packages prior to
+building. To help in this regard, the **list-build-dependencies.sh** script
+prints a list of packages that you can use to install these dependencies.
+
+Use of both scripts is described below.
 
 ## Requirements
 
 - **Windows newer than XP**
     - **NTFS-based C:**, because msys2 doesn't work on FAT filesystems
-	- **Chocolately**, to install msys2
-
 - **MacOS** 10.x
-	- **brew**, as the package manager
-
 - **Ubuntu** 16.04 or newer
-	- **apt**, as the package manager
-	- **sudo**, to permit installation of depedencies (optional) 
-
-- **Build dependencies (all operating systems)**
-    - Per those listed by the accompanying list-build-dependencies.sh script
+- **Fedora** up-to-date
+- **RedHat or CentOS** 7 or newer
+- **Arch-based distribution** up-to-date
+- **OpenSUSE Leap** 15 or newer
 
 ## Windows Installation and Usage
 
 1. Download and install Chocolatey: https://chocolatey.org/install
-1. Open a console and run Cholocatey's command line interface (CLI) to install msys2:  
+1. Open a console and run Cholocatey's command line interface (CLI) to install msys2 and git:  
    `choco install msys2 git --no-progress`
 
     ```
@@ -47,47 +44,81 @@ those necessary packages.
    PATH environment variable does not have C:\tools\msys64 in it. Adding...
    ```
 
-1. Open a new console and clone the DOSBox staging repository:  
-   `git clone https://github.com/dreamer/dosbox-staging.git`
+1. Launch a new MSYS2 terminal (not a CMD prompt or Powershell window):
+    1. Start Menu > Run ... `c:\tools\msys64\msys2_shell.cmd`
+    1. Run all subsequent steps within this terminal.
 
-1. [optional] Install the build tools and package dependencies, if not yet done so:
-   ``` shell
-   cd dosbox-staging
-   SET CWD=%cd%
-   bash -lc "pacman -S --noconfirm $($CWD/scripts/list-build-dependencies.sh)"
-   ```
+1. Clone and enter the repository's directory:
+    1. `git clone https://github.com/dreamer/dosbox-staging.git`
+    1. `cd dosbox-staging`
+    1. Run all subsequent steps while residing in the repo's directory.
 
-1. Launch the build script with default settings:
-   ``` shell
-   cd dosbox-staging
-   SET CWD=%cd%
-   bash -lc "$CWD/scripts/build.sh --bin-path /mingw64/bin --src-path $CWD"
-   ```
+1. (🏁 first-time-only) Install the build tools and package dependencies:  
+   `./scripts/list-build-dependencies.sh -p msys2 | xargs pacman -S --noconfirm`
+
+1. Launch the build script with default settings:  
+   `./scripts/build.sh --bin-path /mingw64/bin`
+
 
 ## MacOS Installation and Usage
 
-1. Download and install brew: https://brew.sh
-1. Install git: `brew install git`
+Builds on Mac can be performed with Clang or GCC.
+
+If you only plan on only building with Clang, then follow the Brew installation steps.
+If you're interested in building with GCC, then either Brew or MacPorts will work.
+Both can be installed without conflicting with eachother.
+
+Before installing either, the Xcode tools need to be installed and the license agreed to:
+
+###  Xcode Installation
+1. Install the command line tools: `xcode-select --install`
+1. Accept the license agreement: `sudo xcodebuild -license`
+
+
+### Brew Installation
+1. Download and install brew per the instructions here: https://brew.sh
+1. Update it with: `brew update`
+1. Install git with: `brew install git`
+1. Install DOSBox dependencies: `brew install $(./scripts/list-build-dependencies.sh -p brew)`
+
+
+### MacPorts Installation
+
+1. Build and install MacPorts along with DOSBox dependencies with the following sequence:
+
+    ``` shell
+    git clone --quiet --depth=1 https://github.com/macports/macports-base.git
+    cd macports-base
+    ./configure
+    make -j"$(sysctl -n hw.physicalcpu || echo 4)"
+    sudo make install
+    PREFIX="/opt/local"
+    PATH="${PREFIX}/sbin:${PREFIX}/bin:${PATH}"
+    sudo port -q selfupdate
+    sudo port -q install $(/scripts/list-build-dependencies.sh -p macports)
+    ```
+
+### Build DOSBox (common for all of the above)
+
 1. Clone the repository: `git clone https://github.com/dreamer/dosbox-staging.git`
 1. Change directories into the repo: `cd dosbox-staging`
-1. [optional] Install the build tools and package dependencies, if not yet done so:
-   ``` shell
-   brew update
-   brew install $(./scripts/list-build-dependencies.sh)
-   ```
-1. Build DOSBox: `./scripts/build.sh`
+1. Build DOSBox:
+    - Clang: `./scripts/build.sh --compiler clang --bin-path /usr/local/bin`
+    - GCC (brew): `./scripts/build.sh --compiler-version 9 --bin-path /usr/local/bin`
+    - GCC (macports): `./scripts/build.sh --compiler-version mp-9 --bin-path /opt/local/bin`
 
-## Linux (Ubuntu/Debian-based) Installation and Usage
+## Linux Installation
+
+1. (🏁 first-time-only) Install dependencies based on your package manager; apt in this example:  
+    `sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt)`  
+    For other supported package managers, run:  
+    `./scripts/list-build-dependencies.sh --help`
 
 1. Install git: `sudo apt install -y git`
 1. Clone the repository: `git clone https://github.com/dreamer/dosbox-staging.git`
 1. Change directories into the repo: `cd dosbox-staging`
-1. [optional] Install the build tools and package dependencies, if not yet done so:
-   ``` shell
-   sudo apt update -y
-   sudo apt install -y $(./scripts/list-build-dependencies.sh)
-   ```
 1. Build DOSBox: `./scripts/build.sh`
+
 
 ## Additional Tips
 
@@ -97,7 +128,7 @@ options to the **list-build-dependencies.sh** and **build.sh** scripts:
 * `--compiler-version 8`, to use a specific version of compiler (if available in your package manager)
 * `--bit-depth 32`, to build a 32-bit binary instead of 64-bit
 
-After building, your binary will reside inside the src/ directory.
+After building, your `dosbox` or `dosbox.exe` binary will reside inside `./dosbox-staging/src/`.
 
 Build flags you might be interested in:
 * `--release debug`, to build a binary containing debug symbols (instead of **fast** or **small**)
@@ -107,4 +138,3 @@ The above flags are othogonal and thus can be mixed-and-matched as desired.
 
 If you want to run multiple back-to-back builds from the same directory with different settings then
 add the `--clean` flag to ensure previous objects and binaries are removed.
-


### PR DESCRIPTION
**Package listing script changes:**
- Replaces host autodetection with a user-specified package manager.
   This approach resolves the ambiguity if a system has more than
   one package manager (ie: macports & brew)
- Adds packages for Fedora, RedHat/CentOS, Arch, and OpenSuse
- Eliminates unnecessary code in the package manager script
   (more can be eliminate at the expense of complexity)
- Fixes #24 

**Build script changes:**
- Packs shorter one-line if/else statements into single lines
- Makes a couple small fixes to accommodate different tools across hosts

**YAML workflows changes:**
- Names individual workflow per: "Compiler Version (Environment)"
- Sorts build names alphabetically
- Adds spacing to create alignment across value, where it improves readability
- Drops the few quotes around YAML strings
- Adds macOS workflows for Homebrew and MacPorts, both ready to
  go and tested, but with the build step just commented out

**Build documentation changes:**
- Updates and adds more package managers to the documentation