### PR TITLE
Fix trivial warnings in src/cpu

### DIFF
--- a/scripts/count-bugs.py
+++ b/scripts/count-bugs.py
@@ -23,7 +23,7 @@ from bs4 import BeautifulSoup
 # then script will return with status 1. Simply change this line if you
 # want to set a different limit.
 #
-MAX_ISSUES = 93
+MAX_ISSUES = 92
 
 def summary_values(summary_table):
     if not summary_table:

--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -23,7 +23,7 @@ import sys
 # then script will return with status 1. Simply change this line if you
 # want to set a different limit.
 #
-MAX_ISSUES = 409
+MAX_ISSUES = 369
 
 # For recognizing warnings in GCC format in stderr:
 #

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -527,7 +527,7 @@ Bitu CALLBACK_SetupExtra(Bitu callback, Bitu type, PhysPt physAddress, bool use_
 			phys_writeb(physAddress+0x1B,(Bit8u)0xC3);	//A RETN Instruction
 		return (use_cb?32:27);
 	default:
-		E_Exit("CALLBACK:Setup:Illegal type %d",type);
+		E_Exit("CALLBACK:Setup:Illegal type %lu", type);
 	}
 	return 0;
 }

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -427,8 +427,13 @@ static void cache_closeblock(void) {
 	Bitu written=cache.pos-block->cache.start;
 	if (written>block->cache.size) {
 		if (!block->cache.next) {
-			if (written>block->cache.size+CACHE_MAXSIZE) E_Exit("CacheBlock overrun 1 %d",written-block->cache.size);	
-		} else E_Exit("CacheBlock overrun 2 written %d size %d",written,block->cache.size);	
+			if (written>block->cache.size+CACHE_MAXSIZE)
+				E_Exit("CacheBlock overrun 1 %lu",
+				       written-block->cache.size);
+		} else {
+			E_Exit("CacheBlock overrun 2 written %lu size %lu",
+			       written, block->cache.size);
+		}
 	} else {
 		Bitu new_size;
 		Bitu left=block->cache.size-written;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1885,15 +1885,6 @@ static void dyn_closeblock(void) {
 	cache_closeblock();
 }
 
-static void dyn_normal_exit(BlockReturn code) {
-	gen_protectflags();
-	dyn_reduce_cycles();
-	dyn_set_eip_last();
-	dyn_save_critical_regs();
-	gen_return(code);
-	dyn_closeblock();
-}
-
 static void dyn_exit_link(Bits eip_change) {
 	gen_protectflags();
 	gen_dop_word_imm(DOP_ADD,decode.big_op,DREG(EIP),(decode.code-decode.code_start)+eip_change);

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2099,7 +2099,6 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 /* Init a load of variables */
 	decode.code_start=start;
 	decode.code=start;
-	Bitu cycles=0;
 	decode.page.code=codepage;
 	decode.page.index=start&4095;
 	decode.page.wmap=codepage->write_map;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -370,17 +370,6 @@ static void dyn_check_irqrequest(void) {
 	used_save_info++;
 }
 
-static void dyn_check_bool_exception_ne(void) {
-	save_info[used_save_info].branch_pos=gen_create_branch_long(BR_Z);
-	dyn_savestate(&save_info[used_save_info].state);
-	if (!decode.cycles) decode.cycles++;
-	save_info[used_save_info].cycles=decode.cycles;
-	save_info[used_save_info].eip_change=decode.op_start-decode.code_start;
-	if (!cpu.code.big) save_info[used_save_info].eip_change&=0xffff;
-	save_info[used_save_info].type=db_exception;
-	used_save_info++;
-}
-
 static void dyn_fill_blocks(void) {
 	for (Bitu sct=0; sct<used_save_info; sct++) {
 		gen_fill_branch_long(save_info[sct].branch_pos);
@@ -485,6 +474,19 @@ static void dyn_write_word_release(DynReg * addr,DynReg * val,bool dword) {
 
 #else
 #if C_TARGETCPU == X86
+
+static void dyn_check_bool_exception_ne(void) {
+	save_info[used_save_info].branch_pos = gen_create_branch_long(BR_Z);
+	dyn_savestate(&save_info[used_save_info].state);
+	if (!decode.cycles)
+		decode.cycles++;
+	save_info[used_save_info].cycles = decode.cycles;
+	save_info[used_save_info].eip_change = decode.op_start - decode.code_start;
+	if (!cpu.code.big)
+		save_info[used_save_info].eip_change &= 0xffff;
+	save_info[used_save_info].type = db_exception;
+	used_save_info++;
+}
 
 static void dyn_read_intro(DynReg * addr,bool release_addr=true) {
 	gen_protectflags();

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1954,6 +1954,9 @@ static void dyn_loop(LoopTypes type) {
 		gen_needflags();
 		branch1=gen_create_branch(BR_Z);
 		break;
+	case LOOP_NONE:
+	case LOOP_JCXZ:
+		break;
 	}
 	gen_protectflags();
 	switch (type) {

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -366,7 +366,7 @@ static void dyn_fpu_esc3(){
 			switch (sub) {
 			case 0x00:				//FNENI
 			case 0x01:				//FNDIS
-				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfuntion :%d",sub);
+				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %lu", sub);
 				break;
 			case 0x02:				//FNCLEX FCLEX
 				gen_call_function((void*)&FPU_FCLEX,"");
@@ -379,11 +379,11 @@ static void dyn_fpu_esc3(){
 //				LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
 				break;
 			default:
-				E_Exit("ESC 3:ILLEGAL OPCODE group %d subfunction %d",group,sub);
+				E_Exit("ESC 3:ILLEGAL OPCODE group %lu subfunction %lu", group, sub);
 			}
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %d subfunction %d",group,sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %lu subfunction %lu", group, sub);
 			break;
 		}
 	} else {
@@ -398,7 +398,7 @@ static void dyn_fpu_esc3(){
 			gen_call_function((void*)&FPU_FLD_I32,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x01:	/* FISTTP */
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d",group,sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
 			break;
 		case 0x02:	/* FIST */
 			gen_call_function((void*)&FPU_FST_I32,"%Drd",DREG(EA));
@@ -416,7 +416,7 @@ static void dyn_fpu_esc3(){
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d",group,sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
 		}
 	}
 }

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -239,7 +239,7 @@ static void dh_fpu_esc3(){
 			switch (sub) {
 			case 0x00:				//FNENI
 			case 0x01:				//FNDIS
-				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfuntion :%d",sub);
+				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %lu", sub);
 				break;
 			case 0x02:				//FNCLEX FCLEX
 				cache_addb(0xdb);
@@ -255,11 +255,11 @@ static void dh_fpu_esc3(){
 //				LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
 				break;
 			default:
-				E_Exit("ESC 3:ILLEGAL OPCODE group %d subfunction %d",group,sub);
+				E_Exit("ESC 3:ILLEGAL OPCODE group %lu subfunction %lu", group, sub);
 			}
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %d subfunction %d",group,sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %lu subfunction %lu", group, sub);
 			break;
 		}
 	} else {
@@ -272,7 +272,7 @@ static void dh_fpu_esc3(){
 			dh_fpu_mem(0xdb);
 			break;
 		case 0x01:	/* FISTTP */
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d",group,sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
 			break;
 		case 0x02:	/* FIST */
 			dh_fpu_mem(0xdb);
@@ -291,7 +291,7 @@ static void dh_fpu_esc3(){
 			gen_call_function((void*)&FPU_FST_80,"%Drd",DREG(EA));
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d",group,sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
 		}
 	}
 }

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -518,7 +518,7 @@ static void gen_load_host(void * data,DynReg * dr1,Bitu size) {
 static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bit8u di1=0) {
 	int idx = FindDynReg(dr1,size==4)->index;
 	opcode op;
-	Bit8u tmp;
+	Bit8u tmp = 0x00;
 	switch (size) {
 	case 1:
 		op.setreg(idx,di1);
@@ -660,7 +660,7 @@ static void gen_dop_byte_imm_mem(DualOps op,DynReg * dr1,Bit8u di1,void* data) {
 		i = opcode(dst->index,true,di1).setea(src);
 	}
 
-	Bit8u tmp;
+	Bit8u tmp = 0x00;
 	switch (op) {
 	case DOP_ADD:	tmp=0x02; break;
 	case DOP_ADC:	tmp=0x12; break;
@@ -1100,7 +1100,7 @@ static void gen_call_function(void * func,const char* ops,...) {
 }
 
 static void gen_call_write(DynReg * dr,Bit32u val,Bitu write_size) {
-	void *func;
+	void *func = NULL;
 	gen_protectflags();
 	gen_load_arg_reg(0,dr,"rd");
 

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -329,7 +329,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bit8u di1=0) {
 
 static void gen_dop_byte(DualOps op,DynReg * dr1,Bit8u di1,DynReg * dr2,Bit8u di2) {
 	GenReg * gr1=FindDynReg(dr1);GenReg * gr2=FindDynReg(dr2);
-	Bit8u tmp;
+	Bit8u tmp = 0x00;
 	switch (op) {
 	case DOP_ADD:	tmp=0x02; break;
 	case DOP_ADC:	tmp=0x12; break;

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -104,6 +104,8 @@ static void dyn_string(STRING_OP op) {
 			gen_call_function((void*)&IO_WriteW,"%Dw%Dw",DREG(EDX),tmp_reg);break;
 		case STR_OUTSD:
 			gen_call_function((void*)&IO_WriteD,"%Dw%Dd",DREG(EDX),tmp_reg);break;
+		default:
+			break;
 		}
 	}
 	if (usedi) {

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -349,7 +349,7 @@ bool CPU_SwitchTask(Bitu new_tss_selector,TSwitchType tstype,Bitu old_eip) {
 	FillFlags();
 	TaskStateSegment new_tss;
 	if (!new_tss.SetSelector(new_tss_selector)) 
-		E_Exit("Illegal TSS for switch, selector=%x, switchtype=%x",new_tss_selector,tstype);
+		E_Exit("Illegal TSS for switch, selector=%lx, switchtype=%x", new_tss_selector, tstype);
 	if (tstype==TSwitch_IRET) {
 		if (!new_tss.desc.IsBusy())
 			E_Exit("TSS not busy for IRET");
@@ -503,7 +503,7 @@ doconforming:
 			Segs.val[cs]=new_cs;
 			break;
 		default:
-			E_Exit("Task switch CS Type %d",cs_desc.Type());
+			E_Exit("Task switch CS Type %lu", cs_desc.Type());
 		}
 	}
 	CPU_SetSegGeneral(es,new_es);
@@ -725,7 +725,7 @@ do_interrupt:
 					}
 					break;		
 				default:
-					E_Exit("INT:Gate Selector points to illegal descriptor with type %x",cs_desc.Type());
+					E_Exit("INT:Gate Selector points to illegal descriptor with type %lx", cs_desc.Type());
 				}
 
 				Segs.val[cs]=(gate_sel&0xfffc) | cpu.cpl;
@@ -755,7 +755,7 @@ do_interrupt:
 			}
 			return;
 		default:
-			E_Exit("Illegal descriptor type %X for int %X",gate.Type(),num);
+			E_Exit("Illegal descriptor type %lX for int %lX", gate.Type(), num);
 		}
 	}
 	assert(1);
@@ -902,7 +902,7 @@ void CPU_IRET(bool use32,Bitu oldeip) {
 				EXCEPTION_GP,n_cs_sel & 0xfffc)
 			break;
 		default:
-			E_Exit("IRET:Illegal descriptor type %X",n_cs_desc.Type());
+			E_Exit("IRET:Illegal descriptor type %lX", n_cs_desc.Type());
 		}
 		CPU_CHECK_COND(!n_cs_desc.saved.seg.p,
 			"IRET with nonpresent code segment",
@@ -1059,7 +1059,7 @@ CODE_jmp:
 			CPU_SwitchTask(selector,TSwitch_JMP,oldeip);
 			break;
 		default:
-			E_Exit("JMP Illegal descriptor type %X",desc.Type());
+			E_Exit("JMP Illegal descriptor type %lX", desc.Type());
 		}
 	}
 	assert(1);
@@ -1295,7 +1295,7 @@ call_code:
 			CPU_Exception(EXCEPTION_GP,selector & 0xfffc);
 			return;
 		default:
-			E_Exit("CALL:Descriptor type %x unsupported",call.Type());
+			E_Exit("CALL:Descriptor type %lx unsupported", call.Type());
 		}
 	}
 	assert(1);
@@ -1353,7 +1353,7 @@ void CPU_RET(bool use32,Bitu bytes,Bitu oldeip) {
 					EXCEPTION_GP,selector & 0xfffc)
 				break;
 			default:
-				E_Exit("RET from illegal descriptor type %X",desc.Type());
+				E_Exit("RET from illegal descriptor type %lX", desc.Type());
 			}
 RET_same_level:
 			if (!desc.saved.seg.p) {
@@ -1398,7 +1398,7 @@ RET_same_level:
 					EXCEPTION_GP,selector & 0xfffc)
 				break;
 			default:
-				E_Exit("RET from illegal descriptor type %X",desc.Type());		// or #GP(selector)
+				E_Exit("RET from illegal descriptor type %lX", desc.Type()); // or #GP(selector)
 			}
 
 			CPU_CHECK_COND(!desc.saved.seg.p,
@@ -1509,7 +1509,8 @@ bool CPU_LTR(Bitu selector) {
 			LOG(LOG_CPU,LOG_ERROR)("LTR failed, selector=%X (not present)",selector);
 			return CPU_PrepareException(EXCEPTION_NP,selector);
 		}
-		if (!cpu_tss.SetSelector(selector)) E_Exit("LTR failed, selector=%X",selector);
+		if (!cpu_tss.SetSelector(selector))
+			E_Exit("LTR failed, selector=%lX", selector);
 		cpu_tss.desc.SetBusy(true);
 		cpu_tss.SaveSelector();
 	} else {


### PR DESCRIPTION
I have more trivial warning fixes WIP but decided to group them by directory.

There are few warnings in this dir, that were not addressed, because they require more digging into the code to understand what was the author's intention.