### PR TITLE
Workflow additions and refactoring

### DIFF
--- a/.github/scripts/build-and-run-sanitizers.sh
+++ b/.github/scripts/build-and-run-sanitizers.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This simple script is used to build, test, and archive the log output from
+# various sanitizer-builds.
+#
+# Usage:
+#   ./build-and-run-sanitizers.sh COMPILER VERSION SANITIZER [SANITIZER [...]]"
+#
+# Examples:
+#   ./build-and-run-sanitizers.sh clang 8 msan usan
+#   ./build-and-run-sanitizers.sh gcc 9 asan uasan usan tsan
+#
+set -euo pipefail
+
+# Check the arguments
+if [[ "$#" -lt 3 ]]; then
+	echo "Usage: $0 COMPILER VERSION SANITIZER [SANITIZER [...]]"
+	exit 1
+fi
+
+# Defaults and arguments
+compiler="${1}"
+compiler_version="${2}"
+logs="${compiler}-logs"
+shift 2
+sanitizers=("$@")
+
+# Move to the top of our source directory
+cd "$(dirname "${0}")/../.."
+
+# Make a directory to hold our build and run output
+mkdir -p "${logs}"
+
+for sanitizer in "${sanitizers[@]}"; do
+
+	# Build DOSBox for each sanitizer
+	time ./scripts/build.sh \
+		--compiler "${compiler}" \
+		--version-postfix "${compiler_version}" \
+		--build-type "${sanitizer}" \
+		&> "${logs}/${compiler}-${sanitizer}-compile.log"
+
+	# Exercise the testcase(s) for each sanitizer
+	# Sanitizers return non-zero if one or more issues were found,
+	# so we or-to-true to ensure our script doesn't end here.
+	time xvfb-run ./src/dosbox -c exit \
+		&> "${logs}/${compiler}-${sanitizer}-EnterExit.log" || true
+
+done
+
+# Compress the logs
+(
+	cd "${logs}"
+	xz -T0 -e ./*.log
+)

--- a/.github/scripts/download-and-build-macports.sh
+++ b/.github/scripts/download-and-build-macports.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script downloads and builds MacPorts from source.
+# Usage: ./download-and-build-macports.sh
+#
+set -xeuo pipefail
+
+# Move to the top of our source directory
+cd "$(dirname "${0}")/../.."
+
+# Download and install MacPorts
+git clone --quiet --depth=1 https://github.com/macports/macports-base.git
+(
+	cd macports-base
+	./configure
+	make -j"$(sysctl -n hw.physicalcpu || echo 4)"
+)

--- a/.github/scripts/install-and-update-macports.sh
+++ b/.github/scripts/install-and-update-macports.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script installs and updates MacPorts from an already-compiled
+# source tree assumed to be located n a directory called
+# 'macports-base' off the root of our source-tree.
+#
+# Usage: ./install-and-update-macports.sh
+#
+set -xeuo pipefail
+
+# Ensure we have sudo rights to install MacPorts
+if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
+
+# Move to the top of our source directory
+cd "$(dirname "${0}")/../.."
+(
+	cd macports-base
+	make install
+)
+# Purge the now-unecessary source
+rm -rf macports-base
+
+# Update our ports collection
+/opt/local/bin/port -q selfupdate || true

--- a/.github/scripts/prepare-for-macports-cachehit.sh
+++ b/.github/scripts/prepare-for-macports-cachehit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script creates a new writable /opt/local directory with
+# sane ownership, permissions, and attributes on the directory.
+# Usage: ./prepare-for-macports-cachehit.sh
+#
+set -xeuo pipefail
+
+# Ensure we have sudo rights to create the directory
+if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
+user="${SUDO_USER}"
+group="$(id -g "${user}")"
+
+mkdir -p /opt/local
+cd /opt/local
+chflags nouchg .
+xattr -rc .
+chmod 770 .
+chown "${user}:${group}" .

--- a/.github/scripts/reset-brew.sh
+++ b/.github/scripts/reset-brew.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script removes all existing brew packages, and then
+# re-installs some important basic packages (listed below).
+#
+# Usage: ./reset-brew.sh
+#
+set -xuo pipefail
+set +e
+
+# Pre-cleanup size
+sudo du -sch /usr/local 2> /dev/null
+
+# Uninstall all packages
+# shellcheck disable=SC2046
+brew remove --force $(brew list) --ignore-dependencies
+# shellcheck disable=SC2046
+brew cask remove --force $(brew cask list)
+
+# Reinstall important packages
+brew install git git-lfs python curl wget jq binutils zstd gnu-tar
+
+# Clean the brew cache
+rm -rf "$(brew --cache)"
+
+# Post-clean up size
+sudo du -sch /usr/local 2> /dev/null
+
+# This script is best-effort, so always return success
+exit 0
+

--- a/.github/scripts/shrink-brew.sh
+++ b/.github/scripts/shrink-brew.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script reduces the size of a brew-managed installation on macOS.
+# Its main use is to shrink this area to fit within GitHub's cache
+# limits however it can also be used by end-users wanting to save space.
+#
+# Note that this script remove alot of content deemed unecessary for our
+# purposes such as ruby, go, grade, azure, etc..) so using on your
+# home system is probably not what you want :-)
+#
+# Usage: ./shrink-brew.sh
+#
+set -xuo pipefail
+set +e
+
+# Ensure we have sudo rights
+if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
+user="${SUDO_USER}"
+group="$(id -g "${user}")"
+
+# If we don't have /usr/local then brew hasn't installed anything yet
+cd /usr/local || exit 0
+
+# Purge unecessary bloat
+for dir in lib/ruby Cellar/go Cellar/gradle Cellar/azure-cli lib/node_modules \
+share/powershell Caskroom/fastlane Cellar/ruby opt/AGPM Caskroom Cellar/node \
+miniconda Cellar/python@2 Cellar/git lib/python2.7 Cellar/git-lfs Cellar/subversion \
+Cellar/maven Cellar/aria2 Homebrew/Library/Homebrew/os/mac/pkgconfig/fuse \
+.com.apple.installer.keep microsoft; do
+	rm -rf "${dir}" || true
+done
+
+# Cleanup permissions and attributes
+chflags nouchg .
+find . -type d -exec xattr -c {} +
+find . -type f -exec xattr -c {} +
+chown -R "${user}:${group}" ./*
+find . ! -path . -type d -exec chmod 770 {} +
+
+# Binary-stripping is *extremely* verbose, so we send these to the ether
+find Cellar -name '*' -a ! -iname 'strip' -type f -perm +111 -exec strip {} + &> /dev/null
+find Cellar -name '*.a' -type f -exec strip {} + &> /dev/null
+
+# Post-cleanup size check
+du -sch . 2> /dev/null
+
+# This entire script is best-effort, so always return success
+exit 0
+

--- a/.github/scripts/shrink-macports.sh
+++ b/.github/scripts/shrink-macports.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script reduces the size of a MacPorts installation
+# under macOS. Its main use is to shrink this area to fit within
+# GitHub's cache limits; however it can also be used by end-users
+# wanting to save space.
+#
+# Usage: ./shrink-macports.sh
+#
+set -xuo pipefail
+set +e
+
+# If MacPorts doesn't exist then our job here is done!
+cd /opt/local || exit 0
+
+# Ensure we have sudo rights
+if [[ $(id -u) -ne 0 ]] ; then echo "Please run as root" ; exit 1 ; fi
+
+# Cleanup permissions and attributes
+chflags nouchg .
+find . -type d -exec xattr -c {} +
+find . -type f -exec xattr -c {} +
+
+for dir in var/macports libexec/macports share/man; do
+	rm -rf "${dir}" &> /dev/null || true
+done
+
+# Binary-stripping is extremely verbose, so send these to the ether
+find . -name '*' -a ! -iname 'strip' -type f -perm +111 -exec ./bin/strip {} + &> /dev/null
+find . -name '*.a' -type f -exec ./bin/strip {} + &> /dev/null
+
+# This entire script is best-effort, so always return success
+exit 0

--- a/.github/scripts/shrink-msys2.sh
+++ b/.github/scripts/shrink-msys2.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script reduces the size of an MSYS2 and MingGW installation
+# under Windows. Its main use is to shrink these areas to fit within
+# GitHub's cache limits; however it can also be used by end-users wanting
+# to save space.
+#
+# Usage: ./shrink-msys2.sh
+#
+set -xuo pipefail
+set +e
+
+# Clean all the package archives from pacman
+pacman -Scc --noconfirm
+
+# Strip binaries using their associated striping tool
+for dir in /usr /mingw32 /mingw64; do
+
+	# Enter our directory if we have it
+	cd "${dir}" || continue
+
+	# Check if we have an associated stripping tool
+	if [[ ! -f "bin/strip.exe" ]]; then continue; fi
+
+	# Start stripping
+	find . -type f              \
+		\( -iname '*.exe'       \
+		   -or -iname '*.a'     \
+		   -or -iname '*.dll'   \
+		   -or -iname '*.so'    \
+		\)                      \
+		-a ! -iname 'strip.exe' \
+		-print0                 \
+	| xargs -0 ./bin/strip.exe --strip-unneeded
+done
+
+# Delete MinGW's share directories
+rm -rf /mingw*/share
+
+# This entire script is best-effort, so always return success
+exit 0

--- a/.github/scripts/tar
+++ b/.github/scripts/tar
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+rcode=0
+# If we're running outside of GitHub then run tar normally
+if [[ -z "${GITHUB_WORKFLOW:-}" ]]; then
+	"/usr/local/bin/gtar" "$@"
+	rcode="$?"
+# Otherwise use zstd and ignore tar's return-code
+else
+	first_arg="${1/z/}"
+	shift
+	[[ "${first_arg}" == "-x" ]] && decomp="-d" || decomp=""
+	set +e -x
+	"/usr/local/bin/gtar" \
+		--warning=none \
+		--use-compress-program="zstd -T0 -19 --long=31 --no-progress -v ${decomp}" \
+		"${first_arg}" "$@"
+fi
+exit "${rcode}"

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -50,7 +50,7 @@ jobs:
           # summary
           echo "Full report is included in build Artifacts"
           echo
-          ./scripts/count-bugs.py -m 92 report/*/index.html
+          ./scripts/count-bugs.py -m 85 report/*/index.html
 
   dynamic_matrix:
     name: ${{ matrix.compiler }} dynamic sanitizers

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,4 +1,4 @@
-name: Static code analysis
+name: Code analysis
 on: push
 jobs:
 
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - run:  sudo apt-get update
       - name: Install pylint
-        run: |
+        run:  |
           sudo apt-get install python3-setuptools
           sudo pip3 install pylint beautifulsoup4 html5lib
       - name: Run pylint
@@ -23,15 +23,15 @@ jobs:
     needs: run_linters
     steps:
       - uses: actions/checkout@v1
-      - name: Log environment
-        run:  ./scripts/log-env.sh
       - run:  sudo apt-get update
-      - name: Install dependencies
-        run:  sudo apt-get install python3-setuptools $(./scripts/list-build-dependencies.sh -p apt)
+      - name: Install C++ compiler and libraries
+        run:  sudo apt-get install python3-setuptools $(./scripts/list-build-dependencies.sh -m apt -c gcc)
       - name: Install scan-build (Python version)
         run:  sudo pip3 install scan-build beautifulsoup4 html5lib
+      - name: Log environment
+        run:  ./scripts/log-env.sh
       - name: Build
-        run: |
+        run:  |
           # build steps
           set -x
           g++ --version
@@ -40,7 +40,8 @@ jobs:
           intercept-build make -j "$(nproc)"
       - name: Analyze
         run:  analyze-build -v -o report --html-title="dosbox-staging (${GITHUB_SHA:0:8})"
-      - uses: actions/upload-artifact@master
+      - name: Upload report
+        uses: actions/upload-artifact@master
         with:
           name: report
           path: report
@@ -49,4 +50,40 @@ jobs:
           # summary
           echo "Full report is included in build Artifacts"
           echo
-          ./scripts/count-bugs.py report/*/index.html
+          ./scripts/count-bugs.py -m 92 report/*/index.html
+
+  dynamic_matrix:
+    name: ${{ matrix.compiler }} dynamic sanitizers
+    needs: run_linters
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [Clang, GCC]
+    steps:
+      - uses: actions/checkout@v1
+      - run:  sudo apt-get update
+      - name: Install C++ compiler and libraries
+        env:
+          VERSION_GCC: 9
+          VERSION_Clang: 8
+        run:  >
+          sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt
+          -c ${{ matrix.compiler }} -v $VERSION_${{ matrix.compiler }})
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - name: Build and run sanitizers
+        env:
+          VERSION_GCC: 9
+          VERSION_Clang: 8
+          SANITIZERS_GCC: UASAN USAN TSAN
+          SANITIZERS_Clang: USAN MSAN
+        run: |
+          ./.github/scripts/build-and-run-sanitizers.sh \
+          ${{ matrix.compiler }} \
+          $VERSION_${{ matrix.compiler }} \
+          $SANITIZERS_${{ matrix.compiler }}
+      - name: Upload logs
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.compiler }}-logs
+          path: ${{ matrix.compiler }}-logs

