### PR TITLE
CDDA merge (4/x): Connect CD audio codecs into DOSBox and improve how DOSBox uses them

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run:  sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt)
       - name: Build
-        run: ./scripts/build.sh
+        run:  ./scripts/build.sh
       - name: Summarize warnings
         run:  ./scripts/count-warnings.py build.log
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -12,7 +12,7 @@ jobs:
         run:  ./scripts/log-env.sh
       - run:  sudo apt update
       - name: Install packages
-        run:  sudo apt-get install libsdl1.2-dev libsdl-net1.2-dev libsdl-sound1.2-dev python3-setuptools
+        run:  sudo apt-get install autoconf-archive libsdl1.2-dev libsdl-net1.2-dev libopusfile-dev libspeexdsp-dev python3-setuptools
       - name: Install scan-build (Python version)
         run:  sudo pip3 install scan-build beautifulsoup4 html5lib
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,7 @@ jobs:
       - name:  Install packages
         shell: pwsh
         run: |
-          vcpkg install libpng sdl1 sdl1-net
+          vcpkg install libpng sdl1 sdl1-net opusfile speexdsp
           vcpkg integrate install
       - name:  Build
         shell: pwsh
@@ -110,7 +110,7 @@ jobs:
       - name:  Install packages
         shell: pwsh
         run: |
-          vcpkg install libpng sdl1 sdl1-net
+          vcpkg install libpng sdl1 sdl1-net opusfile speexdsp
           vcpkg integrate install
       - name:  Build
         shell: pwsh

--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,4 @@
-Things needed for compilation.
+DOSBox uses the following libraries:
 
 SDL 
     The Simple DirectMedia Library available at http://www.libsdl.org
@@ -9,6 +9,25 @@ SDL
     Licensed under LGPL
     Note that only version 1.2 and its subversions (1.2.8, 1.2.13 etc.)
     are currently supported.
+
+Opusfile, by Xiph
+    For compressed audio tracks (.opus) used with CDROM images.
+    Sources are available at https://opus-codec.org, however it is
+    also conveniently packages by all popular package managers for
+    Windows (MSYS2, MinGW, and Chocolatey), Linux (apt, dnf, zypper,
+    pacman), and OS X (Homebrew and MacPorts).  Opus is today's
+    leading compression format and has replaced Vorbis as Ogg's
+    recommended lossy format. Is widely used in the largest audio and
+    video distribution platforms such as YouTube.
+    License: three-clause BSD
+
+SpeexDSP, by Xiph
+    Needed to perform on-the-fly resampling of Opus-compressed CDROM
+    audio data in the event DOSBox's mixer sampling rate differs from
+    that of the Opus sampling rate. Sources are available at
+    https://opus-codec.org, however it is also conveniently packages
+    by all popular package managers.
+    License: three-clause BSD
 
 Curses (optional)
     If you want to enable the debugger you need a curses library.
@@ -32,19 +51,18 @@ SDL_Net (optional)
     For modem/ipx support. Get it from http://www.libsdl.org/projects/SDL_net/
     Licensed under LGPL
 
-SDL_Sound 
-    For compressed audio on diskimages. (optional)
-    This is for cue/bin cdrom images with compressed (mp3/ogg) audio tracks.
-    Get it from http://icculus.org/SDL_sound
-    Licenced under LGPL
-
-ALSA_Headers
-    (optional)
-    for Alsa support under linux. Part of the linux kernel sources
+alsa-lib (optional)
+    For ALSA audio support under linux. Get it from https://www.alsa-project.org/
     Licensed under LGPL
 
-If you want compile from developer sources (SVN) under a unix system, you'll also need 
-automake (>=1.6), autoconf(>=2.50). Should be available at http://www.gnu.org
+If you want compile from developer sources (SVN) under a unix system, you will need:
+ - Subversion to checkout the sources, or gzip and tar to unpack them from archive
+ - GCC (>=4.8.1) or Clang (>=3.3)
+ - automake (>=1.6)
+ - autoconf (>=2.50)
+ - autoconf-archive (>=2009.x)
+ - make (>= 3.8)
+ - pkg-config (>= 0.25)
 
 For building on unix systems.
 If you are building from developer sources run ./autogen.sh first before doing the following.

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,21 @@ AC_CHECK_SIZEOF(unsigned long)
 AC_CHECK_SIZEOF(unsigned long long)
 AC_CHECK_SIZEOF(int *)
 
