### PR TITLE
List files before running linters

### DIFF
--- a/.pylint
+++ b/.pylint
@@ -163,7 +163,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # Set the output format. Available formats are text, parseable, colorized, json
 # and msvs (visual studio). You can also give a reporter class, e.g.
 # mypackage.mymodule.MyReporterClass.
-output-format=text
+output-format=colorized
 
 # Tells whether to display a full report or only the messages.
 reports=no

--- a/scripts/verify-bash.sh
+++ b/scripts/verify-bash.sh
@@ -19,7 +19,7 @@ main () {
 	shellcheck --version >&2
 	echo "Checking files:" >&2
 	list_bash_files >&2
-	list_bash_files | xargs -L 1000 shellcheck "$@"
+	list_bash_files | xargs -L 1000 shellcheck --color "$@"
 }
 
 main "$@"

--- a/scripts/verify-bash.sh
+++ b/scripts/verify-bash.sh
@@ -8,13 +8,18 @@
 #
 # $ ./verify-bash.sh --format=json
 
-run_shellcheck () {
+list_bash_files () {
 	git ls-files \
 		| xargs file \
 		| grep "Bourne-Again shell script" \
-		| cut -d ':' -f 1 \
-		| xargs -L 1000 shellcheck "$@"
+		| cut -d ':' -f 1
 }
 
-shellcheck --version
-run_shellcheck "$@"
+main () {
+	shellcheck --version >&2
+	echo "Checking files:" >&2
+	list_bash_files >&2
+	list_bash_files | xargs -L 1000 shellcheck "$@"
+}
+
+main "$@"

--- a/scripts/verify-python.sh
+++ b/scripts/verify-python.sh
@@ -8,13 +8,19 @@
 #
 # $ ./verify-python.sh --disable=<msg_ids>
 
-run_pylint () {
+list_python_files () {
 	git ls-files \
 		| xargs file \
 		| grep "Python script" \
-		| cut -d ':' -f 1 \
-		| xargs -L 1000 pylint "$@"
+		| cut -d ':' -f 1
 }
 
-pylint --version
-run_pylint --rcfile="$(git rev-parse --show-toplevel)/.pylint" "$@"
+main () {
+	pylint --version >&2
+	echo "Checking files:" >&2
+	list_python_files >&2
+	local -r rc="$(git rev-parse --show-toplevel)/.pylint"
+	list_python_files | xargs -L 1000 pylint --rcfile="$rc" "$@"
+}
+
+main "$@"

--- a/scripts/verify-python.sh
+++ b/scripts/verify-python.sh
@@ -7,6 +7,11 @@
 # the repo.  You can pass additional parameters to this script itself, e.g.:
 #
 # $ ./verify-python.sh --disable=<msg_ids>
+#
+# This script uses exclusively python3 version of pylint; most distributions
+# provide it in a package pylint, but some call it pylint3 or python3-pylint.
+
+set -e
 
 list_python_files () {
 	git ls-files \
@@ -16,11 +21,13 @@ list_python_files () {
 }
 
 main () {
-	pylint --version >&2
+	# Using "python3 -m pylint" to avoid using python2-only
+	# version of pylint by mistake.
+	python3 -m pylint --version >&2
 	echo "Checking files:" >&2
 	list_python_files >&2
 	local -r rc="$(git rev-parse --show-toplevel)/.pylint"
-	list_python_files | xargs -L 1000 pylint --rcfile="$rc" "$@"
+	list_python_files | xargs -L 1000 python3 -m pylint --rcfile="$rc" "$@"
 }
 
 main "$@"


### PR DESCRIPTION
Makes it more readable for human consumption. Also, redirect initial output to stderr to fix e.g. output to json file.

Should address concerns, such as in https://github.com/dreamer/dosbox-staging/issues/45.