--- a/.github/workflows/dormant/linux.yml
+++ b/.github/workflows/dormant/linux.yml
@@ -1,0 +1,46 @@
+name: Linux builds
+on: push
+env:
+  MAX_WARNINGS_GCC_6_Debug:     378
+  MAX_WARNINGS_GCC_6_Release:   661
+  MAX_WARNINGS_GCC_7_Debug:     380
+  MAX_WARNINGS_GCC_7_Release:   329
+  MAX_WARNINGS_GCC_8_Debug:     380
+  MAX_WARNINGS_GCC_8_Release:   330
+  MAX_WARNINGS_GCC_9_Debug:     403
+  MAX_WARNINGS_GCC_9_Release:   358
+  MAX_WARNINGS_Clang_7_Debug:   193
+  MAX_WARNINGS_Clang_7_Release: 193
+  MAX_WARNINGS_Clang_8_Debug:   193
+  MAX_WARNINGS_Clang_8_Release: 193
+
+jobs:
+
+  build_matrix:
+    name: ${{ matrix.compiler }}-${{ matrix.compiler_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [Clang, GCC]
+        compiler_version: [6, 7, 8, 9]
+        # build_type: [Debug, Release]
+        exclude:
+          - compiler: Clang
+            compiler_version: 6
+          - compiler: Clang
+            compiler_version: 9
+    steps:
+      - uses: actions/checkout@v1
+      - run:  sudo apt-get update
+      - name: Install C++ compiler and libraries
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c ${{ matrix.compiler }} -v ${{ matrix.compiler_version }})
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - name: Release build
+        run:  ./scripts/build.sh --compiler ${{ matrix.compiler }} --version-postfix ${{ matrix.compiler_version }} --build-type Release
+      - name: Release warnings
+        run:  ./scripts/count-warnings.py -m $MAX_WARNINGS_${{ matrix.compiler }}_${{ matrix.compiler_version }}_Release build.log
+      - name: Debug build
+        run:  ./scripts/build.sh --compiler ${{ matrix.compiler }} --version-postfix ${{ matrix.compiler_version }} --build-type Debug
+      - name: Debug warnings
+        run:  ./scripts/count-warnings.py -m $MAX_WARNINGS_${{ matrix.compiler }}_${{ matrix.compiler_version }}_Debug build.log

--- a/.github/workflows/dormant/macos-gcc.yml
+++ b/.github/workflows/dormant/macos-gcc.yml
@@ -1,0 +1,76 @@
+name: macOS builds
+on: push
+env:
+  MAX_WARNINGS_GCC_9_Debug:   361
+  MAX_WARNINGS_GCC_9_Release: 321
+  PATH: "${GITHUB_WORKSPACE}/.github/scripts:${PATH}"
+
+jobs:
+  build_macos_gcc_brew:
+    name: GCC-${{ matrix.compiler_version }} (HomeBrew)
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        compiler_version: [9]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Prepare tar-zstd for the cache
+        run:  |
+          brew install zstd gnu-tar
+          cp .github/scripts/tar /usr/local/bin/tar
+      - uses: actions/cache@v1
+        id:   cache-brew
+        with: {path: /usr/local, key: brew-gcc-2019-v18}
+      - name: Install C++ compiler and libraries
+        if:   steps.cache-brew.outputs.cache-hit != 'true'
+        run:  |
+          ./.github/scripts/reset-brew.sh
+          brew install $(./scripts/list-build-dependencies.sh -m brew -c gcc -v ${{ matrix.compiler_version }})
+          sudo ./.github/scripts/shrink-brew.sh
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - name: Release build
+        run: ./scripts/build.sh --compiler gcc --version-postfix ${CC_PREFIX}${{ matrix.compiler_version }} --build-type Release
+      - name: Release warnings
+        run:  python3 ./scripts/count-warnings.py -m $MAX_WARNINGS_GCC_${{ matrix.compiler_version }}_Release build.log
+      - name: Debug build
+        run: ./scripts/build.sh --compiler gcc --version-postfix ${CC_PREFIX}${{ matrix.compiler_version }} --build-type Debug
+      - name: Debug warnings
+        run:  python3 ./scripts/count-warnings.py -m $MAX_WARNINGS_GCC_${{ matrix.compiler_version }}_Debug build.log
+
+  build_macos_gcc_macports:
+    name: GCC-${{ matrix.compiler_version }} (MacPorts)
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        compiler_version: [9]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Prepare tar-zstd and /opt/local for the cache
+        run:  |
+          brew install zstd gnu-tar
+          cp .github/scripts/tar /usr/local/bin/tar
+          sudo ./.github/scripts/prepare-for-macports-cachehit.sh
+      - uses: actions/cache@v1
+        id:   cache-macports
+        with: {path: /opt/local, key: macports-gcc-2019-v14}
+      - name: Install MacPorts, C++ compiler, and libraries
+        if:   steps.cache-macports.outputs.cache-hit != 'true'
+        run:  |
+          ./.github/scripts/download-and-build-macports.sh
+          sudo ./.github/scripts/install-and-update-macports.sh
+          sudo /opt/local/bin/port -q -f install $(./scripts/list-build-dependencies.sh -m macports -c gcc -v ${{ matrix.compiler_version }})
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - name: Release build
+        run:  ./scripts/build.sh --compiler gcc --version-postfix mp-${{ matrix.compiler_version }} --build-type Release --bin-path /opt/local/bin
+      - name: Release warnings
+        run:  python3 ./scripts/count-warnings.py $MAX_WARNINGS_GCC_${{ matrix.compiler_version }}_Release build.log
+      - name: Debug build
+        run:  ./scripts/build.sh --compiler gcc --version-postfix mp-${{ matrix.compiler_version }} --build-type Debug --bin-path /opt/local/bin
+      - name: Debug warnings
+        run:  python3 ./scripts/count-warnings.py $MAX_WARNINGS_GCC_${{ matrix.compiler_version }}_Debug build.log
+
+      - name: Shrink MacPorts for cache
+        if:   steps.cache-macports.outputs.cache-hit != 'true'
+        run:  sudo ./.github/scripts/shrink-macports.sh

--- a/.github/workflows/dormant/windows.yml
+++ b/.github/workflows/dormant/windows.yml
@@ -13,11 +13,8 @@ env:
 jobs:
 
   build_msvc_matrix:
-    name: MSVC 32-bit (${{ matrix.type }})
+    name: MSVC 32-bit
     runs-on: windows-latest
-    strategy:
-      matrix:
-        type: [Release, Debug]
     steps:
       - uses:  actions/checkout@v1
       - name:  Install packages
@@ -28,13 +25,20 @@ jobs:
       - name:  Log environment
         shell: pwsh
         run:   .\scripts\log-env.ps1
-      - name:  ${{ matrix.type }} build
+      - name:  Release build
         shell: pwsh
         env:
           PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
         run: |
           cd visualc_net
-          MSBuild -m dosbox.sln -p:Configuration=${{ matrix.type }}
+          MSBuild -m dosbox.sln -p:Configuration=Release
+      - name:  Debug build
+        shell: pwsh
+        env:
+          PATH: '${env:PATH};C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\amd64'
+        run: |
+          cd visualc_net
+          MSBuild -m dosbox.sln -p:Configuration=Debug
 
 
   build_msys2_matrix:
@@ -68,8 +72,13 @@ jobs:
       - name:  Log environment
         shell: python scripts\msys-bash.py {0}
         run:  ./scripts/log-env.sh
-      - name:  Debug Build
+      - name:  Release build
+        shell: python scripts\msys-bash.py {0}
+        run:   ./scripts/build.sh --compiler ${{ matrix.compiler }} --build-type Release --bin-path /mingw${{ matrix.bits }}/bin
+      - name:  Release warnings
+        run:   '.\scripts\count-warnings.py -m $env:MAX_WARNINGS_${{ matrix.compiler }}_${{ matrix.bits }}bit_Release build.log'
+      - name:  Debug build
         shell: python scripts\msys-bash.py {0}
         run:   ./scripts/build.sh --compiler ${{ matrix.compiler }} --build-type Debug --bin-path /mingw${{ matrix.bits }}/bin
-      - name:  Debug Warnings
+      - name:  Debug warnings
         run:   '.\scripts\count-warnings.py -m $env:MAX_WARNINGS_${{ matrix.compiler }}_${{ matrix.bits }}bit_Debug build.log'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,19 +1,20 @@
 name: Linux builds
 on: push
 env:
-  MAX_WARNINGS_GCC_5_Debug:     373
-  MAX_WARNINGS_GCC_5_Release:    -1
+  MAX_WARNINGS_GCC_5_Debug:     370
   MAX_WARNINGS_GCC_6_Debug:     378
-  MAX_WARNINGS_GCC_6_Release:   661
-  MAX_WARNINGS_GCC_7_Debug:     380
-  MAX_WARNINGS_GCC_7_Release:   329
+  MAX_WARNINGS_GCC_7_Debug:     377
   MAX_WARNINGS_GCC_8_Debug:     380
-  MAX_WARNINGS_GCC_8_Release:   330
-  MAX_WARNINGS_GCC_9_Debug:     403
-  MAX_WARNINGS_GCC_9_Release:   358
+  MAX_WARNINGS_GCC_9_Debug:     400
   MAX_WARNINGS_Clang_7_Debug:   193
+  MAX_WARNINGS_Clang_8_Debug:   191
+
+  MAX_WARNINGS_GCC_5_Release:    -1
+  MAX_WARNINGS_GCC_6_Release:   661
+  MAX_WARNINGS_GCC_7_Release:   329
+  MAX_WARNINGS_GCC_8_Release:   330
+  MAX_WARNINGS_GCC_9_Release:   358
   MAX_WARNINGS_Clang_7_Release: 193
-  MAX_WARNINGS_Clang_8_Debug:   193
   MAX_WARNINGS_Clang_8_Release: 193
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,51 +1,80 @@
 name: Linux builds
 on: push
+env:
+  MAX_WARNINGS_GCC_5_Debug:     373
+  MAX_WARNINGS_GCC_5_Release:    -1
+  MAX_WARNINGS_GCC_6_Debug:     378
+  MAX_WARNINGS_GCC_6_Release:   661
+  MAX_WARNINGS_GCC_7_Debug:     380
+  MAX_WARNINGS_GCC_7_Release:   329
+  MAX_WARNINGS_GCC_8_Debug:     380
+  MAX_WARNINGS_GCC_8_Release:   330
+  MAX_WARNINGS_GCC_9_Debug:     403
+  MAX_WARNINGS_GCC_9_Release:   358
+  MAX_WARNINGS_Clang_7_Debug:   193
+  MAX_WARNINGS_Clang_7_Release: 193
+  MAX_WARNINGS_Clang_8_Debug:   193
+  MAX_WARNINGS_Clang_8_Release: 193
+
 jobs:
 
-  build_ubuntu_clang_8:
-    name: Clang 8 (ubuntu-18.04)
-    runs-on: ubuntu-18.04
+  gcc-5_1604:
+    name: GCC-5 (Ubuntu 16.04)
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
+      - run:  sudo apt-get update
+      - name: Install C++ compiler and libraries
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c gcc)
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - run:  sudo apt-get update
-      - name: Install dependencies
-        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -p apt --compiler clang --compiler-version 8)
-      - name: Build
-        run:  ./scripts/build.sh --compiler clang --compiler-version 8 --lto
-      - name: Summarize warnings
-        run:  ./scripts/count-warnings.py build.log
+      - name: Debug build
+        run:  ./scripts/build.sh --compiler gcc --build-type Debug
+      - name: Debug warnings
+        run:  ./scripts/count-warnings.py -m $MAX_WARNINGS_GCC_5_Debug build.log
 