+dnl check and use C++ circa-2003 language constructs.
+AX_CXX_COMPILE_STDCXX_0X(noext, mandatory)
+if test "$ax_cv_cxx_compile_cxx0x_native" = no; then
+  if test "$ax_cv_cxx_compile_cxx0x_cxx" = yes; then
+    CXXFLAGS="$CXXFLAGS -std=c++0x"
+  else
+    AC_MSG_ERROR([A C++ compiler that supports the C++03 standard is required])
+  fi
+fi
+# Note that the above macro is deprecated in favor of AX_CXX_COMPILE_STDCXX_11:
+# https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx_0x.html
+# However we use it anyway because it is suggested that C++03 should
+# be the limit for now: https://sourceforge.net/p/dosbox/patches/283/#cb9a
+
+
 dnl some semi complex check for sys/socket so it works on darwin as well
 AC_CHECK_HEADERS([stdlib.h sys/types.h])
 AC_CHECK_HEADERS([sys/socket.h  netinet/in.h pwd.h], [], [],
@@ -451,6 +466,15 @@ else
    AC_MSG_WARN([Can't find SDL_net, internal modem and ipx disabled])
 fi
 
+# Check for required Opus decoding libraries
+PKG_CHECK_MODULES([OPUSFILE], [opusfile],
+  [ LIBS="$LIBS ${OPUSFILE_LIBS}"
+    CPPFLAGS="$CPPFLAGS ${OPUSFILE_CFLAGS}" ], [])
+
+PKG_CHECK_MODULES([SPEEXDSP], [speexdsp],
+  [ LIBS="$LIBS ${SPEEXDSP_LIBS}"
+    CPPFLAGS="$CPPFLAGS ${SPEEXDSP_CFLAGS}" ], [])
+
 AH_TEMPLATE(C_X11_XKB,[define to 1 if you have XKBlib.h and X11 lib])
 AC_CHECK_LIB(X11, main, have_x11_lib=yes, have_x11_lib=no, )
 AC_CHECK_HEADER(X11/XKBlib.h, have_x11_h=yes, have_x11_h=no, )
@@ -514,22 +538,7 @@ case "$host" in
 esac
 fi
 
-AH_TEMPLATE(C_SDL_SOUND,[Define to 1 to enable SDL_sound support])
-AC_CHECK_HEADER(SDL_sound.h,have_SDL_sound_h=yes,)
-AC_CHECK_LIB(SDL_sound, Sound_Init, have_SDL_sound_init=yes,,)
-AC_CHECK_LIB(SDL_sound, Sound_Seek, have_SDL_sound_seek=yes,,)
-if test x$have_SDL_sound_h = xyes -a x$have_SDL_sound_init = xyes ; then
-  if test x$have_SDL_sound_seek = xyes ; then
-    LIBS="-lSDL_sound $LIBS"
-    AC_DEFINE(C_SDL_SOUND,1)
-   else 
-     AC_MSG_WARN([Can't find SoundSeek in libSDL_Sound, libSDL_sound support disabled])
-   fi
-else
-  AC_MSG_WARN([Can't find libSDL_sound, libSDL_sound support disabled])
-fi
-
-dnl Check for mprotect. Needed for 64 bits linux 
+dnl Check for mprotect. Needed for 64 bits linux
 AH_TEMPLATE(C_HAVE_MPROTECT,[Define to 1 if you have the mprotect function])
 AC_CHECK_HEADER([sys/mman.h], [
 AC_CHECK_FUNC([mprotect],[AC_DEFINE(C_HAVE_MPROTECT,1)])
@@ -551,8 +560,9 @@ int main(int argc,char * argv[]) {
 
 dnl Some target detection and actions for them
 case "$host" in
-    *-*-cygwin* | *-*-mingw32*)
+    *-*-cygwin* | *-*-mingw* | *-*-msys*)
        LIBS="$LIBS -lwinmm"
+       AC_DEFINE(WIN32, 1, [Compiling on Windows])
        AC_DEFINE(C_DIRECTSERIAL, 1, [ Define to 1 if you want serial passthrough support (Win32, Posix and OS/2 only).])
        if test x$have_sdl_net_lib = xyes -a x$have_sdl_net_h = xyes ; then
          LIBS="$LIBS -lws2_32"
@@ -619,6 +629,7 @@ src/ints/Makefile
 src/libs/Makefile
 src/libs/zmbv/Makefile
 src/libs/gui_tk/Makefile
+src/libs/decoders/Makefile
 src/misc/Makefile
 src/shell/Makefile
 src/platform/Makefile

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -259,10 +259,6 @@ function tools_and_flags() {
 	if [[ "${SYSTEM}" == "macos" ]]; then
 		AR="ar"
 		RANLIB="ranlib"
-
-	# MSYS universal
-	elif [[ "${SYSTEM}" == "msys2" ]]; then
-		LIBS_ARRAY+=("-lwinmm" "-lws2_32")
 	fi
 }
 

--- a/scripts/list-build-dependencies.sh
+++ b/scripts/list-build-dependencies.sh
@@ -105,17 +105,17 @@ function list_packages() {
 			if [[ "${COMPILER}" == "gcc" ]]; then
 				COMPILER="g++"
 			fi
-			PACKAGES=(libtool build-essential libsdl1.2-dev libsdl-net1.2-dev libopusfile-dev libspeexdsp-dev)
+			PACKAGES=(libtool build-essential autoconf-archive libsdl1.2-dev libsdl-net1.2-dev libopusfile-dev libspeexdsp-dev)
 			;;
 
 		dnf)
 			VERSION_DELIM="-"
-			PACKAGES=(libtool SDL SDL_net-devel opusfile-devel speexdsp-devel)
+			PACKAGES=(libtool autoconf-archive SDL SDL_net-devel opusfile-devel speexdsp-devel)
 			;;
 
 		pacman)
 			# Arch offers 32-bit versions of SDL and speexDSP (but not others)
-			PACKAGES=(libtool sdl_net opusfile)
+			PACKAGES=(libtool autoconf-archive sdl_net opusfile)
 			if [[ "${BITS}" == 32 ]]; then
 				PACKAGES+=(lib32-sdl lib32-speexdsp)
 			else
@@ -125,7 +125,7 @@ function list_packages() {
 
 		zypper)
 			# OpenSUSE offers 32-bit versions of SDL, SDL_net, and speexDSP (but not others)
-			PACKAGES=(devel_basis libtool opusfile)
+			PACKAGES=(devel_basis libtool autoconf-archive opusfile)
 			if [[ "${BITS}" == 32 ]]; then
 				PACKAGES+=(libSDL-devel-32bit libSDL_net-devel-32bit libspeexdsp1-32bit)
 			else
@@ -151,11 +151,11 @@ function list_packages() {
 			if [[ "${COMPILER}" == "clang" ]]; then
 				COMPILER=""
 			fi
-			PACKAGES=(coreutils autogen autoconf automake pkg-config libpng sdl sdl_net opusfile speexdsp)
+			PACKAGES=(coreutils autogen autoconf autoconf-archive automake pkg-config libpng sdl sdl_net opusfile speexdsp)
 			;;
 
 		macports)
-			PACKAGES=(coreutils autogen automake autoconf pkgconfig libpng libsdl libsdl_net opusfile speexDSP)
+			PACKAGES=(coreutils autogen automake autoconf autoconf-archive pkgconfig libpng libsdl libsdl_net opusfile speexDSP)
 			;;
 
 		msys2)
@@ -166,7 +166,7 @@ function list_packages() {
 			if [[ "${BITS}" == 32 ]]; then
 				pkg_type="i686"
 			fi
-			PACKAGES=(autogen autoconf base-devel automake-wrapper)
+			PACKAGES=(autogen autoconf autoconf-archive base-devel automake-wrapper)
 			for pkg in pkg-config libtool libpng zlib SDL SDL_net opusfile speexdsp; do
 				PACKAGES+=("mingw-w64-${pkg_type}-${pkg}")
 			done

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
-SUBDIRS = cpu debug dos fpu gui hardware libs ints misc shell platform 
+SUBDIRS = cpu debug dos fpu gui hardware libs ints misc shell platform
 
 bin_PROGRAMS = dosbox
 
@@ -14,8 +14,6 @@ endif
 dosbox_SOURCES = dosbox.cpp $(ico_stuff)
 dosbox_LDADD = cpu/libcpu.a debug/libdebug.a dos/libdos.a fpu/libfpu.a  hardware/libhardware.a gui/libgui.a \
                ints/libints.a misc/libmisc.a shell/libshell.a hardware/mame/libmame.a \
-               hardware/serialport/libserial.a libs/gui_tk/libgui_tk.a
+               hardware/serialport/libserial.a libs/gui_tk/libgui_tk.a libs/decoders/libdecoders.a
 
 EXTRA_DIST = winres.rc dosbox.ico
-
-

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -16,6 +16,10 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+// #define DEBUG 1
+#ifdef DEBUG
+#include <time.h> // time_t, tm, time(), and localtime()
+#endif
 
 #include <cctype>
 #include <cmath>
@@ -43,16 +47,30 @@ using namespace std;
 #define MAX_LINE_LENGTH 512
 #define MAX_FILENAME_LENGTH 256
 
+#ifdef DEBUG
+char* get_time() {
+	static char time_str[] = "00:00:00";
+	static time_t rawtime;
+	time(&rawtime);
+	const struct tm* ptime = localtime(&rawtime);
+	snprintf(time_str, sizeof(time_str), "%02d:%02d:%02d", ptime->tm_hour, ptime->tm_min, ptime->tm_sec);
+	return time_str;
+}
+#endif
+
 CDROM_Interface_Image::BinaryFile::BinaryFile(const char *filename, bool &error)
+	:TrackFile(RAW_SECTOR_SIZE)
 {
 	file = new ifstream(filename, ios::in | ios::binary);
-	error = (file == NULL) || (file->fail());
+	error = (file == nullptr) || (file->fail());
 }
 
 CDROM_Interface_Image::BinaryFile::~BinaryFile()
 {
-	delete file;
-	file = NULL;
+	if (file != nullptr) {
+		delete file;
+		file = nullptr;
+	}
 }
 
 bool CDROM_Interface_Image::BinaryFile::read(Bit8u *buffer, int seek, int count)
@@ -64,20 +82,58 @@ bool CDROM_Interface_Image::BinaryFile::read(Bit8u *buffer, int seek, int count)
 
 int CDROM_Interface_Image::BinaryFile::getLength()
 {
-	file->seekg(0, ios::end);
-	int length = (int)file->tellg();
-	if (file->fail()) return -1;
+	int length = -1; // The maximum value held by a signed int is 2,147,483,647,
+	                 // which is larger than the maximum size of a CDROM, which
+	                 // is known to be 99 minutes or roughly 870 MB in size.
+	if (file) {
+		std::streampos original_pos = file->tellg();
+		file->seekg(0, ios::end);
+		length = static_cast<int>(file->tellg());
+		file->seekg(original_pos, ios::end);
+	}
 	return length;
 }
 
-#if defined(C_SDL_SOUND)
-CDROM_Interface_Image::AudioFile::AudioFile(const char *filename, bool &error)
+Bit16u CDROM_Interface_Image::BinaryFile::getEndian()
 {
-	Sound_AudioInfo desired = {AUDIO_S16, 2, 44100};
-	sample = Sound_NewSampleFromFile(filename, &desired, RAW_SECTOR_SIZE);
-	lastCount = RAW_SECTOR_SIZE;
-	lastSeek = 0;
-	error = (sample == NULL);
+	// Image files are read into native-endian byte-order
+#if defined(WORDS_BIGENDIAN)
+	return AUDIO_S16MSB;
+#else
+	return AUDIO_S16LSB;
+#endif
+}
+
+
+bool CDROM_Interface_Image::BinaryFile::seek(Bit32u offset)
+{
+	file->seekg(offset, ios::beg);
+	return !file->fail();
+}
+
+Bit16u CDROM_Interface_Image::BinaryFile::decode(Bit8u *buffer)
+{
+	file->read((char*)buffer, chunkSize);
+	return (Bit16u) file->gcount();
+}
+
+CDROM_Interface_Image::AudioFile::AudioFile(const char *filename, bool &error)
+	:TrackFile(4096)
+{
+	// Use the audio file's actual sample rate and number of channels as opposed to overriding
+	Sound_AudioInfo desired = {AUDIO_S16, 0, 0};
+	sample = Sound_NewSampleFromFile(filename, &desired, chunkSize);
+	if (sample) {
+		error = false;
+		std::string filename_only(filename);
+		filename_only = filename_only.substr(filename_only.find_last_of("\\/") + 1);
+		LOG_MSG("CDROM: Loaded %s [%d Hz %d-channel]",
+		        filename_only.c_str(),
+		        this->getRate(),
+		        this->getChannels());
+	} else {
+		error = true;
+	}
 }
 
 CDROM_Interface_Image::AudioFile::~AudioFile()
@@ -85,65 +141,111 @@ CDROM_Interface_Image::AudioFile::~AudioFile()
 	Sound_FreeSample(sample);
 }
 
-bool CDROM_Interface_Image::AudioFile::read(Bit8u *buffer, int seek, int count)
+bool CDROM_Interface_Image::AudioFile::seek(Bit32u offset)
 {
-	if (lastCount != count) {
-		int success = Sound_SetBufferSize(sample, count);
-		if (!success) return false;
-	}
-	if (lastSeek != (seek - count)) {
-		int success = Sound_Seek(sample, (int)((double)(seek) / 176.4f));
-		if (!success) return false;
-	}
-	lastSeek = seek;
-	int bytes = Sound_Decode(sample);
-	if (bytes < count) {
-		memcpy(buffer, sample->buffer, bytes);
-		memset(buffer + bytes, 0, count - bytes);
-	} else {
-		memcpy(buffer, sample->buffer, count);
-	}
-	
-	return !(sample->flags & SOUND_SAMPLEFLAG_ERROR);
+#ifdef BENCHMARK
+#include <ctime>
+	// This benchmarking block requires C++11 to create a trivial ANSI sub-second timer
+	// that's portable across Windows, Linux, and macOS. Otherwise, to do so using lesser
+	// standards requires a combination of very lengthly solutions for each operating system:
+	// https://stackoverflow.com/questions/361363/how-to-measure-time-in-milliseconds-using-ansi-c
+	// Leave this in place (but #ifdef'ed away) for development and regression testing purposes.
+	const auto begin = std::chrono::steady_clock::now();
+#endif
+
+	// Convert the byte-offset to a time offset (milliseconds)
+	const bool result = Sound_Seek(sample, lround(offset/176.4f));
+
+#ifdef BENCHMARK
+	const auto end = std::chrono::steady_clock::now();
+	LOG_MSG("%s CDROM: seek(%u) took %f ms",
+	        get_time(),
+	        offset,
+	        chrono::duration <double, milli> (end - begin).count());
+#endif
+	return result;
+}
+
+Bit16u CDROM_Interface_Image::AudioFile::decode(Bit8u *buffer)
+{
+	const Bit16u bytes = Sound_Decode(sample);
+	memcpy(buffer, sample->buffer, bytes);
+	return bytes;
+}
+
+Bit16u CDROM_Interface_Image::AudioFile::getEndian()
+{
+	return sample->actual.format;
+}
+
+Bit32u CDROM_Interface_Image::AudioFile::getRate()
+{
+	return sample ? sample->actual.rate : 0;
+}
+
+Bit8u CDROM_Interface_Image::AudioFile::getChannels()
+{
+	return sample ? sample->actual.channels : 0;
 }
 
 int CDROM_Interface_Image::AudioFile::getLength()
 {
-	int time = 1;
-	int shift = 0;
-	if (!(sample->flags & SOUND_SAMPLEFLAG_CANSEEK)) return -1;
-	
-	while (true) {
-		int success = Sound_Seek(sample, (unsigned int)(shift + time));
-		if (!success) {
-			if (time == 1) return lround((double)shift * 176.4f);
-			shift += time >> 1;
-			time = 1;
-		} else {
-			if (time > ((numeric_limits<int>::max() - shift) / 2)) return -1;
-			time = time << 1;
-		}
+	int length(-1);
+
+	// GetDuration returns milliseconds ... but getLength needs Red Book bytes.
+	const int duration_ms = Sound_GetDuration(sample);
+	if (duration_ms > 0) {
+		// ... so convert ms to "Red Book bytes" by multiplying with 176.4f,
+		// which is 44,100 samples/second * 2-channels * 2 bytes/sample
+		// / 1000 milliseconds/second
+		length = (int) round(duration_ms * 176.4f);
 	}
-}
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: AudioFile::getLength is %d bytes",
+	        get_time(),
+	        length);
 #endif
+
+	return length;
+}
 
 // initialize static members
 int CDROM_Interface_Image::refCount = 0;
 CDROM_Interface_Image* CDROM_Interface_Image::images[26] = {};
 CDROM_Interface_Image::imagePlayer CDROM_Interface_Image::player = {
-	NULL, NULL, NULL, {0}, 0, 0, 0, false, false, false, {0} };
+	{0},     // buffer[]
+	{0},     // ctrlData struct
+	nullptr, // TrackFile*
+	nullptr, // MixerChannel*
+	nullptr, // CDROM_Interface_Image*
+	nullptr, // addSamples
+	0,       // startFrame
+	0,       // currFrame
+	0,       // numFrames
+	0,       // playbackTotal
+	0,       // playbackRemaining
+	0,       // bufferPos
+	0,       // bufferConsumed
+	false,   // isPlaying
+	false,   // isPaused
+	false    // ctrlUsed
+};
 
-	
+
 CDROM_Interface_Image::CDROM_Interface_Image(Bit8u subUnit)
                       :subUnit(subUnit)
 {
 	images[subUnit] = this;
 	if (refCount == 0) {
-		player.mutex = SDL_CreateMutex();
-		if (!player.channel) {
-			player.channel = MIXER_AddChannel(&CDAudioCallBack, 44100, "CDAUDIO");
+		if (player.channel == nullptr) {
+			// channel is kept dormant except during cdrom playback periods
+			player.channel = MIXER_AddChannel(&CDAudioCallBack, 0, "CDAUDIO");
+			player.channel->Enable(false);
+#ifdef DEBUG
+			LOG_MSG("CDROM: Initialized with %d-byte circular buffer",
+			        AUDIO_DECODE_BUFFER_SIZE);
+#endif
 		}
-		player.channel->Enable(true);
 	}
 	refCount++;
 }
@@ -151,11 +253,17 @@ CDROM_Interface_Image::CDROM_Interface_Image(Bit8u subUnit)
 CDROM_Interface_Image::~CDROM_Interface_Image()
 {
 	refCount--;
-	if (player.cd == this) player.cd = NULL;
+	if (player.cd == this) {
+		player.cd = nullptr;
+	}
 	ClearTracks();
 	if (refCount == 0) {
-		SDL_DestroyMutex(player.mutex);
-		player.channel->Enable(false);
+		StopAudio();
+		MIXER_DelChannel(player.channel);
+		player.channel = nullptr;
+#ifdef DEBUG
+		LOG_MSG("CDROM: Audio channel freed");
+#endif
 	}
 }
 
@@ -165,9 +273,11 @@ void CDROM_Interface_Image::InitNewMedia()
 
 bool CDROM_Interface_Image::SetDevice(char* path, int forceCD)
 {
-	if (LoadCueSheet(path)) return true;
-	if (LoadIsoFile(path)) return true;
-	
+	if (LoadCueSheet(path) ||
+	    LoadIsoFile(path)) {
+		return true;
+	}
+
 	// print error message on dosbox console
 	char buf[MAX_LINE_LENGTH];
 	snprintf(buf, MAX_LINE_LENGTH, "Could not load image file: %s\n", path);
@@ -180,6 +290,12 @@ bool CDROM_Interface_Image::GetUPC(unsigned char& attr, char* upc)
 {
 	attr = 0;
 	strcpy(upc, this->mcn.c_str());
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: GetUPC=%s",
+	        get_time(),
+	        upc);
+#endif
+
 	return true;
 }
 
@@ -187,27 +303,77 @@ bool CDROM_Interface_Image::GetAudioTracks(int& stTrack, int& end, TMSF& leadOut
 {
 	stTrack = 1;
 	end = (int)(tracks.size() - 1);
-	frames_to_msf(tracks[tracks.size() - 1].start + 150, &leadOut.min, &leadOut.sec, &leadOut.fr);
+	frames_to_msf(tracks[tracks.size() - 1].start + 150,
+	              &leadOut.min, &leadOut.sec, &leadOut.fr);
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: GetAudioTracks, stTrack=%d, end=%d, "
+	        "leadOut.min=%d, leadOut.sec=%d, leadOut.fr=%d",
+	        get_time(),
+	        stTrack,
+	        end,
+	        leadOut.min,
+	        leadOut.sec,
+	        leadOut.fr);
+#endif
+
 	return true;
 }
 
 bool CDROM_Interface_Image::GetAudioTrackInfo(int track, TMSF& start, unsigned char& attr)
 {
-	if (track < 1 || track > (int)tracks.size()) return false;
-	frames_to_msf(tracks[track - 1].start + 150, &start.min, &start.sec, &start.fr);
+	if (track < 1 || track > (int)tracks.size()) {
+		return false;
+	}
+	frames_to_msf(tracks[track - 1].start + 150,
+	              &start.min, &start.sec, &start.fr);
 	attr = tracks[track - 1].attr;
+
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: GetAudioTrackInfo track=%d MSF %02d:%02d:%02d, attr=%u",
+	        get_time(),
+	        track,
+	        start.min,
+	        start.sec,
+	        start.fr,
+	        attr);
+#endif
 	return true;
 }
 
-bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos)
+bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& track,
+                                        unsigned char& index, TMSF& relPos, TMSF& absPos)
 {
 	int cur_track = GetTrack(player.currFrame);
-	if (cur_track < 1) return false;
+	if (cur_track < 1) {
+		return false;
+	}
 	track = (unsigned char)cur_track;
 	attr = tracks[track - 1].attr;
 	index = 1;
 	frames_to_msf(player.currFrame + 150, &absPos.min, &absPos.sec, &absPos.fr);
 	frames_to_msf(player.currFrame - tracks[track - 1].start, &relPos.min, &relPos.sec, &relPos.fr);
+
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: GetAudioSub attr=%u, track=%u, index=%u",
+	        get_time(),
+	        attr,
+	        track,
+	        index);
+
+	LOG_MSG("%s CDROM: GetAudioSub absoute  offset (%d), MSF=%d:%d:%d",
+            get_time(),
+	        player.currFrame + 150,
+	        absPos.min,
+	        absPos.sec,
+	        absPos.fr);
+
+	LOG_MSG("%s CDROM: GetAudioSub relative offset (%d), MSF=%d:%d:%d",
+            get_time(),
+	        player.currFrame - tracks[track - 1].start + 150,
+	        relPos.min,
+	        relPos.sec,
+	        relPos.fr);
+#endif
 	return true;
 }
 
@@ -215,6 +381,14 @@ bool CDROM_Interface_Image::GetAudioStatus(bool& playing, bool& pause)
 {
 	playing = player.isPlaying;
 	pause = player.isPaused;
+
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: GetAudioStatus playing=%d, paused=%d",
+	        get_time(),
+	        playing,
+	        pause);
+#endif
+
 	return true;
 }
 
