### PR TITLE
Create a wrapper for MSYS2 bash CI environment

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,17 +8,20 @@ jobs:
     env:
       CHERE_INVOKING: yes
     steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-      - name: Log environment
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 --compiler clang --bit-depth 32 | xargs pacman -S --noconfirm"
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --compiler clang --bit-depth 32 --bin-path /mingw32/bin"
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log
+      - uses:  actions/checkout@v1
+      - name:  Install msys2 environment
+        run:   choco install msys2 --no-progress
+      - name:  Log environment
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/log-env.sh
+      - name:  Install dependencies
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/list-build-dependencies.sh -p msys2 --compiler clang --bit-depth 32 | xargs pacman -S --noconfirm
+      - name:  Build
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/build.sh --compiler clang --bit-depth 32 --bin-path /mingw32/bin
+      - name:  Summarize warnings
+        run:   .\scripts\count-warnings.py build.log
 
   build_msys2_clang_64:
     name: Clang 8 x86_64 (MSYS2)
@@ -26,17 +29,20 @@ jobs:
     env:
       CHERE_INVOKING: yes
     steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-      - name: Log environment
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 --compiler clang | xargs pacman -S --noconfirm"
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --compiler clang --bin-path /mingw64/bin"
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log
+      - uses:  actions/checkout@v1
+      - name:  Install msys2 environment
+        run:   choco install msys2 --no-progress
+      - name:  Log environment
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/log-env.sh
+      - name:  Install dependencies
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/list-build-dependencies.sh -p msys2 --compiler clang | xargs pacman -S --noconfirm
+      - name:  Build
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/build.sh --compiler clang --bin-path /mingw64/bin
+      - name:  Summarize warnings
+        run:   .\scripts\count-warnings.py build.log
 
   build_msys2_gcc_32:
     name: GCC 9 i686 (MSYS2)
@@ -44,17 +50,20 @@ jobs:
     env:
       CHERE_INVOKING: yes
     steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-      - name: Log environment
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 --bit-depth 32 | xargs pacman -S --noconfirm"
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --bit-depth 32 --bin-path /mingw32/bin"
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log
+      - uses:  actions/checkout@v1
+      - name:  Install msys2 environment
+        run:   choco install msys2 --no-progress
+      - name:  Log environment
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/log-env.sh
+      - name:  Install dependencies
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/list-build-dependencies.sh -p msys2 --bit-depth 32 | xargs pacman -S --noconfirm
+      - name:  Build
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/build.sh --bit-depth 32 --bin-path /mingw32/bin
+      - name:  Summarize warnings
+        run:   .\scripts\count-warnings.py build.log
 
 
   build_msys2_gcc_64:
@@ -63,17 +72,20 @@ jobs:
     env:
       CHERE_INVOKING: yes
     steps:
-      - uses: actions/checkout@v1
-      - name: Install msys2 environment
-        run:  choco install msys2 --no-progress
-      - name: Log environment
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/log-env.sh"
-      - name: Install dependencies
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/list-build-dependencies.sh -p msys2 | xargs pacman -S --noconfirm"
-      - name: Build
-        run:  C:\tools\msys64\usr\bin\bash -lc "./scripts/build.sh --bin-path /mingw64/bin"
-      - name: Summarize warnings
-        run:  .\scripts\count-warnings.py build.log
+      - uses:  actions/checkout@v1
+      - name:  Install msys2 environment
+        run:   choco install msys2 --no-progress
+      - name:  Log environment
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/log-env.sh
+      - name:  Install dependencies
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/list-build-dependencies.sh -p msys2 | xargs pacman -S --noconfirm
+      - name:  Build
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/build.sh --bin-path /mingw64/bin
+      - name:  Summarize warnings
+        run:   .\scripts\count-warnings.py build.log
 
   build_msvc_debug:
     name: MSVC Debug x86 (win-2019)
@@ -118,5 +130,3 @@ jobs:
           # build steps
           cd visualc_net
           MSBuild -m dosbox.sln -p:Configuration=Release
-
-

--- a/scripts/msys-bash.py
+++ b/scripts/msys-bash.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2019 Patryk Obara <patryk.obara@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# pylint: disable=invalid-name
+# pylint: disable=line-too-long
+
+"""
+This is a wrapper for MSYS2 bash inside Windows GitHub CI environment.
+
+Usage:
+
+- name:  Step Name
+  shell: python scripts\msys-bash.py {0}
+  run:   echo "Hello"
+
+GitHub documentation for specifying shell is here: [1], although it
+leaves several VERY important details out:
+
+- The first parameter (program name) in template shell invocation needs to be
+  in PATH; absolute path will result in obscure C# exception.
+- Name of temporary script file ends with a hardcoded extension matching the
+  first parameter.
+- There is some additional undocumented trickery about expansion of {0} in
+  template (most probably it's something about formatting strings in C#).
+- For some shells, an additional first line is prepended to the temporary
+  script (but not for python!)
+
+[1] https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
+"""
+
+import shutil
+import subprocess
+import sys
+
+if __name__ == "__main__":
+    script_py = sys.argv[1]
+    script_sh = script_py + '.sh'
+    shutil.copy(script_py, script_sh)
+    bash = [r'C:\tools\msys64\usr\bin\bash', '-eo', 'pipefail', '-l']
+    subprocess.call(bash + [script_sh])


### PR DESCRIPTION
This way there's no need to prepend every line in build job with a path
to MSYS2-installed bash, and deal with problems related to escaping
embedded shell invocations.