-  build_ubuntu_matrix_gcc:
-    name: GCC
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-16.04]
+  gcc-7_latest:
+    name: GCC-7 (Ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - run:  sudo apt-get update
+      - name: Install C++ compiler and libraries
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c gcc)
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - run:  sudo apt-get update
-      - name: Install dependencies
-        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -p apt)
-      - name: Build
-        run:  ./scripts/build.sh
-      - name: Summarize warnings
-        run:  ./scripts/count-warnings.py build.log
+      - name: Debug build
+        run:  ./scripts/build.sh --compiler gcc --build-type Debug
+      - name: Debug warnings
+        run:  ./scripts/count-warnings.py -m $MAX_WARNINGS_GCC_7_Debug build.log
 
-  build_ubuntu_gcc9:
-    name: GCC 9 (ubuntu-18.04)
-    runs-on: ubuntu-18.04
+  gcc-9_latest:
+    name: GCC-9 (Ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - run:  sudo apt-get update
+      - name: Install C++ compiler and libraries
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c gcc -v 9)
       - name: Log environment
         run:  ./scripts/log-env.sh
+      - name: Debug build
+        run:  ./scripts/build.sh --compiler gcc --version-postfix 9 --build-type Debug
+      - name: Debug warnings
+        run:  ./scripts/count-warnings.py -m $MAX_WARNINGS_GCC_9_Debug build.log
+
+  clang-8_latest:
+    name: Clang-8 (Ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
       - run:  sudo apt-get update
-      - name: Install dependencies
-        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -p apt --compiler-version 9)
-      - name: Build
-        run:  ./scripts/build.sh --compiler-version 9 --lto
-      - name: Summarize warnings
-        run:  ./scripts/count-warnings.py build.log
+      - name: Install C++ compiler and libraries
+        run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c clang -v 8)
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - name: Debug build
+        run:  ./scripts/build.sh --compiler clang --version-postfix 8 --build-type Debug
+      - name: Debug warnings
+        run:  ./scripts/count-warnings.py -m $MAX_WARNINGS_Clang_8_Debug build.log
+

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,10 +1,11 @@
 name: macOS builds
 on: push
 env:
-  MAX_WARNINGS_Clang_Debug:   245
-  MAX_WARNINGS_Clang_Release: 245
-  MAX_WARNINGS_GCC_9_Debug:   361
-  MAX_WARNINGS_GCC_9_Release: 321
+  MAX_WARNINGS_Clang_Debug:   243
+  MAX_WARNINGS_GCC_9_Debug:   358
+
+  MAX_WARNINGS_Clang_Release: 243
+  MAX_WARNINGS_GCC_9_Release: 316
 
 jobs:
   clang_xcode:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,60 +1,51 @@
 name: macOS builds
 on: push
-jobs:
+env:
+  MAX_WARNINGS_Clang_Debug:   245
+  MAX_WARNINGS_Clang_Release: 245
+  MAX_WARNINGS_GCC_9_Debug:   361
+  MAX_WARNINGS_GCC_9_Release: 321
 
-  build_macos_xcode_clang:
+jobs:
+  clang_xcode:
     name: Clang (Xcode)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Install C++ compiler and libraries
+        run:  brew install $(./scripts/list-build-dependencies.sh -m brew -c clang)
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - name: Install dependencies
-        run:  brew install $(./scripts/list-build-dependencies.sh -p brew --compiler clang)
-      - name: Build
-        run:  ./scripts/build.sh --compiler clang --lto
-      - name: Summarize warnings
-        run:  python3 ./scripts/count-warnings.py build.log
+      - name: Debug build
+        run:  ./scripts/build.sh --compiler clang --build-type Debug
+      - name: Debug warnings
+        run:  python3 ./scripts/count-warnings.py -m $MAX_WARNINGS_Clang_Debug build.log
 
-
-#  build_macos_brew_gcc9:
-#    name: GCC 9 (Homebrew)
-#    runs-on: macos-latest
-#    steps:
-#      - uses: actions/checkout@v1
-#      - name: Log environment
-#        run:  ./scripts/log-env.sh
-#      - name: Install dependencies
-#        run:  brew install $(./scripts/list-build-dependencies.sh -p brew --compiler-version 9)
-#      - name: Build
-#        run:  echo ./scripts/build.sh --compiler-version 9 --lto
-#      - name: Summarize warnings
-#        run:  echo python3 ./scripts/count-warnings.py build.log
-
-
-#  build_macos_macports_gcc9:
-#    name: GCC 9 (MacPorts)
-#    runs-on: macos-latest
-#    steps:
-#      - uses: actions/checkout@v1
-#      - name: Install MacPorts
-#        run: |
-#          # xcode-select --install || true
-#          # sudo xcodebuild -license || true
-#          git clone --quiet --depth=1 https://github.com/macports/macports-base.git
-#          cd macports-base
-#          ./configure
-#          make -j"$(sysctl -n hw.physicalcpu || echo 4)"
-#          sudo make install
-#
-#      - name: Install dependencies
-#        run: |
-#          PATH="/opt/local/sbin:/opt/local/bin:${PATH}"
-#          sudo port -q selfupdate || true
-#          sudo port -q install $(./scripts/list-build-dependencies.sh -p macports --compiler-version 9)
-#
-#      - name: Build
-#        run:  echo ./scripts/build.sh --compiler-version mp-9 --bin-path /opt/local/bin
-#      - name: Summarize warnings
-#        run:  echo python3 ./scripts/count-warnings.py build.log
+  gcc_brew:
+    name: GCC-${{ matrix.compiler_version }} (HomeBrew)
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        compiler_version: [9]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Prepare tar-zstd for the cache
+        run:  |
+          brew install zstd gnu-tar
+          cp .github/scripts/tar /usr/local/bin/tar
+      - uses: actions/cache@v1
+        id:   cache-brew
+        with: {path: /usr/local, key: brew-gcc-2019-v18}
+      - name: Install C++ compiler and libraries
+        if:   steps.cache-brew.outputs.cache-hit != 'true'
+        run:  |
+          ./.github/scripts/reset-brew.sh
+          brew install $(./scripts/list-build-dependencies.sh -m brew -c gcc -v ${{ matrix.compiler_version }})
+          sudo ./.github/scripts/shrink-brew.sh
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - name: Debug build
+        run: ./scripts/build.sh --compiler gcc --version-postfix ${CC_PREFIX}${{ matrix.compiler_version }} --build-type Debug
+      - name: Debug warnings
+        run:  python3 ./scripts/count-warnings.py -m $MAX_WARNINGS_GCC_${{ matrix.compiler_version }}_Debug build.log
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,13 +1,14 @@
 name: Windows builds
 on: push
 env:
-  MAX_WARNINGS_GCC_32bit_Debug:     320
-  MAX_WARNINGS_GCC_32bit_Release:   284
-  MAX_WARNINGS_GCC_64bit_Debug:     405
-  MAX_WARNINGS_GCC_64bit_Release:   369
+  MAX_WARNINGS_GCC_32bit_Debug:     307
+  MAX_WARNINGS_GCC_64bit_Debug:     420
   MAX_WARNINGS_Clang_32bit_Debug:   129
-  MAX_WARNINGS_Clang_32bit_Release: 129
   MAX_WARNINGS_Clang_64bit_Debug:   190
+
+  MAX_WARNINGS_GCC_32bit_Release:   284
+  MAX_WARNINGS_GCC_64bit_Release:   369
+  MAX_WARNINGS_Clang_32bit_Release: 129
   MAX_WARNINGS_Clang_64bit_Release: 190
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,16 @@ stamp-h1
 # Other
 compile
 build.log
+clean.log
+make.log
+.previous_build
+.current_build
 
 # Visual Studio
 .vs
+
+# Common editor temp/backup files
+*~
+*.swp
+*.tmp
+

--- a/.pylint
+++ b/.pylint
@@ -138,7 +138,8 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/scripts/automator/build/clang-darwin_x86_64
+++ b/scripts/automator/build/clang-darwin_x86_64
@@ -1,0 +1,8 @@
+ld="ld"
+
+TYPES+=("msan" "usan")
+cflags_msan=("${cflags_debug[@]}" "-fsanitize-recover=all" "-fsanitize=memory" "-fno-omit-frame-pointer")
+cflags_usan=("${cflags_debug[@]}" "-fsanitize-recover=all" "-fsanitize=undefined")
+
+MODIFIERS+=("lto")
+cflags_lto=("-flto=thin")

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -1,0 +1,16 @@
+# Tool overrides
+cc="clang${postfix}"
+cxx="clang++${postfix}"
+
+# Flag additions
+TYPES+=("debug" "profile")
+cflags+=("-fcolor-diagnostics")
+cflags_release=("${cflags[@]}" "-Os")
+cflags_debug=("${cflags[@]}" "-g" "-Og" "-fno-omit-frame-pointer")
+cflags_profile=("${cflags_debug[@]}" "-fprofile-instr-generate" "-fcoverage-mapping")
+
+
+# Modifier additions
+MODIFIERS=("fdo")
+ldflags_fdo=("-fprofile-instr-generate")
+cflags_fdo=("-fprofile-sample-use=${FDO_FILE:-}")