@@ -223,39 +397,137 @@ bool CDROM_Interface_Image::GetMediaTrayStatus(bool& mediaPresent, bool& mediaCh
 	mediaPresent = true;
 	mediaChanged = false;
 	trayOpen = false;
+
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: GetMediaTrayStatus present=%d, changed=%d, open=%d",
+	        get_time(),
+	        mediaPresent,
+	        mediaChanged,
+	        trayOpen);
+#endif
+
 	return true;
 }
 
-bool CDROM_Interface_Image::PlayAudioSector(unsigned long start,unsigned long len)
+bool CDROM_Interface_Image::PlayAudioSector(unsigned long start, unsigned long len)
 {
-	// We might want to do some more checks. E.g valid start and length
-	SDL_mutexP(player.mutex);
-	player.cd = this;
-	player.currFrame = start;
-	player.targetFrame = start + len;
-	int track = GetTrack(start) - 1;
-	if(track >= 0 && tracks[track].attr == 0x40) {
+	bool is_playable(false);
+	const int track = GetTrack(start) - 1;
+
+	// The CDROM Red Book standard allows up to 99 tracks, which includes the data track
+	if ( track < 0 || track > 99 )
+		LOG(LOG_MISC, LOG_WARN)("Game tried to load track #%d, which is invalid", track);
+
+	// Attempting to play zero sectors is a no-op
+	else if (len == 0)
+		LOG(LOG_MISC, LOG_WARN)("Game tried to play zero sectors, skipping");
+
+	// The maximum storage achieved on a CDROM was ~900MB or just under 100 minutes
+	// with overburning, so use this threshold to sanity-check the start sector.
+	else if (start > 450000)
+		LOG(LOG_MISC, LOG_WARN)("Game tried to read sector %lu, "
+		                        "which is beyond the 100-minute maximum of a CDROM",
+		                        start);
+
+	// We can't play audio from a data track (as it would result in garbage/static)
+	else if (track >= 0 && tracks[track].attr == 0x40)
 		LOG(LOG_MISC,LOG_WARN)("Game tries to play the data track. Not doing this");
-		player.isPlaying = false;
-		//Unclear wether return false should be here. 
-		//specs say that this function returns at once and games should check the status wether the audio is actually playing
-		//Real drives either fail or succeed as well
-	} else player.isPlaying = true;
-	player.isPaused = false;
-	SDL_mutexV(player.mutex);
-	return true;
+
+	// Checks passed, setup the audio stream
+	else {
+		TrackFile* trackFile = tracks[track].file;
+
+		// Convert the playback start sector to a time offset (milliseconds) relative to the track
+		const Bit32u offset = tracks[track].skip + (start - tracks[track].start) * tracks[track].sectorSize;
+		is_playable = trackFile->seek(offset);
+
+		// only initialize the player elements if our track is playable
+		if (is_playable) {
+			const Bit8u channels = trackFile->getChannels();
+			const Bit32u rate = trackFile->getRate();
+
+			player.cd = this;
+			player.trackFile = trackFile;
+			player.startFrame = start;
+			player.currFrame = start;
+			player.numFrames = len;
+			player.bufferPos = 0;
+			player.bufferConsumed = 0;
+			player.isPlaying = true;
+			player.isPaused = false;
+
+
+#if defined(WORDS_BIGENDIAN)
+			if (trackFile->getEndian() != AUDIO_S16SYS)
+#else
+			if (trackFile->getEndian() == AUDIO_S16SYS)
+#endif
+				player.addSamples = channels ==  2  ? &MixerChannel::AddSamples_s16 \
+				                                    : &MixerChannel::AddSamples_m16;
+			else
+				player.addSamples = channels ==  2  ? &MixerChannel::AddSamples_s16_nonnative \
+				                                    : &MixerChannel::AddSamples_m16_nonnative;
+
+			const float bytesPerMs = (float) (rate * channels * 2 / 1000.0);
+			player.playbackTotal = lround(len * tracks[track].sectorSize * bytesPerMs / 176.4);
+			player.playbackRemaining = player.playbackTotal;
+
+#ifdef DEBUG
+			LOG_MSG("%s CDROM: Playing track %d at %.1f KHz "
+			        "%d-channel at start sector %lu (%.1f minute-mark), seek %u "
+			        "(skip=%d,dstart=%d,secsize=%d), for %lu sectors (%.1f seconds)",
+			        get_time(),
+			        track,
+			        rate/1000.0,
+			        channels,
+			        start,
+			        offset * (1/10584000.0),
+			        offset,
+			        tracks[track].skip,
+			        tracks[track].start,
+			        tracks[track].sectorSize,
+			        len,
+			        player.playbackRemaining / (1000 * bytesPerMs));
+#endif
+
+			// start the channel!
+			player.channel->SetFreq(rate);
+			player.channel->Enable(true);
+		}
+	}
+	if (!is_playable) StopAudio();
+	return is_playable;
 }
 
 bool CDROM_Interface_Image::PauseAudio(bool resume)
 {
-	player.isPaused = !resume;
+	// Only switch states if needed
+	if (player.isPaused == resume) {
+		player.channel->Enable(resume);
+		player.isPaused = !resume;
+	}
+
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: PauseAudio, state=%s",
+	        get_time(), resume ? "resumed" : "paused");
+#endif
+
 	return true;
 }
 
 bool CDROM_Interface_Image::StopAudio(void)
 {
-	player.isPlaying = false;
-	player.isPaused = false;
+	// Only switch states if needed
+	if (player.isPlaying) {
+		player.channel->Enable(false);
+		player.isPlaying = false;
+		player.isPaused = false;
+	}
+
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: StopAudio", get_time());
+#endif
+
 	return true;
 }
 
