### PR TITLE
Use macos-latest and windows-latest in CI jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,8 +3,8 @@ on: push
 jobs:
 
   build_macos_xcode_clang:
-    name: Clang 10 (Xcode)
-    runs-on: macOS-10.14
+    name: Clang (Xcode)
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
       - name: Log environment
@@ -19,7 +19,7 @@ jobs:
 
 #  build_macos_brew_gcc9:
 #    name: GCC 9 (Homebrew)
-#    runs-on: macOS-10.14
+#    runs-on: macos-latest
 #    steps:
 #      - uses: actions/checkout@v1
 #      - name: Log environment
@@ -34,7 +34,7 @@ jobs:
 
 #  build_macos_macports_gcc9:
 #    name: GCC 9 (MacPorts)
-#    runs-on: macOS-10.14
+#    runs-on: macos-latest
 #    steps:
 #      - uses: actions/checkout@v1
 #      - name: Install MacPorts

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ jobs:
 
   build_msys2_clang_32:
     name: Clang 8 i686 (MSYS2)
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       CHERE_INVOKING: yes
     steps:
@@ -25,7 +25,7 @@ jobs:
 
   build_msys2_clang_64:
     name: Clang 8 x86_64 (MSYS2)
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       CHERE_INVOKING: yes
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   build_msys2_gcc_32:
     name: GCC 9 i686 (MSYS2)
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       CHERE_INVOKING: yes
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   build_msys2_gcc_64:
     name: GCC 9 x86_64 (MSYS2)
-    runs-on: windows-2019
+    runs-on: windows-latest
     env:
       CHERE_INVOKING: yes
     steps:
@@ -88,8 +88,8 @@ jobs:
         run:   .\scripts\count-warnings.py build.log
 
   build_msvc_debug:
-    name: MSVC Debug x86 (win-2019)
-    runs-on: windows-2019
+    name: MSVC Debug x86
+    runs-on: windows-latest
     steps:
       - uses:  actions/checkout@v1
       - name:  Log environment
@@ -110,8 +110,8 @@ jobs:
           MSBuild -m dosbox.sln -p:Configuration=Debug
 
   build_msvc_release:
-    name: MSVC Release x86 (win-2019)
-    runs-on: windows-2019
+    name: MSVC Release x86
+    runs-on: windows-latest
     steps:
       - uses:  actions/checkout@v1
       - name:  Log environment


### PR DESCRIPTION
GitHub notified me, that they are dropping macOS-10.14 completely, all
users are upgraded to macOS-10.15 and the only valid value in CI jobs
will be macos-latest from now on.

I haven't seen any indication of the same happening for Windows
machines, but GitHub Actions documentation dropped all references to
windows-2016 and windows-2019 - windows-latest seems to be the only
valid value for shared runners from now on.

Ubuntu machines are left as they are (thankfully).