--- a/scripts/automator/build/clang-linux_x86_64
+++ b/scripts/automator/build/clang-linux_x86_64
@@ -1,0 +1,13 @@
+# Tool additions
+ar="llvm-ar${postfix}"
+ld="llvm-link${postfix}"
+ranlib="llvm-ranlib${postfix}"
+
+# Build additions
+TYPES+=("msan" "usan")
+cflags_msan=("${cflags_debug[@]}" "-fsanitize-recover=all" "-fsanitize=memory" "-fno-omit-frame-pointer")
+cflags_usan=("${cflags_debug[@]}" "-fsanitize-recover=all" "-fsanitize=undefined")
+
+# Modifier additions
+MODIFIERS+=("lto")
+cflags_lto=("-O2" "-flto=thin")

--- a/scripts/automator/build/clang-msys_nt_x86_64
+++ b/scripts/automator/build/clang-msys_nt_x86_64
@@ -1,0 +1,5 @@
+# Flag additions
+ar="llvm-ar${postfix}"
+ld="llvm-link${postfix}"
+ranlib="llvm-ranlib${postfix}"
+ldflags+=("-static-libgcc" "-static-libstdc++")

--- a/scripts/automator/build/compiler-defaults
+++ b/scripts/automator/build/compiler-defaults
@@ -1,0 +1,14 @@
+# Tools and flags for all compilers
+VARIABLES=("ar" "cc" "cxx" "ld" "ranlib" "cflags" "ldflags" "libs")
+ar=""
+cc=""
+cxx=""
+ld=""
+ranlib=""
+cflags=("-Wall" "-pipe")
+ldflags=("")
+libs=("")
+
+# Builds for all compilers
+TYPES=("release")
+cflags_release=("${cflags[@]}")

--- a/scripts/automator/build/gcc-darwin_x86_64
+++ b/scripts/automator/build/gcc-darwin_x86_64
@@ -1,0 +1,15 @@
+# Tool overrides
+ar="ar"
+ranlib="ranlib"
+
+# Build additions
+TYPES+=("asan" "uasan" "usan" "tsan")
+cflags_asan=("${cflags_debug[@]}" "-fsanitize=address")
+cflags_uasan=("${cflags_debug[@]}" "-fsanitize=address,undefined" "-fsanitize-recover=signed-integer-overflow")
+cflags_usan=("${cflags_debug[@]}" "-fsanitize=undefined" "-fsanitize-recover=signed-integer-overflow")
+cflags_tsan=("${cflags_debug[@]}" "-fsanitize=thread")
+
+# Modifier additions
+MODIFIERS+=("lto")
+cflags_lto=("-flto")
+ldflags_lto=("${cflags[@]}" "-flto")

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -1,0 +1,17 @@
+# Tool overrides
+ar="gcc-ar${postfix}"
+cc="gcc${postfix}"
+cxx="g++${postfix}"
+ld="gcc${postfix}"
+ranlib="gcc-ranlib${postfix}"
+
+# Flag additions
+TYPES+=("debug" "profile")
+cflags+=("-fstack-protector" "-fdiagnostics-color=always")
+cflags_release=("${cflags[@]}" "-Ofast" "-ffunction-sections" "-fdata-sections")
+cflags_debug=("${cflags[@]}" "-g" "-Og" "-fno-omit-frame-pointer")
+cflags_profile=("${cflags_debug[@]}" "-pg")
+
+# Modifier additions
+MODIFIERS=("fdo")
+cflags_fdo=("-fauto-profile=${FDO_FILE:-}")

--- a/scripts/automator/build/gcc-linux_x86_64
+++ b/scripts/automator/build/gcc-linux_x86_64
@@ -1,0 +1,14 @@
+# Tool additions
+ldflags+=("-Wl,--as-needed")
+
+# Build additions
+TYPES+=("asan" "uasan" "usan" "tsan")
+cflags_asan=("${cflags_debug[@]}" "-fsanitize=address")
+cflags_uasan=("${cflags_debug[@]}" "-fsanitize=address,undefined" "-fsanitize-recover=signed-integer-overflow")
+cflags_usan=("${cflags_debug[@]}" "-fsanitize=undefined" "-fsanitize-recover=signed-integer-overflow")
+cflags_tsan=("${cflags_debug[@]}" "-fsanitize=thread")
+
+# Modifier additions
+MODIFIERS+=("lto")
+cflags_lto=("-flto")
+ldflags_lto=("${cflags[@]}" "-flto=$(( $(nproc) + 2 ))")

--- a/scripts/automator/build/gcc-msys_nt_x86_64
+++ b/scripts/automator/build/gcc-msys_nt_x86_64
@@ -1,0 +1,3 @@
+# Flag additions
+ldflags+=("-Wl,--as-needed" "-static-libgcc" "-static-libstdc++")
+

--- a/scripts/automator/build/machine-x86_64
+++ b/scripts/automator/build/machine-x86_64
@@ -1,0 +1,3 @@
+# Modifier additions universal for gcc and clang, but specific to x86_64:
+MODIFIERS+=("native")
+cflags_native=("-march=native")

--- a/scripts/automator/build/os-darwin
+++ b/scripts/automator/build/os-darwin
@@ -1,0 +1,5 @@
+# Tool additions and overrides for Darwin, regardless of compiler
+ar="ar"
+ranlib="ranlib"
+function make_binary() { make -j$(sysctl -n hw.physicalcpu) 2>&1 | tee build.log; }
+dependencies=("otool" "-L" "${executable}")

--- a/scripts/automator/build/os-defaults
+++ b/scripts/automator/build/os-defaults
@@ -1,0 +1,57 @@
+# Steps in-common to all OSes, plus some helper variables and functions.
+
+STEPS=("pre_build" "clean" "autogen" "configure" "make_binary" "strip_binary" "dependencies" "post_build")
+
+executable="src/dosbox"
+dependencies=("ldd" "${executable}")
+
+function pre_build() {
+	cd ../..
+	underline "Environment"
+	echo "[$("${CC}" --version | head -1)]"
+	for v in "${VARIABLES[@]}"; do
+		vupper=$(upper "${v}")
+		echo "${vupper}=\"$(eval echo \$"${vupper}")\""
+	done
+	underline "Launching"
+}
+
+function stamp() {
+	echo "${compiler}-${selected_type}-${modifiers[*]}"
+}
+
+function autogen() {
+	if [[ ! -f configure || configure.ac -nt configure ]]; then
+		./autogen.sh
+	fi
+}
+
+function configure() {
+	if [[ ! -f Makefile || ! -f .previous_build || configure -nt Makefile ]]; then
+		export CXXFLAGS="${CFLAGS}"
+		./configure --enable-core-inline
+	fi
+}
+
+function strip_binary() {
+	if [[ "${selected_type}" == "release" ]]; then
+		strip "${executable}"
+	fi
+}
+
+function post_build() {
+	underline "Binary" "-"
+	ls -1lh "${executable}"
+	stamp > .previous_build
+}
+
+function clean() {
+	stamp > .current_build
+	if [[ -f Makefile ]]; then
+		if [[ ! -f .previous_build ]] || ! diff -q .previous_build .current_build &> /dev/null; then
+			rm -f .previous_build
+			echo "cleaning, this is a different build type"
+			make clean &> clean.log || cat clean.log
+		fi
+	fi
+}

--- a/scripts/automator/build/os-linux
+++ b/scripts/automator/build/os-linux
@@ -1,0 +1,2 @@
+function make_binary() { make -j$(nproc) 2>&1 | tee build.log; }
+

--- a/scripts/automator/build/os-msys_nt
+++ b/scripts/automator/build/os-msys_nt
@@ -1,0 +1,3 @@
+function make_binary() { make -j$(nproc) 2>&1 | tee build.log; }
+executable="src/dosbox.exe"
+

--- a/scripts/automator/main.sh
+++ b/scripts/automator/main.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Automator is a generic automation tool that helps separate data
+# from logical code.  It uses one or more "variables" files placed
+# in a single sub-directory, that are sourced in logical succession,
+# such as variables defined in earler files are either added-to or
+# overridden in subsequent files.
+#
+# For a thorough example, see scripts/build.sh and its data files
+# in scripts/automator/build.
+#
+# TODO: This script manages variables using eval meta-programming.
+#       Although the syntax is quite readable under bash 4.x,
+#       we have limitted our syntax to the uglier and heavier bash 3.x
+#       because Apple is still only shipping bash 3.x, even on their
+#       latest operating system (Nov-2019).
+#
+#       Future work might involve switching this to python and using YAML
+#       syntax in the variables files. Python's dictionaries can be
+#       merged or have their values overridden, and key names can be readily
+#       manipulated.
+#
+set -euo pipefail
+
+function underline() {
+	echo ""
+	echo "$1"
+	echo "${1//?/${2:--}}"
+}
+
+function lower() {
+	echo "${1}" | tr '[:upper:]' '[:lower:]'
+}
+
+function upper() {
+	echo "${1}" | tr '[:lower:]' '[:upper:]'
+}
+
+function arg_error() {
+	local PURPLE='\033[0;34m'
+	local BLACK='\033[0;30m'
+	local ON_WHITE='\033[47m'
+	local NO_COLOR='\033[0m'
+	>&2 echo -e "Please specify the ${BLACK}${ON_WHITE}${1}${NO_COLOR} argument with one of: ${PURPLE}${2}${NO_COLOR}"
+	exit 1
+}
+
+function import() { # arguments: category instance
+	category=$(lower "${1}")
+	instance=$(lower "${2}")
+	if [[ -z "$instance" ]]; then
+		instances=( "$(find "${data_dir}" -name "${category}-*" -a ! -name '*defaults' | sed 's/.*-//' | xargs)" )
+		arg_error "--${category}" "${instances[*]}"
+	else for instance in defaults "${instance}"; do
+		varfile="${data_dir}/${category}-${instance}"
+		# shellcheck disable=SC1090,SC1091
+		if [[ -f "$varfile" ]]; then source "$varfile"
+		else >&2 echo "${varfile} does not exist, skipping"; fi; done
+	fi
+}
+
+function construct_environment() {
+	# underline "Environment"
+	for base_var in "${VARIABLES[@]}"; do
+		# First check if we have a build-specific variable
+		# shellcheck disable=SC2154
+		if [[ -n "$(eval 'echo ${'"${base_var}_${selected_type}"'[*]:-}')" ]]; then
+			var_name="${base_var}_${selected_type}"
+		# Otherwise fallback to the default variable
+		else var_name="${base_var}"; fi
+
+		# Aggregate any modifiers, which are stand-alone arguments
+		mod_values=""
+		# shellcheck disable=SC2154
+		for mod_upper in "${modifiers[@]}"; do
+			mod=$(lower "${mod_upper}")
+			# Mods can only add options to existing VARs, so we check for those
+			if [[ -n "$(eval 'echo ${'"${base_var}_${mod}"'[*]:-}')" ]]; then
+				var_with_mod="${base_var}_${mod}"
+				# shellcheck disable=SC2034
+				mod_values=$(eval 'echo ${mod_values} ${'"${var_with_mod}"'[*]}')
+			fi
+		done
+
+		# Expand our variable array (or scalar) and combine it with our aggregated
+		# modification string. Echo takes care of spacing out our variables without
+		# explicit padding, because it either drops empty variables or adds spaces
+		# between them if they exist.
+		# shellcheck disable=SC2034
+		combined=$(eval 'echo ${'"${var_name}"'[*]} ${mod_values}')
+		env_var=$(upper "${base_var}")
+		eval 'export '"${env_var}"'="${combined}"'
+		# echo "${env_var}=\"$(eval echo \$"${env_var}")\""
+	done
+}
+
+function perform_steps() {
+	# underline "Launching"
+	for step in "${STEPS[@]}"; do
+		if type -t "$step" | grep -q function; then "$step"
+		else
+			# eval 'echo ${'"${step}"'[*]}'
+			eval '${'"${step}"'[*]}'
+		fi
+	done
+}
+
+function main() {
+	cd "$(dirname "$0")/automator"
+	if [[ -z "${data_dir:-}" ]]; then data_dir="$(basename "$0" '.sh')"; fi
+	parse_args "$@"
+	construct_environment
+	perform_steps
+}
+
+main "$@"
+