@@ -270,7 +542,7 @@ bool CDROM_Interface_Image::ReadSectors(PhysPt buffer, bool raw, unsigned long s
 	int sectorSize = raw ? RAW_SECTOR_SIZE : COOKED_SECTOR_SIZE;
 	Bitu buflen = num * sectorSize;
 	Bit8u* buf = new Bit8u[buflen];
-	
+
 	bool success = true; //Gobliiins reads 0 sectors
 	for(unsigned long i = 0; i < num; i++) {
 		success = ReadSector(&buf[i * sectorSize], raw, sector + i);
@@ -279,7 +551,6 @@ bool CDROM_Interface_Image::ReadSectors(PhysPt buffer, bool raw, unsigned long s
 
 	MEM_BlockWrite(buffer, buf, buflen);
 	delete[] buf;
-
 	return success;
 }
 
@@ -292,11 +563,13 @@ int CDROM_Interface_Image::GetTrack(int sector)
 {
 	vector<Track>::iterator i = tracks.begin();
 	vector<Track>::iterator end = tracks.end() - 1;
-	
+
 	while(i != end) {
 		Track &curr = *i;
 		Track &next = *(i + 1);
-		if (curr.start <= sector && sector < next.start) return curr.number;
+		if (curr.start <= sector && sector < next.start) {
+			return curr.number;
+		}
 		i++;
 	}
 	return -1;
@@ -305,110 +578,215 @@ int CDROM_Interface_Image::GetTrack(int sector)
 bool CDROM_Interface_Image::ReadSector(Bit8u *buffer, bool raw, unsigned long sector)
 {
 	int track = GetTrack(sector) - 1;
-	if (track < 0) return false;
-	
+	if (track < 0) {
+		return false;
+	}
+
 	int seek = tracks[track].skip + (sector - tracks[track].start) * tracks[track].sectorSize;
 	int length = (raw ? RAW_SECTOR_SIZE : COOKED_SECTOR_SIZE);
-	if (tracks[track].sectorSize != RAW_SECTOR_SIZE && raw) return false;
+	if (tracks[track].sectorSize != RAW_SECTOR_SIZE && raw) {
+		return false;
+	}
 	if (tracks[track].sectorSize == RAW_SECTOR_SIZE && !tracks[track].mode2 && !raw) seek += 16;
 	if (tracks[track].mode2 && !raw) seek += 24;
 
+#ifdef DEBUG
+	LOG_MSG("CDROM: ReadSector track=%d, desired raw=%s, sector=%ld, length=%d",
+	        track,
+	        raw ? "true":"false",
+	        sector,
+	        length);
+#endif
 	return tracks[track].file->read(buffer, seek, length);
 }
 
 void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 {
-	len *= 4;       // 16 bit, stereo
-	if (!len) return;
-	if (!player.isPlaying || player.isPaused) {
-		player.channel->AddSilence();
+	// Our member object "playbackRemaining" holds the
+	// exact number of stream-bytes we need to play before meeting the
+	// DOS program's desired playback duration in sectors. We simply
+	// decrement this counter each callback until we're done.
+	if (len == 0 || !player.isPlaying || player.isPaused) {
 		return;
 	}
-	
-	SDL_mutexP(player.mutex);
-	while (player.bufLen < (Bits)len) {
-		bool success;
-		if (player.targetFrame > player.currFrame)
-			success = player.cd->ReadSector(&player.buffer[player.bufLen], true, player.currFrame);
-		else success = false;
-		
-		if (success) {
-			player.currFrame++;
-			player.bufLen += RAW_SECTOR_SIZE;
-		} else {
-			memset(&player.buffer[player.bufLen], 0, len - player.bufLen);
-			player.bufLen = len;
-			player.isPlaying = false;
+
+	// determine bytes per request (16-bit samples)
+	const Bit8u channels = player.trackFile->getChannels();
+	const Bit8u bytes_per_request = channels * 2;
+	int total_requested = len * bytes_per_request;
+
+	while (total_requested > 0) {
+		int requested = total_requested;
+
+		// Every now and then the callback wants a big number of bytes,
+		// which can exceed our circular buffer. In these cases we need
+		// read through as many iteration of our circular buffer as needed.
+		if (total_requested > AUDIO_DECODE_BUFFER_SIZE) {
+			requested = AUDIO_DECODE_BUFFER_SIZE;
+			total_requested -= AUDIO_DECODE_BUFFER_SIZE;
 		}
-	}
-	SDL_mutexV(player.mutex);
-	if (player.ctrlUsed) {
-		Bit16s sample0,sample1;
-		Bit16s * samples=(Bit16s *)&player.buffer;
-		for (Bitu pos=0;pos<len/4;pos++) {
-#if defined(WORDS_BIGENDIAN)
-			sample0=(Bit16s)host_readw((HostPt)&samples[pos*2+player.ctrlData.out[0]]);
-			sample1=(Bit16s)host_readw((HostPt)&samples[pos*2+player.ctrlData.out[1]]);
-#else
-			sample0=samples[pos*2+player.ctrlData.out[0]];
-			sample1=samples[pos*2+player.ctrlData.out[1]];
-#endif
-			samples[pos*2+0]=(Bit16s)(sample0*player.ctrlData.vol[0]/255.0);
-			samples[pos*2+1]=(Bit16s)(sample1*player.ctrlData.vol[1]/255.0);
+		else {
+			total_requested = 0;
 		}
+
+		// Three scenarios in order of probabilty:
+		//
+		// 1. Consume: If our decoded circular buffer is sufficiently filled to
+		//             satify the Mixer's requested size, then feed the Mixer with
+		//             the requested number of bytes.
+		//
+		// 2. Wrap:    If we've decoded and consumed to edge of our buffer, then
+		//             we need to wrap any remaining decoded-but-not-consumed
+		//             samples back around to the front of the buffer.
+		//
+		// 3. Fill:    When our circular buffer is too depleted to satisfy the
+		//             Mixer's requested size, then ask the decoder for more data;
+		//             to either enough to completely fill our buffer or whatever
+		//             is left to satisfy the remaining samples in this requested
+		//             playback sequence (the Mixer is unaware of how much audio
+		//             xwe need to play; instead we decide when to cutoff the mixer).
+		//
+		while (true) {
+
+			// 1. Consume
+			if (player.bufferPos - player.bufferConsumed >= requested) {
+				if (player.ctrlUsed) {
+					for (Bit8u i=0; i < channels; i++) {
+						Bit16s  sample;
+						Bit16s* samples = (Bit16s*)&player.buffer[player.bufferConsumed];
+						for (int pos = 0; pos < requested / bytes_per_request; pos++) {
 #if defined(WORDS_BIGENDIAN)
-		player.channel->AddSamples_s16(len/4,(Bit16s *)player.buffer);
-	} else	player.channel->AddSamples_s16_nonnative(len/4,(Bit16s *)player.buffer);
+							sample = (Bit16s)host_readw((HostPt) & samples[pos * 2 + player.ctrlData.out[i]]);
 #else
-	}
-	player.channel->AddSamples_s16(len/4,(Bit16s *)player.buffer);
+							sample = samples[pos * 2 + player.ctrlData.out[i]];
 #endif
-	memmove(player.buffer, &player.buffer[len], player.bufLen - len);
-	player.bufLen -= len;
+							samples[pos * 2 + i] = (Bit16s)(sample * player.ctrlData.vol[i] / 255.0);
+						}
+					}
+				}
+				// uses either the stereo or mono and native or nonnative AddSamples
+				// call assigned during construction
+				(player.channel->*player.addSamples)(requested / bytes_per_request,
+				                                     (Bit16s*)(player.buffer + player.bufferConsumed) );
+				player.bufferConsumed += requested;
+				player.playbackRemaining -= requested;
+
+				// Games can query the current Red Book MSF frame-position, so we keep that up-to-date here.
+				// We scale the final number of frames by the percent complete, which
+				// avoids having to keep track of the equivlent number of Red Book frames
+				// read (which would involve coverting the compressed streams data-rate into
+				// CDROM Red Book rate, which is more work than simply scaling).
+				//
+				const double playbackPercentSoFar = (player.playbackTotal - player.playbackRemaining) / player.playbackTotal;
+				player.currFrame = player.startFrame + (Bit32u) ceil(player.numFrames * playbackPercentSoFar);
+				break;
+			}
+
+			// 2. Wrap
+			else {
+				memcpy(player.buffer,
+					   player.buffer + player.bufferConsumed,
+					   player.bufferPos - player.bufferConsumed);
+				player.bufferPos -= player.bufferConsumed;
+				player.bufferConsumed = 0;
+			}
+
+			// 3. Fill
+			const Bit16u chunkSize = player.trackFile->chunkSize;
+			while(AUDIO_DECODE_BUFFER_SIZE - player.bufferPos >= chunkSize &&
+			      (player.bufferPos - player.bufferConsumed < player.playbackRemaining ||
+				   player.bufferPos - player.bufferConsumed < requested) ) {
+
+				const Bit16u decoded = player.trackFile->decode(player.buffer + player.bufferPos);
+				player.bufferPos += decoded;
+
+				// if we decoded less than expected, which could be due to EOF or if the CUE file specified
+				// an exact "INDEX 01 MIN:SEC:FRAMES" value but the compressed track is ever-so-slightly less than
+				// that specified, then simply pad with zeros.
+				const Bit16s underDecode = chunkSize - decoded;
+				if (underDecode > 0) {
+
+#ifdef DEBUG
+					LOG_MSG("%s CDROM: Underdecoded by %d. Feeding mixer with zeros.",
+					         get_time(),
+					         underDecode);
+#endif
+
+					memset(player.buffer + player.bufferPos, 0, underDecode);
+					player.bufferPos += underDecode;
+				}
+			} // end of fill-while
+		} // end of decode and fill loop
+	} // end while total_requested
+
+	if (player.playbackRemaining <= 0) {
+		player.cd->StopAudio();
+	}
 }
 
 bool CDROM_Interface_Image::LoadIsoFile(char* filename)
 {
 	tracks.clear();
-	
+
 	// data track
-	Track track = {0, 0, 0, 0, 0, 0, false, NULL};
+	Track track = {nullptr, // TrackFile*
+	               0,       // number
+	               0,       // attr
+	               0,       // start
+	               0,       // length
+	               0,       // skip
+	               0,       // sectorSize
+	               false};  // mode2
+
 	bool error;
 	track.file = new BinaryFile(filename, error);
 	if (error) {
-		delete track.file;
-		track.file = NULL;
+		if (track.file != nullptr) {
+			delete track.file;
+			track.file = nullptr;
+		}
 		return false;
 	}
 	track.number = 1;
 	track.attr = 0x40;//data
-	
+
 	// try to detect iso type
 	if (CanReadPVD(track.file, COOKED_SECTOR_SIZE, false)) {
 		track.sectorSize = COOKED_SECTOR_SIZE;
 		track.mode2 = false;
 	} else if (CanReadPVD(track.file, RAW_SECTOR_SIZE, false)) {
 		track.sectorSize = RAW_SECTOR_SIZE;
-		track.mode2 = false;		
+		track.mode2 = false;
 	} else if (CanReadPVD(track.file, 2336, true)) {
 		track.sectorSize = 2336;
-		track.mode2 = true;		
+		track.mode2 = true;
 	} else if (CanReadPVD(track.file, RAW_SECTOR_SIZE, true)) {
 		track.sectorSize = RAW_SECTOR_SIZE;
-		track.mode2 = true;		
-	} else return false;
-	
+		track.mode2 = true;
+	} else {
+		if (track.file != nullptr) {
+			delete track.file;
+			track.file = nullptr;
+		}
+		return false;
+	}
 	track.length = track.file->getLength() / track.sectorSize;
+#ifdef DEBUG
+	LOG_MSG("LoadIsoFile: %s, track 1, 0x40, sectorSize=%d, mode2=%s",
+	        filename,
+	        track.sectorSize,
+	        track.mode2 ? "true":"false");
+#endif
+
 	tracks.push_back(track);
-	
+
 	// leadout track
 	track.number = 2;
 	track.attr = 0;
 	track.start = track.length;
 	track.length = 0;
-	track.file = NULL;
+	track.file = nullptr;
 	tracks.push_back(track);
-
 	return true;
 }
 
@@ -427,9 +805,9 @@ bool CDROM_Interface_Image::CanReadPVD(TrackFile *file, int sectorSize, bool mod
 #if defined(WIN32)
 static string dirname(char * file) {
 	char * sep = strrchr(file, '\\');
-	if (sep == NULL)
+	if (sep == nullptr)
 		sep = strrchr(file, '/');
-	if (sep == NULL)
+	if (sep == nullptr)
 		return "";
 	else {
 		int len = (int)(sep - file);
@@ -442,44 +820,55 @@ static string dirname(char * file) {
 
 bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 {
-	Track track = {0, 0, 0, 0, 0, 0, false, NULL};
+	Track track = {nullptr, // TrackFile*
+	               0,       // number
+	               0,       // attr
+	               0,       // start
+	               0,       // length
+	               0,       // skip
+	               0,       // sectorSize
+	               false};  // mode2
 	tracks.clear();
 	int shift = 0;
 	int currPregap = 0;
 	int totalPregap = 0;
-	int prestart = 0;
+	int prestart = -1;
 	bool success;
 	bool canAddTrack = false;
-	char tmp[MAX_FILENAME_LENGTH];	// dirname can change its argument
+	char tmp[MAX_FILENAME_LENGTH];  // dirname can change its argument
 	safe_strncpy(tmp, cuefile, MAX_FILENAME_LENGTH);
 	string pathname(dirname(tmp));
 	ifstream in;
 	in.open(cuefile, ios::in);
-	if (in.fail()) return false;
-	
+	if (in.fail()) {
+		return false;
+	}
+
 	while(!in.eof()) {
 		// get next line
 		char buf[MAX_LINE_LENGTH];
 		in.getline(buf, MAX_LINE_LENGTH);
-		if (in.fail() && !in.eof()) return false;  // probably a binary file
+		if (in.fail() && !in.eof()) {
+			return false;  // probably a binary file
+		}
 		istringstream line(buf);
-		
+
 		string command;
 		GetCueKeyword(command, line);
-		
+
 		if (command == "TRACK") {
 			if (canAddTrack) success = AddTrack(track, shift, prestart, totalPregap, currPregap);
 			else success = true;
-			
+
 			track.start = 0;
 			track.skip = 0;
 			currPregap = 0;
-			prestart = 0;
-	
+			prestart = -1;
+
 			line >> track.number;
 			string type;
 			GetCueKeyword(type, line);
-			
+
 			if (type == "AUDIO") {
 				track.sectorSize = RAW_SECTOR_SIZE;
 				track.attr = 0;
@@ -501,7 +890,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 				track.attr = 0x40;
 				track.mode2 = true;
 			} else success = false;
-			
+
 			canAddTrack = true;
 		}
 		else if (command == "INDEX") {
@@ -509,7 +898,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 			line >> index;
 			int frame;
 			success = GetCueFrame(frame, line);
-			
+
 			if (index == 1) track.start = frame;
 			else if (index == 0) prestart = frame;
 			// ignore other indices
@@ -518,110 +907,143 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 			if (canAddTrack) success = AddTrack(track, shift, prestart, totalPregap, currPregap);
 			else success = true;
 			canAddTrack = false;
-			
+
 			string filename;
 			GetCueString(filename, line);
 			GetRealFileName(filename, pathname);
 			string type;
 			GetCueKeyword(type, line);
 
-			track.file = NULL;
+			track.file = nullptr;
 			bool error = true;
 			if (type == "BINARY") {
 				track.file = new BinaryFile(filename.c_str(), error);
 			}
-#if defined(C_SDL_SOUND)
-			//The next if has been surpassed by the else, but leaving it in as not 
-			//to break existing cue sheets that depend on this.(mine with OGG tracks specifying MP3 as type)
-			else if (type == "WAVE" || type == "AIFF" || type == "MP3") {
+			else {
 				track.file = new AudioFile(filename.c_str(), error);
-			} else { 
-				const Sound_DecoderInfo **i;
-				for (i = Sound_AvailableDecoders(); *i != NULL; i++) {
-					if (*(*i)->extensions == type) {
-						track.file = new AudioFile(filename.c_str(), error);
-						break;
-					}
-				}
+				// SDL_Sound first tries using a decoder having a matching registered extension
+				// as the filename, and then falls back to trying each decoder before finally
+				// giving up.
 			}
-#endif
 			if (error) {
-				delete track.file;
-				track.file = NULL;
+				if (track.file != nullptr) {
+					delete track.file;
+					track.file = nullptr;
+				}
 				success = false;
 			}
 		}
 		else if (command == "PREGAP") success = GetCueFrame(currPregap, line);
 		else if (command == "CATALOG") success = GetCueString(mcn, line);
 		// ignored commands
-		else if (command == "CDTEXTFILE" || command == "FLAGS" || command == "ISRC"
-			|| command == "PERFORMER" || command == "POSTGAP" || command == "REM"
-			|| command == "SONGWRITER" || command == "TITLE" || command == "") success = true;
+		else if (command == "CDTEXTFILE" || command == "FLAGS"   || command == "ISRC" ||
+		         command == "PERFORMER"  || command == "POSTGAP" || command == "REM" ||
+		         command == "SONGWRITER" || command == "TITLE"   || command == "") {
+			success = true;
+		}
 		// failure
-		else success = false;
-
-		if (!success) return false;
+		else {
+			if (track.file != nullptr) {
+				delete track.file;
+				track.file = nullptr;
+			}
+			success = false;
+		}
+		if (!success) {
+			if (track.file != nullptr) {
+				delete track.file;
+				track.file = nullptr;
+			}
+			return false;
+		}
 	}
 	// add last track
-	if (!AddTrack(track, shift, prestart, totalPregap, currPregap)) return false;
-	
+	if (!AddTrack(track, shift, prestart, totalPregap, currPregap)) {
+		return false;
+	}
+
 	// add leadout track
 	track.number++;
 	track.attr = 0;//sync with load iso
 	track.start = 0;
 	track.length = 0;
-	track.file = NULL;
-	if(!AddTrack(track, shift, 0, totalPregap, 0)) return false;
-
+	track.file = nullptr;
+	if (!AddTrack(track, shift, -1, totalPregap, 0)) {
+		return false;
+	}
 	return true;
 }
 
+
+
 bool CDROM_Interface_Image::AddTrack(Track &curr, int &shift, int prestart, int &totalPregap, int currPregap)
 {
+	int skip = 0;
+
 	// frames between index 0(prestart) and 1(curr.start) must be skipped
-	int skip;
-	if (prestart > 0) {
-		if (prestart > curr.start) return false;
+	if (prestart >= 0) {
+		if (prestart > curr.start) {
+			return false;
+		}
 		skip = curr.start - prestart;
-	} else skip = 0;
-	
+	}
+
 	// first track (track number must be 1)
 	if (tracks.empty()) {
-		if (curr.number != 1) return false;
+		if (curr.number != 1) {
+			return false;
+		}
 		curr.skip = skip * curr.sectorSize;
 		curr.start += currPregap;
 		totalPregap = currPregap;
 		tracks.push_back(curr);
 		return true;
 	}
-	
+
 	Track &prev = *(tracks.end() - 1);
-	
+
 	// current track consumes data from the same file as the previous
 	if (prev.file == curr.file) {
 		curr.start += shift;
-		prev.length = curr.start + totalPregap - prev.start - skip;
-		curr.skip += prev.skip + prev.length * prev.sectorSize + skip * curr.sectorSize;		
+		if (!prev.length) {
+			prev.length = curr.start + totalPregap - prev.start - skip;
+		}
+		curr.skip += prev.skip + prev.length * prev.sectorSize + skip * curr.sectorSize;
 		totalPregap += currPregap;
 		curr.start += totalPregap;
 	// current track uses a different file as the previous track
 	} else {
-		int tmp = prev.file->getLength() - prev.skip;
-		prev.length = tmp / prev.sectorSize;
-		if (tmp % prev.sectorSize != 0) prev.length++; // padding
-		
+		if (!prev.length) {
+			int tmp = prev.file->getLength() - prev.skip;
+			prev.length = tmp / prev.sectorSize;
+			if (tmp % prev.sectorSize != 0) prev.length++; // padding
+		}
 		curr.start += prev.start + prev.length + currPregap;
 		curr.skip = skip * curr.sectorSize;
 		shift += prev.start + prev.length;
 		totalPregap = currPregap;
 	}
-	
+
+#ifdef DEBUG
+	LOG_MSG("%s CDROM: AddTrack cur.start=%d cur.len=%d cur.start+len=%d "
+	        "| prev.start=%d prev.len=%d prev.start+len=%d",
+	        get_time(),
+	        curr.start,
+	        curr.length,
+	        curr.start + curr.length,
+	        prev.start,
+	        prev.length,
+	        prev.start + prev.length);
+#endif
+
 	// error checks
-	if (curr.number <= 1) return false;
-	if (prev.number + 1 != curr.number) return false;
-	if (curr.start < prev.start + prev.length) return false;
-	if (curr.length < 0) return false;
-	
+	if (curr.number <= 1                      ||
+	    prev.number + 1 != curr.number        ||
+	    curr.start < prev.start + prev.length ||
+	    curr.length < 0) {
+		return false;
+	}
+
 	tracks.push_back(curr);
 	return true;
 }
@@ -630,7 +1052,9 @@ bool CDROM_Interface_Image::HasDataTrack(void)
 {
 	//Data track has attribute 0x40
 	for(track_it it = tracks.begin(); it != tracks.end(); it++) {
-		if ((*it).attr == 0x40) return true;
+		if ((*it).attr == 0x40) {
+			return true;
+		}
 	}
 	return false;
 }
@@ -640,8 +1064,10 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 {
 	// check if file exists
 	struct stat test;
-	if (stat(filename.c_str(), &test) == 0) return true;
-	
+	if (stat(filename.c_str(), &test) == 0) {
+		return true;
+	}
+
 	// check if file with path relative to cue file exists
 	string tmpstr(pathname + "/" + filename);
 	if (stat(tmpstr.c_str(), &test) == 0) {
@@ -653,8 +1079,10 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 	char tmp[CROSS_LEN];
 	safe_strncpy(tmp, filename.c_str(), CROSS_LEN);
 	Bit8u drive;
-	if (!DOS_MakeName(tmp, fullname, &drive)) return false;
-	
+	if (!DOS_MakeName(tmp, fullname, &drive)) {
+		return false;
+	}
+
 	localDrive *ldp = dynamic_cast<localDrive*>(Drives[drive]);
 	if (ldp) {
 		ldp->GetSystemFilename(tmp, fullname);
@@ -666,13 +1094,13 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 #if defined (WIN32) || defined(OS2)
 	//Nothing
 #else
-	//Consider the possibility that the filename has a windows directory seperator (inside the CUE file) 
+	//Consider the possibility that the filename has a windows directory seperator (inside the CUE file)
 	//which is common for some commercial rereleases of DOS games using DOSBox
 
 	string copy = filename;
 	size_t l = copy.size();
 	for (size_t i = 0; i < l;i++) {
-		if(copy[i] == '\\') copy[i] = '/';
+		if (copy[i] == '\\') copy[i] = '/';
 	}
 
 	if (stat(copy.c_str(), &test) == 0) {
@@ -694,7 +1122,7 @@ bool CDROM_Interface_Image::GetCueKeyword(string &keyword, istream &in)
 {
 	in >> keyword;
 	for(Bitu i = 0; i < keyword.size(); i++) keyword[i] = toupper(keyword[i]);
-	
+
 	return true;
 }
 
@@ -731,7 +1159,7 @@ void CDROM_Interface_Image::ClearTracks()
 	vector<Track>::iterator i = tracks.begin();
 	vector<Track>::iterator end = tracks.end();
 
-	TrackFile* last = NULL;	
+	TrackFile* last = nullptr;
 	while(i != end) {
 		Track &curr = *i;
 		if (curr.file != last) {
@@ -744,14 +1172,10 @@ void CDROM_Interface_Image::ClearTracks()
 }
 
 void CDROM_Image_Destroy(Section*) {
-#if defined(C_SDL_SOUND)
 	Sound_Quit();
-#endif
 }
 
-void CDROM_Image_Init(Section* section) {
-#if defined(C_SDL_SOUND)
+void CDROM_Image_Init(Section* sec) {
+	sec->AddDestroyFunction(CDROM_Image_Destroy, false);
 	Sound_Init();
-	section->AddDestroyFunction(CDROM_Image_Destroy, false);
-#endif
 }

--- a/src/dos/cdrom_ioctl_win32.cpp
+++ b/src/dos/cdrom_ioctl_win32.cpp
@@ -176,7 +176,7 @@ bool CDROM_Interface_Ioctl::mci_CDPosition(int *position) {
 CDROM_Interface_Ioctl::dxPlayer CDROM_Interface_Ioctl::player = {
 	NULL, NULL, NULL, {0}, 0, 0, 0, false, false, false, {0} };
 
-CDROM_Interface_Ioctl::CDROM_Interface_Ioctl(cdioctl_cdatype ioctl_cda) {
+CDROM_Interface_Ioctl::CDROM_Interface_Ioctl(CDROM_Interface_Ioctl::cdioctl_cdatype ioctl_cda) {
 	pathname[0] = 0;
 	hIOCTL = INVALID_HANDLE_VALUE;
 	memset(&oldLeadOut,0,sizeof(oldLeadOut));

--- a/src/libs/Makefile.am
+++ b/src/libs/Makefile.am
@@ -1,3 +1,4 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
-SUBDIRS = zmbv gui_tk
+SUBDIRS = zmbv gui_tk decoders
+

--- a/src/libs/decoders/Makefile.am
+++ b/src/libs/decoders/Makefile.am
@@ -1,0 +1,33 @@
+noinst_LIBRARIES = libdecoders.a
+
+libdecoders_a_SOURCES = \
+	SDL_sound.c          \
+	SDL_sound.h          \
+	SDL_sound_internal.h \
+	audio_convert.c      \
+	wav.c                \
+	dr_wav.h             \
+	flac.c               \
+	dr_flac.h            \
+	opus.c               \
+	vorbis.c             \
+	stb_vorbis.h         \
+	mp3.cpp              \
+	mp3_seek_table.cpp   \
+	mp3_seek_table.h     \
+	dr_mp3.h             \
+	archive.h            \
+	xxhash.c             \
+	xxhash.h
+
+libdecoders_a_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	$(CXXFLAGS) \
+	-Wpedantic \
+	-Wall
+
+libdecoders_a_CFLAGS = \
+	$(AM_CFLAGS) \
+	$(CFLAGS) \
+	-Wpedantic \
+	-Wall

--- a/src/libs/decoders/flac.c
+++ b/src/libs/decoders/flac.c
@@ -17,7 +17,7 @@
  *  published by the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
  *
- *  This  SDL_sound Ogg Opus decoder backend is distributed in the hope that it
+ *  This SDL_sound FLAC decoder backend is distributed in the hope that it
  *  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
  *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.

--- a/src/libs/decoders/mp3.cpp
+++ b/src/libs/decoders/mp3.cpp
@@ -90,14 +90,14 @@ static void MP3_close(Sound_Sample* const sample)
 {
     Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal* const>(sample->opaque);
     mp3_t* p_mp3 = static_cast<mp3_t*>(internal->decoder_private);
-    if (p_mp3 != NULL) {
-        if (p_mp3->p_dr != NULL) {
+    if (p_mp3 != nullptr) {
+        if (p_mp3->p_dr != nullptr) {
             drmp3_uninit(p_mp3->p_dr);
             SDL_free(p_mp3->p_dr);
         }
         // maps and vector destructors free their memory
         SDL_free(p_mp3);
-        internal->decoder_private = NULL;
+        internal->decoder_private = nullptr;
     }
 } /* MP3_close */
 
@@ -147,10 +147,10 @@ static Sint32 MP3_open(Sound_Sample* const sample, const char* const ext)
     Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal*>(sample->opaque);
     Sint32 result(0); // assume failure until proven otherwise
     mp3_t* p_mp3 = (mp3_t*) SDL_calloc(1, sizeof (mp3_t));
-    if (p_mp3 != NULL) {
+    if (p_mp3 != nullptr) {
         p_mp3->p_dr = (drmp3*) SDL_calloc(1, sizeof (drmp3));
-        if (p_mp3->p_dr != NULL) {
-            result = drmp3_init(p_mp3->p_dr, mp3_read, mp3_seek, sample, NULL, NULL);
+        if (p_mp3->p_dr != nullptr) {
+            result = drmp3_init(p_mp3->p_dr, mp3_read, mp3_seek, sample, nullptr, nullptr);
             if (result == DRMP3_TRUE) {
                 SNDDBG(("MP3: Accepting data stream.\n"));
                 sample->flags = SOUND_SAMPLEFLAG_CANSEEK;
@@ -199,7 +199,7 @@ static Sint32 MP3_seek(Sound_Sample* const sample, const Uint32 ms)
 } /* MP3_seek */
 
 /* dr_mp3 will play layer 1 and 2 files, too */
-static const char* extensions_mp3[] = { "MP3", "MP2", "MP1", NULL };
+static const char* extensions_mp3[] = { "MP3", "MP2", "MP1", nullptr };
 
 extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MP3 = {
     {

--- a/src/libs/decoders/vorbis.c
+++ b/src/libs/decoders/vorbis.c
@@ -17,10 +17,9 @@
  *  published by the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
  *
- *  This  SDL_sound Ogg Opus decoder backend is distributed in the hope that it
- *  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ *  This decoder backend is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
  *  along with the SDL Sound Library.  If not, see <http://www.gnu.org/licenses/>.

--- a/visualc_net/dosbox.vcxproj
+++ b/visualc_net/dosbox.vcxproj
@@ -69,7 +69,7 @@
       <CompileAs>Default</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;sdl_net.lib;winmm.lib;libpng16d.lib;sdlmaind.lib;sdl.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;sdl_net.lib;winmm.lib;libpng16d.lib;sdlmaind.lib;sdl.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;libspeexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\Debug\dosbox.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -115,7 +115,7 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;sdl_net.lib;sdl.lib;sdlmain.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;winmm.lib;libpng16.lib;sdl_net.lib;sdl.lib;sdlmain.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;opusfile.lib;opus.lib;ogg.lib;libspeexdsp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>.\Release/dosbox.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -246,6 +246,15 @@
     <ClCompile Include="..\src\ints\mouse.cpp" />
     <ClCompile Include="..\src\ints\xms.cpp" />
     <ClCompile Include="..\src\libs\gui_tk\gui_tk.cpp" />
+    <ClCompile Include="..\src\libs\decoders\audio_convert.c" />
+    <ClCompile Include="..\src\libs\decoders\flac.c" />
+    <ClCompile Include="..\src\libs\decoders\mp3.cpp" />
+    <ClCompile Include="..\src\libs\decoders\mp3_seek_table.cpp" />
+    <ClCompile Include="..\src\libs\decoders\opus.c" />
+    <ClCompile Include="..\src\libs\decoders\SDL_sound.c" />
+    <ClCompile Include="..\src\libs\decoders\vorbis.c" />
+    <ClCompile Include="..\src\libs\decoders\wav.c" />
+    <ClCompile Include="..\src\libs\decoders\xxhash.c" />
     <ClCompile Include="..\src\misc\cross.cpp" />
     <ClCompile Include="..\src\misc\messages.cpp" />
     <ClCompile Include="..\src\misc\programs.cpp" />
@@ -358,6 +367,17 @@
     <ClInclude Include="..\src\hardware\serialport\softmodem.h" />
     <ClInclude Include="..\src\ints\int10.h" />
     <ClInclude Include="..\src\ints\xms.h" />
+    <ClInclude Include="..\src\libs\decoders\archive.h" />
+    <ClInclude Include="..\src\libs\decoders\dr_flac.h" />
+    <ClInclude Include="..\src\libs\decoders\dr_mp3.h" />
+    <ClInclude Include="..\src\libs\decoders\dr_wav.h" />
+    <ClInclude Include="..\src\libs\decoders\mp3_seek_table.h" />
+    <ClInclude Include="..\src\libs\decoders\SDL_sound.h" />
+    <ClInclude Include="..\src\libs\decoders\SDL_sound_internal.h" />
+    <ClInclude Include="..\src\libs\decoders\stb.h" />
+    <ClInclude Include="..\src\libs\decoders\stb_vorbis.h" />
+    <ClInclude Include="..\src\libs\decoders\xxh3.h" />
+    <ClInclude Include="..\src\libs\decoders\xxhash.h" />
     <ClInclude Include="..\src\platform\visualc\config.h" />
     <ClInclude Include="..\src\platform\visualc\unistd.h" />
   </ItemGroup>


### PR DESCRIPTION
**Runtime improvements:**
- Replaces the existing audio callback routine with an efficient chunked circular-buffer audio reader
- Replaces assumptions that all audio tracks are 44.1 kHz & stereo. The mixer is now fed data at the actual compressed track's rate and channel count
- Eliminates all SDL locks in the audio code in favour of mixer state control
- Queries the codec for track-length instead of using hundreds of iterative decimating seeks to determine track length (loading a 99-track CUE now takes 0.1 user-seconds versus 3+ seconds previously)
- Seeks are performed within the already-decoded buffer (for all codecs) instead of discarding and re-running the decode sequence
- SDL_Sound's buffer-size is now set once and never resized, which eliminates repeated re-malloc'ing in the library
- Only one seek is performed per-playback sequence followed by sequential decodes, similar to a physical CDROM (The baseline dosbox performs a seek for every 2352-bytes of uncompressed audio)
- The DOSBox mixer is now only active during playback sequences and fully dormant otherwise (baseline dosbox instead performs hundreds of calls/second with empty data)
- When using Opus audio tracks, and if your dosbox.conf [mixer] rate=48000, then you will (very likely) achieve sample-exact unadulterated pass-through along your entire audio chain from the decoder, to DOSBox, to your operating system's software mixer, to your sound card driver, to your sound card, to your speakers, or to your digital receiver / USB speakers/headphones / or HDMI TV/screen. This is because almost all modern hardware DACs use a native sample rate of 48000

**Source-level maintenance improvements:**
- Eliminated external dependence on SDL_Sound and its outdated of external library dependencies -- thank you Dominus and DosFreak for recommending this approach.
- SDL_Sound, Vorbis, FLAC, and MP3 libraries are not needed on your system nor do you need to build or provide pointers to these in CFLAGS/LIBS/etc..
- CD image mounting and all codecs are "always on"
- It strips all references to SDL_Sound from configure.ac
- It strips all pre-processor #ifdef branching for SDL_Sound from the code
- It adds src/libs/decoders, which holds the top-level opus, flac, vorbis, and wav decoders
- Fixes all codec compiler warnings; builds have been tested with gcc 4 to 10, Clang 6 to 10, and VisualStudio 14
- Tested on Linux, MacOS X (xcode), and Windows (MSYS2) operating systems
- Tested on i386, x86_64, ARM (little-endian), and PowerPC (big-endian) architectures