### PR TITLE
Use apt-get instead of apt

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,8 +9,9 @@ jobs:
       - uses: actions/checkout@v1
       - name: Log environment
         run:  ./scripts/log-env.sh
+      - run:  sudo apt-get update
       - name: Install dependencies
-        run:  sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt --compiler clang --compiler-version 8)
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -p apt --compiler clang --compiler-version 8)
       - name: Build
         run:  ./scripts/build.sh --compiler clang --compiler-version 8 --lto
       - name: Summarize warnings
@@ -26,8 +27,9 @@ jobs:
       - uses: actions/checkout@v1
       - name: Log environment
         run:  ./scripts/log-env.sh
+      - run:  sudo apt-get update
       - name: Install dependencies
-        run:  sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt)
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -p apt)
       - name: Build
         run:  ./scripts/build.sh
       - name: Summarize warnings
@@ -40,8 +42,9 @@ jobs:
       - uses: actions/checkout@v1
       - name: Log environment
         run:  ./scripts/log-env.sh
+      - run:  sudo apt-get update
       - name: Install dependencies
-        run:  sudo apt-get update && sudo apt install -y $(./scripts/list-build-dependencies.sh -p apt --compiler-version 9)
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -p apt --compiler-version 9)
       - name: Build
         run:  ./scripts/build.sh --compiler-version 9 --lto
       - name: Summarize warnings

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,7 @@
 name: macOS builds
 on: push
 jobs:
+
   build_macos_xcode_clang:
     name: Clang 10 (Xcode)
     runs-on: macOS-10.14

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,8 +1,7 @@
 name: Static code analysis
-
-on: [push]
-
+on: push
 jobs:
+
   build_clang_static_analyser:
     name: Clang static analyzer
     runs-on: ubuntu-18.04
@@ -10,9 +9,9 @@ jobs:
       - uses: actions/checkout@v1
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - run:  sudo apt update
-      - name: Install packages
-        run:  sudo apt-get install autoconf-archive libsdl1.2-dev libsdl-net1.2-dev libopusfile-dev libspeexdsp-dev python3-setuptools
+      - run:  sudo apt-get update
+      - name: Install dependencies
+        run:  sudo apt-get install python3-setuptools $(./scripts/list-build-dependencies.sh -p apt)
       - name: Install scan-build (Python version)
         run:  sudo pip3 install scan-build beautifulsoup4 html5lib
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,3 @@
-#  SPDX-License-Identifier: GPL-2.0-or-later
-
 name: Windows builds
 on: push
 jobs:


### PR DESCRIPTION
Apt does not have a stable CLI interface, therefore should be avoided in
scripts. Using apt-get should be fine.

Split 'apt-get update' to a separate step. It makes it easier to
check, what mirrors and repositories are being used by CI machines.

Remove SPDX identifier - it's missing from other .yml files (I would
consider these configuration files and not source code, so not covered
by copyright).

Use the same build dependencies for static analysis build as in other
Linux jobs.