--- a/scripts/automator/packages/clang-brew
+++ b/scripts/automator/packages/clang-brew
@@ -1,0 +1,3 @@
+# Brew does not supply "clang", so exclude it here
+compiler=""
+

--- a/scripts/automator/packages/clang-defaults
+++ b/scripts/automator/packages/clang-defaults
@@ -1,0 +1,2 @@
+compiler=(clang${postfix})
+

--- a/scripts/automator/packages/clang-macports
+++ b/scripts/automator/packages/clang-macports
@@ -1,0 +1,2 @@
+# macports doesn't supply Clang, so knock it out here
+compiler=""

--- a/scripts/automator/packages/clang-msys2
+++ b/scripts/automator/packages/clang-msys2
@@ -1,0 +1,4 @@
+# Under MSYS2, only the 'default' version is available, so we don't postfix the package
+compiler="mingw-w64-${pkg_type}-${selected_type}"
+
+

--- a/scripts/automator/packages/clang-vcpkg
+++ b/scripts/automator/packages/clang-vcpkg
@@ -1,0 +1,4 @@
+# vcpkg doesn't provide clang or gcc, because it assumes you're using MS VisualStudio.
+# So we knock out the compiler.
+compiler=""
+

--- a/scripts/automator/packages/gcc-apt
+++ b/scripts/automator/packages/gcc-apt
@@ -1,0 +1,2 @@
+compiler=(g++${postfix})
+

--- a/scripts/automator/packages/gcc-defaults
+++ b/scripts/automator/packages/gcc-defaults
@@ -1,0 +1,1 @@
+compiler=(gcc${postfix})

--- a/scripts/automator/packages/gcc-msys2
+++ b/scripts/automator/packages/gcc-msys2
@@ -1,0 +1,3 @@
+# Under MSYS2 only the 'default' version of gcc is available, so we don't postfix it with the version
+compiler="mingw-w64-${pkg_type}-${selected_type}"
+

--- a/scripts/automator/packages/gcc-vcpkg
+++ b/scripts/automator/packages/gcc-vcpkg
@@ -1,0 +1,4 @@
+# vcpkg doesn't provide clang or gcc, because it assumes you're using MS VisualStudio.
+# So we knock out the compiler.               
+compiler=""
+

--- a/scripts/automator/packages/manager-apt
+++ b/scripts/automator/packages/manager-apt
@@ -1,0 +1,2 @@
+# Package repo: https://packages.ubuntu.com/
+packages+=(xvfb libtool build-essential libsdl1.2-dev libsdl-net1.2-dev libopusfile-dev)

--- a/scripts/automator/packages/manager-brew
+++ b/scripts/automator/packages/manager-brew
@@ -1,0 +1,3 @@
+# Package repo: https://formulae.brew.sh/
+delim="@"
+packages+=(coreutils autogen autoconf automake pkg-config libpng sdl sdl_net opusfile)

--- a/scripts/automator/packages/manager-defaults
+++ b/scripts/automator/packages/manager-defaults
@@ -1,0 +1,11 @@
+VARIABLES=(packages bits delim compiler)
+TYPES=(gcc clang)
+
+packages=(autoconf-archive zstd)
+delim="-"
+compiler=""
+
+STEPS=(print)
+function print() {
+	echo "${PACKAGES[*]}" "${COMPILER}"
+}

--- a/scripts/automator/packages/manager-dnf
+++ b/scripts/automator/packages/manager-dnf
@@ -1,0 +1,2 @@
+# Package repo: https://apps.fedoraproject.org/packages/
+packages+=(xvfb libtool SDL SDL_net-devel opusfile-devel)

--- a/scripts/automator/packages/manager-macports
+++ b/scripts/automator/packages/manager-macports
@@ -1,0 +1,3 @@
+# Package repo: https://www.macports.org/ports.php?by=name
+delim=""
+packages+=(coreutils autogen autoconf automake pkgconfig libpng libsdl libsdl_net opusfile)

--- a/scripts/automator/packages/manager-msys2
+++ b/scripts/automator/packages/manager-msys2
@@ -1,0 +1,7 @@
+# Package repo: https://packages.msys2.org/base
+# MSYS2 only supports the current latest releases of Clang and GCC, so we disable version customization
+packages+=(autogen autoconf base-devel automake-wrapper binutils)
+pkg_type=$([[ "${bits}" == "64" ]] && echo "x86_64" || echo "i686")
+for pkg in pkg-config libtool libpng zlib SDL SDL_net opusfile; do
+	packages+=("mingw-w64-${pkg_type}-${pkg}")
+done

--- a/scripts/automator/packages/manager-pacman
+++ b/scripts/automator/packages/manager-pacman
@@ -1,0 +1,4 @@
+# Package repo: https://www.archlinux.org/packages/
+# Arch offers 32-bit versions of SDL (but not others)
+packages+=(xvfb libtool sdl_net opusfile)
+[[ "${bits}" == "32" ]] && packages+=(lib32-sdl) || packages+=(sdl)

--- a/scripts/automator/packages/manager-vcpkg
+++ b/scripts/automator/packages/manager-vcpkg
@@ -1,0 +1,2 @@
+# Package repo: https://repology.org/projects/?inrepo=vcpkg
+packages+=(libpng sdl1 sdl1-net opusfile)

--- a/scripts/automator/packages/manager-zypper
+++ b/scripts/automator/packages/manager-zypper
@@ -1,0 +1,10 @@
+# Package repo: https://pkgs.org/
+# openSUSE offers 32-bit versions of SDL and SDL_net (but not others)
+packages+=(devel_basis xvfb libtool opusfile)
+
+if [[ "${bits}" == "32" ]]; then
+	packages+=(libSDL-devel-32bit libSDL_net-devel-32bit)
+else
+	packages+=(SDL SDL_net)
+fi
+

--- a/scripts/build.md
+++ b/scripts/build.md
@@ -57,7 +57,7 @@ Use of both scripts is described below.
    `./scripts/list-build-dependencies.sh -p msys2 | xargs pacman -S --noconfirm`
 
 1. Launch the build script with default settings:  
-   `./scripts/build.sh --bin-path /mingw64/bin`
+   `./scripts/build/run.sh --bin-path /mingw64/bin`
 
 
 ## MacOS Installation and Usage
@@ -131,10 +131,15 @@ options to the **list-build-dependencies.sh** and **build.sh** scripts:
 After building, your `dosbox` or `dosbox.exe` binary will reside inside `./dosbox-staging/src/`.
 
 Build flags you might be interested in:
-* `--release debug`, to build a binary containing debug symbols (instead of **fast** or **small**)
 * `--lto`, perform optimizations across the entire object space instead of per-file (Only available on Mac and Linux)
-
-The above flags are othogonal and thus can be mixed-and-matched as desired.
+* `--release debug`, to build a binary containing debug symbols
+    * You can run the resulting binary in the GNU debugger: `gdb /path/to/dosbox`, followed by `start mygame.bat`
+* `--release profile`, to generate performance statistics
+    * Instructions are provided after the build completes, which describe how to generate and process the profiling data
+* `--release <sanitizer-type>`, to build a binary that performs dynamic code-analysis at runtime (Linux and macOS)
+    * see `./scripts/build.sh --help` for a list of sanitizer-types that are available
+    * Run your binary like normal and it will generate output describing problematic behavior
+    * Some sanitizers accept runtime options via an environment variables, such as `ASAN_OPTIONS`, described here: https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
 
 If you want to run multiple back-to-back builds from the same directory with different settings then
 add the `--clean` flag to ensure previous objects and binaries are removed.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,518 +1,61 @@
 #!/bin/bash
 
-##
-#
-#  Copyright (c) 2019 Kevin R. Croft
-#  SPDX-License-Identifier: GPL-2.0-or-later
-#
-#  This script builds DOSBox within supported environments including
-#  MacOS, Ubuntu Linux, and MSYS2 using specified compilers and release types.
-#
-#  For automation without prompts, Windows should have User Account Control (UAC)
-#  disabled, which matches the configuration of GitHub'Windows VMs, described here:
-#  https://help.github.com/en/articles/virtual-environments-for-github-actions
-#
-#  See the usage block below for details or run it with the -h or --help arguments.
-#
-#  In general, this script adheres to Google's shell scripting style guide
-#  (https://google.github.io/styleguide/shell.xml), however some deviations (such as
-#  tab indents instead of two-spaces) are used to fit with DOSBox's in-practice"
-#  coding style.
-#
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
 
+# This script builds the software for the given build-type (release,
+# debug, ... ) and compiler (gcc or clang).
+#
+# If run without arguments, the script asks for required arguments one
+# by one, which includes the above two (--compiler and --build-type).
+#
+# Optional arguments include the version of compiler and additional
+# build modifiers such as link-time-optimizations (--modifier lto),
+# feedback-directed-optimizations (--modifier fdo), and taking advantage
+# of the building-machine's full instructions sets (--modifier native).
+# All modifiers are available simulatenously.
+#
+# Usage examples:
+#   $ ./build.sh                             # asks for a compiler
+#   $ ./build.sh --compiler gcc              # asks for a build-type
+#   $ ./build.sh --compiler clang --build-type debug       # builds!
+#   $ ./build.sh -c gcc -t release -m lto -m native        # builds!
+#
+# This script makes use of the automator package, see automator/main.sh.
+#
 set -euo pipefail
-readonly INVOCATION="${0}"
-readonly IFS=$'\n\t'
-
-function usage() {
-	if [ -n "${1}" ]; then
-		errcho "${1}"
-	fi
-	local script
-	script=$(basename "${INVOCATION}")
-	echo "Usage: ${script} [-b 32|64] [-c gcc|clang] [-f linux|macos|msys2] [-d] [-l]"
-	echo "                 [-p /custom/bin] [-u #] [-r fast|small|debug] [-s /your/src] [-t #]"
-	echo ""
-	echo "  FLAG                     Description                                           Default"
-	echo "  -----------------------  ----------------------------------------------------- -------"
-	echo "  -b, --bit-depth         Build a 64 or 32 bit binary                            [$(print_var "${BITS}")]"
-	echo "  -c, --compiler          Choose either gcc or clang                             [$(print_var "${COMPILER}")]"
-	echo "  -f, --force-system      Force the system to be linux, macos, or msys2          [$(print_var "${SYSTEM}")]"
-	echo "  -d, --fdo               Use Feedback-Directed Optimization (FDO) data          [$(print_var "${FDO}")]"
-	echo "  -l, --lto               Perform Link-Time-Optimizations (LTO)                  [$(print_var "${LTO}")]"
-	echo "  -p, --bin-path          Prepend PATH with the one provided to find executables [$(print_var "${BIN_PATH}")]"
-	echo "  -u, --compiler-version  Customize the compiler postfix (ie: 9 -> gcc-9)        [$(print_var "${COMPILER_VERSION}")]"
-	echo "  -r, --release           Build a fast, small, or debug release                  [$(print_var "${RELEASE}")]"
-	echo "  -s, --src-path          Enter a different source directory before building     [$(print_var "${SRC_PATH}")]"
-	echo "  -t, --threads           Override the number of threads with which to compile   [$(print_var "${THREADS}")]"
-	echo "  -v, --version           Print the version of this script                       [$(print_var "${SCRIPT_VERSION}")]"
-	echo "  -x, --clean             Clean old objects prior to building                    [$(print_var "${CLEAN}")]"
-	echo "  -h, --help              Print this usage text"
-	echo ""
-	echo "Example: ${script} -b 32 --compiler clang -u 8 --bin-path /mingw64/bin -r small --lto"
-	echo ""
-	echo "Note: the last value will take precendent if duplicate flags are provided."
-	exit 1
-}
 
 function parse_args() {
-	set_defaults
+	# Gather the parameters that define this build
+	postfix=""
+	modifiers=("")
 	while [[ "${#}" -gt 0 ]]; do case ${1} in
-		-b|--bit-depth)         BITS="${2}";            shift;shift;;
-		-c|--compiler)          COMPILER="${2}";        shift;shift;;
-		-d|--fdo)               FDO="true";             shift;;
-		-f|--force-system)      SYSTEM="${2}";          shift;shift;;
-		-l|--lto)               LTO="true";             shift;;
-		-p|--bin-path)          BIN_PATH="${2}";        shift;shift;;
-		-u|--compiler-version)  COMPILER_VERSION="${2}";shift;shift;;
-		-r|--release)           RELEASE="${2}";         shift;shift;;
-		-s|--src-path)          SRC_PATH="${2}";        shift;shift;;
-		-t|--threads)           THREADS="${2}";         shift;shift;;
-		-v|--version)           print_version;          shift;;
-		-x|--clean)             CLEAN="true";           shift;;
-		-h|--help)              usage "Show usage";     shift;;
-		*) usage "Unknown parameter: ${1}";             shift;shift;;
+		-c|--compiler)          compiler="${2}";        shift 2;;
+		-v|--version-postfix)   postfix="-${2}";        shift 2;;
+		-t|--build-type)        selected_type="${2}";   shift 2;;
+		-m|--modifier)          modifiers+=("${2}");    shift 2;;
+		-p|--bin-path)          PATH="${2}:${PATH}";    shift 2;;
+		*) >&2 echo "Unknown parameter: ${1}"; exit 1;  shift 2;;
 	esac; done
+
+	# Import our settings and report missing values
+	machine="$(uname -m | sed 's/-.*//')"; import machine "${machine}"
+	os="$(uname -s | sed 's/-.*//')"; import os "${os}"
+	import compiler "${compiler:-}"
+	import "${compiler:-}" "${os}_${machine}"
+	if [[ -z "${selected_type:-}" ]]; then arg_error "--build-type" "${TYPES[*]}"; fi
+
+	# Create a pretty modifier string that we can add to our build-type
+	printf -v mod_string '+%s' "${modifiers[@]:1}"
+	if [[ "${mod_string}" == "+" ]]; then mod_string=""; fi
+
+	# Print a summary of our build configuration
+	underline "Compiling a ${selected_type}${mod_string} build using "`
+	          `"${compiler}${postfix} on ${os}-${machine}" "="
+
+	# Ensure our selected_type is lower-case before proceeding
+	selected_type=$(lower "${selected_type}")
 }
 
-function set_defaults() {
-	# variables that are directly set via user arguments
-	BITS="64"
-	CLEAN="false"
-	COMPILER="gcc"
-	COMPILER_VERSION="unset"
-	FDO="false"
-	LTO="false"
-	BIN_PATH="unset"
-	RELEASE="fast"
-	SRC_PATH="unset"
-	SYSTEM="auto"
-	THREADS="auto"
-
-	# derived variables with initial values
-	EXECUTABLE="unset"
-	VERSION_POSTFIX=""
-	MACHINE="unset"
-	CONFIGURE_OPTIONS=("--enable-core-inline")
-	CFLAGS_ARRAY=("-Wall" "-pipe")
-	LDFLAGS_ARRAY=("")
-	LIBS_ARRAY=("")
-	CALL_CACHE=("")
-
-	# read-only strings
-	readonly SCRIPT_VERSION="1.0"
-	readonly REPO_URL="https://github.com/dreamer/dosbox-staging"
-
-	# environment variables passed onto the build
-	export CC="CC_is_not_set"
-	export CXX="CXX_is_not_set"
-	export LD="LD_is_not_set"
-	export AR="AR_is_not_set"
-	export RANLIB="RANLIB_is_not_set"
-	export CFLAGS=""
-	export CXXFLAGS=""
-	export LDFLAGS=""
-	export LIBS=""
-	export GCC_COLORS="error=01;31:warning=01;35:note=01;36:range1=32:range2=34:locus=01:\
-quote=01:fixit-insert=32:fixit-delete=31:diff-filename=01:\
-diff-hunk=32:diff-delete=31:diff-insert=32:type-diff=01;32"
-}
-
-function errcho() {
-	local CLEAR='\033[0m'
-	local RED='\033[0;91m'
-	>&2 echo ""
-	>&2 echo -e " ${RED}👉  ${*}${CLEAR}" "\\n"
-}
-function bug() {
-	local CLEAR='\033[0m'
-	local YELLOW='\033[0;33m'
-	>&2 echo -e " ${YELLOW}Please report the following at ${REPO_URL}${CLEAR}"
-	errcho "${@}"
-	exit 1
-}
-
-function error() {
-	errcho "${@}"
-	exit 1
-}
-
-function exists() {
-	command -v "${1}" &> /dev/null
-}
-
-function print_var() {
-	if [[ -z "${1}" ]]; then
-		echo "unset"
-	else
-		echo "${1}"
-	fi
-}
-
-##
-#  Uses
-#  ----
-#  Alows function to indicate which other functions they depend on.
-#  For example: "uses system" indicates a function needs the system
-#  to be defined prior to running.
-#  This uses function acts like a call cache, ensuring each used function
-#  is only actually called once.  This allows all functions to thoroughly
-#  employ the 'uses' mechanism without the performance-hit of repeatedly
-#  executing the same function.  Likely, functions that are 'used' are
-#  atomic in that they will only be called once per script invocation.
-#
-function uses() {
-	# assert
-	if [[ "${#}" != 1 ]]; then
-		bug "The 'uses' function was called without an argument"
-	fi
-
-	# only operate on functions in our call-scope, otherwise fail hard
-	func="${1}"
-	if [[ "$(type -t "${func}")" != "function" ]]; then
-		bug "The 'uses' function was passed ${func}, which isn't a function"
-	fi
-
-	# Check the call cache to see if the function has already been called
-	local found_in_previous="false"
-	for previous_func in "${CALL_CACHE[@]}"; do
-		if [[ "${previous_func}" == "${func}" ]]; then
-			found_in_previous="true"
-			break
-		fi
-	done
-
-	# if it hasn't been called then record it and run it
-	if [[ "${found_in_previous}" == "false" ]]; then
-		CALL_CACHE+=("${func}")
-		"${func}"
-	fi
-}
-
-
-function print_version() {
-	echo "${SCRIPT_VERSION}"
-	exit 0
-}
-
-function system() {
-	if   [[ "${MACHINE}" == "unset" ]]; then MACHINE="$(uname -m)"; fi
-	if   [[ "${SYSTEM}" == "auto" ]]; then SYSTEM="$(uname -s)"; fi
-	case "$SYSTEM" in
-		Darwin|macos) SYSTEM="macos" ;;
-		MSYS*|msys2)  SYSTEM="msys2" ;;
-		Linux|linux)  SYSTEM="linux" ;;
-		*)            error "Your system, $SYSTEM, is not currently supported" ;;
-	esac
-}
-
-function bits() {
-	if [[ "${BITS}" != 64 && "${BITS}" != 32 ]]; then
-		usage "A bit-depth of ${BITS} is not allowed; choose 64 or 32"
-	fi
-}
-
-function compiler_type() {
-	if [[ "${COMPILER}" != "gcc" && "${COMPILER}" != "clang" ]]; then
-		usage "The choice of compiler (${COMPILER}) is not valid; choose gcc or clang"
-	fi
-}
-
-function tools_and_flags() {
-	uses compiler_type
-	uses compiler_version
-	uses system
-
-	# GCC universal
-	if [[ "${COMPILER}" == "gcc" ]]; then
-		CC="gcc${VERSION_POSTFIX}"
-		LD="gcc${VERSION_POSTFIX}"
-		CXX="g++${VERSION_POSTFIX}"
-		CFLAGS_ARRAY+=("-fstack-protector" "-fdiagnostics-color=always")
-
-		# Prioritize versioned lib-tools over generics
-		AR="gcc-ar${VERSION_POSTFIX}"
-		RANLIB="gcc-ranlib${VERSION_POSTFIX}"
-		if ! exists "${AR}"; then AR="ar"; fi
-		if ! exists "${RANLIB}"; then RANLIB="ranlib"; fi
-
-	# CLANG universal
-	elif [[ "${COMPILER}" == "clang" ]]; then
-		CC="clang${VERSION_POSTFIX}"
-		CXX="clang++${VERSION_POSTFIX}"
-		CFLAGS_ARRAY+=("-fcolor-diagnostics")
-
-		# CLANG on Linux and MSYS2
-		if [[ "${SYSTEM}" == "linux" || "${SYSTEM}" == "msys2" ]]; then
-			LD="llvm-link${VERSION_POSTFIX}"
-			AR="llvm-ar${VERSION_POSTFIX}"
-			RANLIB="llvm-ranlib${VERSION_POSTFIX}"
-
-		# CLANG on MacOS
-		elif [[ "${SYSTEM}" == "macos" ]]; then LD="ld"; fi
-	fi
-
-	# macOS universal
-	if [[ "${SYSTEM}" == "macos" ]]; then
-		AR="ar"
-		RANLIB="ranlib"
-	fi
-}
-
-function src_path() {
-	if [[ "${SRC_PATH}" == "unset" ]]; then
-		SRC_PATH="$(cd "$(dirname "${INVOCATION}")" && cd .. && pwd -P)"
-	elif [[ ! -d "${SRC_PATH}" ]]; then
-		usage "The requested source directory (${SRC_PATH}) does not exist, is not a directory, or is not accessible"
-	fi
-	cd "${SRC_PATH}"
-}
-
-function bin_path() {
-	uses system
-	uses compiler_type
-
-	# By default, if we're on macOS and using GCC then always include /usr/local/bin, because
-	# that's where brew installs all the binaries.  If the user adds their own --bin-path,
-	# that will be prefixed ahead of /usr/local/bin and take precedent.
-	if [[ "${SYSTEM}" == "macos" && "${COMPILER}" == "gcc" ]]; then
-		PATH="/usr/local/bin:${PATH}"
-	fi
-
-	if [[ "${BIN_PATH}" != "unset" ]]; then
-		if [[ ! -d "${BIN_PATH}" ]]; then
-			usage "The requested PATH (${BIN_PATH}) does not exist, is not a directory, or is not accessible"
-		else
-			PATH="${BIN_PATH}:${PATH}"
-		fi
-	fi
-}
-
-function check_build_tools() {
-	for tool in "${CC}" "${CXX}" "${LD}" "${AR}" "${RANLIB}"; do
-		if ! exists "${tool}"; then
-			error "${tool} was not found in your PATH or is not executable. If it's in a custom path, use --bin-path"
-		fi
-	done
-}
-
-function compiler_version() {
-	if [[ "${COMPILER_VERSION}" != "unset" ]]; then
-		VERSION_POSTFIX="-${COMPILER_VERSION}"
-	fi
-}
-
-function release_flags() {
-	uses compiler_type
-
-	if [[ "${RELEASE}" == "fast" ]]; then CFLAGS_ARRAY+=("-Ofast")
-	elif [[ "${RELEASE}" == "small" ]]; then
-		CFLAGS_ARRAY+=("-Os")
-		if [[ "${COMPILER}" == "gcc" ]]; then
-			CFLAGS_ARRAY+=("-ffunction-sections" "-fdata-sections")
-
-			# ld on MacOS doesn't understand --as-needed, so exclude it
-			uses system
-			if [[ "${SYSTEM}" != "macos" ]]; then LDFLAGS_ARRAY+=("-Wl,--as-needed"); fi
-		fi
-	elif [[ "${RELEASE}" == "debug" ]]; then CFLAGS_ARRAY+=("-g" "-O1")
-	else usage "The release type of ${RELEASE} is not allowed. Choose fast, small, or debug"
-	fi
-}
-
-function threads() {
-	if [[ "${THREADS}" == "auto" ]]; then
-		if exists nproc; then THREADS="$(nproc)"
-		else THREADS="$(sysctl -n hw.physicalcpu || echo 4)"; fi
-	fi
-	# make presents a descriptive error message in the scenario where the user overrides
-	# THREADS with an illegal value: the '-j' option requires a positive integer argument.
-}
-
-function fdo_flags() {
-	if [[ "${FDO}" != "true" ]]; then
-		return
-	fi
-
-	uses compiler_type
-	uses src_path
-	local fdo_file="${SRC_PATH}/scripts/profile-data/${COMPILER}.profile"
-	if [[ ! -f "${fdo_file}" ]]; then
-		error "The Feedback-Directed Optimization file provided (${fdo_file}) does not exist or could not be accessed"
-	fi
-
-	if [[ "${COMPILER}" == "gcc" ]]; then
-		# Don't let GCC 6.x and under use both FDO and LTO
-		uses compiler_version
-		if [[ ( "${COMPILER_VERSION}" == "unset"
-		        && "$(2>&1 gcc -v | grep -Po '(?<=version )[^.]+')" -lt "7"
-		        || "${COMPILER_VERSION}" -lt "7" )
-		      && "${LTO}" == "true" ]]; then
-			error "GCC versions 6 and under cannot handle FDO and LTO simultaneously; please change one or more these."
-		fi
-		CFLAGS_ARRAY+=("-fauto-profile=${fdo_file}")
-
-	elif [[ "${COMPILER}" == "clang" ]]; then
-		CFLAGS_ARRAY+=("-fprofile-sample-use=${fdo_file}")
-	fi
-}
-
-function lto_flags() {
-	if [[ "${LTO}" != "true" ]]; then
-		return
-	fi
-
-	uses system
-	# Only allow LTO on Linux and MacOS; it currently fails under Windows
-	if [[ "${SYSTEM}" == "msys2" ]]; then
-		usage "LTO currently does not link or build on Windows with GCC or Clang"
-	fi
-
-	uses compiler_type
-	if [[ "${COMPILER}" == "gcc" ]]; then
-		CFLAGS_ARRAY+=("-flto")
-
-		# The linker performs the code optimizations across all objects, and therefore
-		# needs the same flags as the compiler would normally get
-		LDFLAGS_ARRAY+=("${CFLAGS_ARRAY[@]}")
-
-		# GCC on MacOS fails to parse the thread flag, so we only provide it under Linux
-		# (error: unsupported argument 4 to option flto=)
-		if [[ "${SYSTEM}" == "linux" ]]; then
-			uses threads
-			LDFLAGS_ARRAY+=("-flto=$THREADS")
-		fi
-
-	elif [[ "${COMPILER}" == "clang" ]]; then
-		CFLAGS_ARRAY+=("-flto=thin")
-
-		# Clang LTO on Linux is incompatible with -Os so replace them with -O2
-		# (ld: error: Optimization level must be between 0 and 3)
-		if [[ "${SYSTEM}" == "linux" ]]; then
-			CFLAGS_ARRAY=("${CFLAGS_ARRAY[@]/-Os/-O2}")
-		fi # clang-linux-lto-small exclusion
-	fi # gcc & clang
-}
-
-function configure_options() {
-	uses system
-	if [[ "${MACHINE}" != *"86"* ]]; then
-		CONFIGURE_OPTIONS+=("--disable-dynamic-x86" "--disable-fpu-x86" "--disable-fpu-x64")
-	fi
-}
-
-function do_autogen() {
-	uses src_path
-	if [[ ! -f autogen.sh ]]; then
-		error "autogen.sh doesn't exist in our current directory $PWD. If your DOSBox source is somewhere else set it with --src-path"
-	fi
-
-	# Only autogen if needed ..
-	if [[ ! -f configure ]]; then
-		uses bin_path
-		./autogen.sh
-	fi
-}
-
-function do_configure() {
-	uses bin_path
-	uses src_path
-	uses tools_and_flags
-	uses release_flags
-	uses fdo_flags
-	uses lto_flags
-	uses check_build_tools
-	uses configure_options
-
-	# Convert our arrays into space-delimited strings
-	LIBS=$(    printf "%s " "${LIBS_ARRAY[@]}")
-	CFLAGS=$(  printf "%s " "${CFLAGS_ARRAY[@]}")
-	CXXFLAGS=$(printf "%s " "${CFLAGS_ARRAY[@]}")
-	LDFLAGS=$( printf "%s " "${LDFLAGS_ARRAY[@]}")
-
-	local lto_string=""
-	local fdo_string=""
-	if [[ "${LTO}" == "true" ]]; then lto_string="-LTO"; fi
-	if [[ "${FDO}" == "true" ]]; then fdo_string="-FDO"; fi
-
-	echo ""
-	echo "Launching with:"
-	echo ""
-	echo "    CC       = ${CC}"
-	echo "    CXX      = ${CXX}"
-	echo "    LD       = ${LD}"
-	echo "    AR       = ${AR}"
-	echo "    RANLIB   = ${RANLIB}"
-	echo "    CFLAGS   = ${CFLAGS}"
-	echo "    CXXFLAGS = ${CXXFLAGS}"
-	echo "    LIBS     = ${LIBS}"
-	echo "    LDFLAGS  = ${LDFLAGS}"
-	echo "    THREADS  = ${THREADS}"
-	echo ""
-	echo "Build type: ${SYSTEM}-${MACHINE}-${BITS}bit-${COMPILER}-${RELEASE}${lto_string}${fdo_string}"
-	echo ""
-	"${CC}" --version
-	sleep 5
-
-	if [[ ! -f configure ]]; then
-		error "configure script doesn't exist in $PWD. If the source is somewhere else, set it with --src-path"
-
-	elif ! ./configure "${CONFIGURE_OPTIONS[@]}"; then
-		>&2 cat "config.log"
-		error "configure failed, see config.log output above"
-	fi
-}
-
-function executable() {
-	uses src_path
-	EXECUTABLE="src/"
-	if [[ "${SYSTEM}" == "msys2" ]]; then EXECUTABLE+="dosbox.exe"
-	else EXECUTABLE+="dosbox"
-	fi
-
-	if [[ ! -f "${EXECUTABLE}" ]]; then
-		error "${EXECUTABLE} does not exist or hasn't been created yet"
-	fi
-}
-
-function build() {
-	uses src_path
-	uses bin_path
-	uses threads
-
-	if [[ "${CLEAN}" == "true" && -f "Makefile" ]]; then
-		make clean 2>&1 | tee -a build.log
-	fi
-	do_autogen
-	do_configure
-	make -j "${THREADS}" 2>&1 | tee -a build.log
-}
-
-function strip_binary() {
-	if [[ "${RELEASE}" == "debug" ]]; then
-		echo "[skipping strip] Debug symbols will be left in the binary because it's a debug release"
-	else
-		uses bin_path
-		uses executable
-		strip "${EXECUTABLE}"
-	fi
-}
-
-function show_binary() {
-	uses bin_path
-	uses system
-	uses executable
-
-	if [[ "$SYSTEM" == "macos" ]]; then otool -L "${EXECUTABLE}"
-	else ldd "${EXECUTABLE}"; fi
-	ls -1lh "${EXECUTABLE}"
-}
-
-function main() {
-	parse_args "$@"
-	build
-	strip_binary
-	show_binary
-}
-
-main "$@"
+# shellcheck source=scripts/automator/main.sh
+source "$(dirname "$0")/automator/main.sh"

--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -2,28 +2,26 @@
 
 # Copyright (c) 2019 Patryk Obara <patryk.obara@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
-
-# This script counts all compiler warnings and prints a summary.
 #
-# Usage: ./count-warnings.py build.log
-# Usage: cat "*.log" | ./count-warnings.py -
-#
-# note: new compilers include additional flag -fdiagnostics-format=[text|json],
-# which could be used instead of parsing using regex, but we want to preserve
-# human-readable output in standard log.
-
 # pylint: disable=invalid-name
 # pylint: disable=missing-docstring
 
+"""
+This script counts all compiler warnings and prints a summary.
+
+It returns success to the shell if the number or warnings encountered
+is less than or equal to the desired maximum warnings. See --help
+for a description of how to set the maximum.
+
+note: new compilers include additional flag -fdiagnostics-format=[text|json],
+which could be used instead of parsing using regex, but we want to preserve
+human-readable output in standard log.
+"""
+
+import argparse
 import os
 import re
 import sys
-
-# Maximum allowed number of issues; if build will include more warnings,
-# then script will return with status 1. Simply change this line if you
-# want to set a different limit.
-#
-MAX_ISSUES = 384
 
 # For recognizing warnings in GCC format in stderr:
 #
@@ -76,20 +74,52 @@ def print_summary(issues):
             text=warning, count=count, field_size=size))
     print()
 
+def to_int(value):
+    return int(value) if value is not None else None
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter, description=__doc__)
+
+    parser.add_argument(
+        'logfile',
+        metavar='LOGFILE',
+        help=("Path to the logfile, or use - to read from stdin"))
+
+    max_warnings = to_int(os.getenv('MAX_WARNINGS', None))
+    parser.add_argument(
+        '-m', '--max-warnings',
+        type=int,
+        required=not isinstance(max_warnings, int),
+        default=max_warnings,
+        help='Defines the maximum number of warnings permitted to exist\n'
+             'in the log file before returning a failure to the shell.\n'
+             'If not provided, the script will attempt to read it from\n'
+             'the MAX_WARNINGS environment variable, which is currently\n'
+             'set to: {}.  If a maximum of -1 is set then success is\n'
+             'always returned to the shell.\n\n'.format(str(max_warnings)))
+
+    return parser.parse_args()
 
 def main():
+    rcode = 0
     total = 0
     warning_types = {}
-    for line in get_input_lines(sys.argv[1]):
+    args = parse_args()
+    for line in get_input_lines(args.logfile):
         total += count_warning(line, warning_types)
     if warning_types:
         print("Warnings grouped by type:\n")
         print_summary(warning_types)
-    print('Total: {} warnings (out of {} allowed)\n'.format(total, MAX_ISSUES))
-    if total > MAX_ISSUES:
-        print('Error: upper limit of allowed warnings is', MAX_ISSUES)
-        sys.exit(1)
-
+    print('Total: {} warnings'.format(total), end='')
+    if args.max_warnings >= 0:
+        print(' (out of {} allowed)\n'.format(args.max_warnings))
+        if total > args.max_warnings:
+            print('Error: upper limit of allowed warnings is', args.max_warnings)
+            rcode = 1
+    else:
+        print('\n')
+    return rcode
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/scripts/list-build-dependencies.sh
+++ b/scripts/list-build-dependencies.sh
@@ -1,196 +1,55 @@
 #!/bin/bash
 
-##
-#  Copyright (c) 2019 Kevin R. Croft
-#  SPDX-License-Identifier: GPL-2.0-or-later
-#
-#  This script lists development packages and DOSBox dependencies needed to build DOSBox.
-#  This package names provided are tailor based on the provided package manager,
-#  choice of compiler, and optionally its bit-depth.
-#
-#  See the usage arguments below for details or run it with the -h or --help.
-#
-#  In general, this script adheres to Google's shell scripting style guide
-#  (https://google.github.io/styleguide/shell.xml), however some deviations (such as
-#  tab indents instead of two-spaces) are used to fit DOSBox's in-practice coding style.
-#
+# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
 
+# This script prints package dependencies for a given package manmager,
+# compiler (gcc or clang), and bit-depth (32 or 64).
+#
+# If run without arguments, the script asks for required arguments one
+# by one, which includes the package manager (--manager) and --compiler.
+#
+# Optional arguments include the bit-depth, defaults to 64-bit;
+# and the compiler version, which defaults to the package manager's
+# default version.
+#
+# Usage examples:
+#   $ ./list-build-dependencies.sh               # asks for --manager
+#   $ ./list-build-dependencies.sh --manager apt # asks for --compiler
+#   $ ./list-build-dependencies.sh --manager apt --compiler gcc -v 9
+#   $ ./list-build-dependencies.sh --manager zypper --compiler clang
+#   $ ./list-build-dependencies.sh --manager msy2 --compiler gcc -b 32
+#
+# This script makes use of the automator package, see automator/main.sh.
+#
 set -euo pipefail
-IFS=$'\n\t'
 
-function usage() {
-	if [ -n "${1}" ]; then
-		errcho "${1}"
-	fi
-	local script
-	script=$(basename "${0}")
-	echo "Usage: ${script} -p apt|xcode|brew|macports|msys2|vcpkg [-b 32|64] [-c gcc|clang] [-o FILE] [-u #]"
-	echo ""
-	echo "  FLAG                       Description                                          Default"
-	echo "  -----------------------    ---------------------------------------------------  -------"
-	echo "  -b, --bit-depth            Choose either a 64 or 32 bit compiler                [$(print_var "${BITS}")]"
-	echo "  -c, --compiler             Choose either gcc or clang                           [$(print_var "${COMPILER}")]"
-	echo "  -u, --compiler-version <#> Customize the compiler version (if available)        [$(print_var "${COMPILER_VERSION}")]"
-	echo "  -v, --version              Print the version of this script                     [$(print_var "${SCRIPT_VERSION}")]"
-	echo "  -h, --help                 Print this usage text"
-	echo "  -p, --package-manager      Choose one of the following:"
-	echo "                               - apt      (Linux: Debian, Ubuntu, Raspbian)"
-	echo "                               - dnf      (Linux: Fedora, RedHat, CentOS)"
-	echo "                               - pacman   (Linux: Arch, Manjaro)"
-	echo "                               - zypper   (Linux: SuSE, OpenSUSE)"
-	echo "                               - xcode    (OS X: Apple-supported)"
-	echo "                               - brew     (OS X: Homebrew community-supported)"
-	echo "                               - macports (OS X: MacPorts community-supported)"
-	echo "                               - msys2    (Windows: Cygwin-based, community-support)"
-	echo "                               - vcpkg    (Windows: Visual Studio builds)"
-	echo "  -----------------------    ---------------------------------------------------  -------"
-	echo ""
-	echo "Example: ${script} --package-manager apt --compiler clang --compiler-version 8"
-	echo ""
-	echo "Note: the last value will take precendent if duplicate flags are provided."
-	exit 1
-}
-
-function defaults() {
-	BITS="64"
-	COMPILER="gcc"
-	COMPILER_VERSION=""
-	PACKAGE_MANAGER="unset"
-	readonly SCRIPT_VERSION="0.2"
-}
-
-# parse params
 function parse_args() {
-	defaults
+	# Gather the parameters that define this build
+	bits="64"
+	modifiers=("")
+	# shellcheck disable=SC2034
 	while [[ "${#}" -gt 0 ]]; do case ${1} in
-		-b|--bit-depth)        BITS="${2}";             shift;shift;;
-		-c|--compiler)         COMPILER="${2}";         shift;shift;;
-		-p|--package-manager)  PACKAGE_MANAGER="${2}";  shift;shift;;
-		-u|--compiler-version) COMPILER_VERSION="${2}"; shift;shift;;
-		-v|--version)          print_version;           shift;;
-		-h|--help)             usage "Show usage";      shift;;
-		*) usage "Unknown parameter: ${1}";             shift;shift;;
+		-m|--manager)           manager="${2}";                shift 2;;
+		-c|--compiler)          selected_type=$(lower "${2}"); shift 2;;
+		-b|--bit-depth)         bits="${2}";                   shift 2;;
+		-v|--compiler-version)  version="${2}";                shift 2;;
+		-a|--addon)             modifiers+=("${2}");           shift 2;;
+		*) >&2 echo "Unknown parameter: ${1}"; exit 1;         shift 2;;
 	esac; done
 
-	# Check mandatory arguments
-	if [[ "${PACKAGE_MANAGER}" == "unset" ]]; then
-		usage "A choice of package manager must be provided; use '-p <choice>' or '--package-manager <choice>'"
-	fi
+	# Import our settings and report missing values
+	import manager "${manager:-}"
+	if [[ -z "${selected_type:-}" ]]; then arg_error "--compiler" "${TYPES[*]}"; fi
+
+	# If a version was provided then construct a postfix string given the manager's
+	# potential unique delimeter (ie: gcc@9 for brew, gcc-9 for apt).
+	# shellcheck disable=SC2034,SC2154
+	postfix=$([[ -n "${version:-}" ]] && echo "${delim}${version}" || echo "")
+	import "${selected_type:-}" "${manager:-}"
 }
+# shellcheck disable=SC2034
+data_dir="packages"
 
-function errcho() {
-	local CLEAR='\033[0m'
-	local RED='\033[0;91m'
-	>&2 echo ""
-	>&2 echo -e " ${RED}👉  ${*}${CLEAR}" "\\n"
-}
-
-function print_var() {
-	if [[ -z "${1}" ]]; then
-		echo "unset"
-	else
-		echo "${1}"
-	fi
-}
-
-function list_packages() {
-	VERSION_DELIM=""
-	case "$1" in
-
-		apt)
-			# Apt separates GCC into the gcc and g++ pacakges, the latter which depends on the prior.
-			# Therefore, we provide g++ in-place of gcc.
-			VERSION_DELIM="-"
-			if [[ "${COMPILER}" == "gcc" ]]; then
-				COMPILER="g++"
-			fi
-			PACKAGES=(libtool build-essential autoconf-archive libsdl1.2-dev libsdl-net1.2-dev libopusfile-dev)
-			;;
-
-		dnf)
-			VERSION_DELIM="-"
-			PACKAGES=(libtool autoconf-archive SDL SDL_net-devel opusfile-devel)
-			;;
-
-		pacman)
-			# Arch offers 32-bit versions of SDL (but not others)
-			PACKAGES=(libtool autoconf-archive sdl_net opusfile)
-			if [[ "${BITS}" == 32 ]]; then
-				PACKAGES+=(lib32-sdl)
-			else
-				PACKAGES+=(sdl)
-			fi
-			;;
-
-		zypper)
-			# OpenSUSE offers 32-bit versions of SDL and SDL_net (but not others)
-			PACKAGES=(devel_basis libtool autoconf-archive opusfile)
-			if [[ "${BITS}" == 32 ]]; then
-				PACKAGES+=(libSDL-devel-32bit libSDL_net-devel-32bit)
-			else
-				PACKAGES+=(SDL SDL_net)
-			fi
-			;;
-
-		xcode)
-			# If the user doesn't want to use Homebrew or MacPorts, then they are limited to
-			# Apple's Clang plus the provided command line development tools provided by Xcode.
-			COMPILER=""
-			echo "Execute the following:"
-			echo "   xcode-select --install    # to install command line development tools"
-			echo "   sudo xcodebuild -license  # to accept Apple's license agreement"
-			echo ""
-			echo "Now download, build, and install the following manually to avoid using Homebrew or MacPorts:"
-			echo " - coreutils autogen autoconf automake pkg-config libpng sdl sdl_net opusfile"
-			;;
-
-		brew)
-			# If the user wants Clang, we knock it out because it's provided provided out-of-the-box
-			VERSION_DELIM="@"
-			if [[ "${COMPILER}" == "clang" ]]; then
-				COMPILER=""
-			fi
-			PACKAGES=(coreutils autogen autoconf autoconf-archive automake pkg-config libpng sdl sdl_net opusfile)
-			;;
-
-		macports)
-			PACKAGES=(coreutils autogen automake autoconf autoconf-archive pkgconfig libpng libsdl libsdl_net opusfile)
-			;;
-
-		msys2)
-			# MSYS2 only supports the current latest releases of Clang and GCC, so we disable version customization
-			COMPILER_VERSION=""
-			local pkg_type
-			pkg_type="x86_64"
-			if [[ "${BITS}" == 32 ]]; then
-				pkg_type="i686"
-			fi
-			PACKAGES=(autogen autoconf autoconf-archive base-devel automake-wrapper)
-			for pkg in pkg-config libtool libpng zlib SDL SDL_net opusfile; do
-				PACKAGES+=("mingw-w64-${pkg_type}-${pkg}")
-			done
-			COMPILER="mingw-w64-${pkg_type}-${COMPILER}"
-			;;
-
-		vcpkg)
-			# VCPKG doesn't provide Clang or GCC, so we knock out the compiler and just give packages
-			COMPILER=""
-			PACKAGES=(libpng sdl1 sdl1-net opusfile)
-			;;
-		*)
-			usage "Unknown package manager ${1}"
-			;;
-	esac
-
-	if [[ -n "${COMPILER_VERSION}" && -n "${COMPILER}" ]]; then
-		COMPILER+="${VERSION_DELIM}${COMPILER_VERSION}"
-	fi
-	echo "${COMPILER} ${PACKAGES[*]}"
-}
-
-function main() {
-	parse_args "$@"
-	list_packages "${PACKAGE_MANAGER}"
-}
-
-main "$@"
+# shellcheck source=scripts/automator/main.sh
+source "$(dirname "$0")/automator/main.sh"


### PR DESCRIPTION
- Refactors the build and package scripts by separating their "data" from code
- Adds the ability to take in the maximum-issue count to the `count-{warnings,bugs}.py` scripts
- Refactors the workflows with full coverage of compilers, serialized Release and Debug builds, per-build warning counts, use of GitHub's new cache feature, and more use of matrix.* operators.
- Adds serialized sanitizer builds and test runs (using xvfb) to the code analysis workflow, which has been renamed from 'static code analysis' to 'code analysis'.

This sets us up to more easily add more build types (cross-compiling for ARM, PPC, nightly release builds, ... ). 