### PR TITLE
Play into subsequent track(s) if requested length requires it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -574,6 +574,7 @@ case "$host" in
     *-*-cygwin* | *-*-mingw* | *-*-msys*)
        LIBS="$LIBS -lwinmm"
        AC_DEFINE(WIN32, 1, [Compiling on Windows])
+       AC_DEFINE(NOMINMAX, 1, [Prevent <windows.h> from clobbering std::min and std::max])
        AC_DEFINE(C_DIRECTSERIAL, 1, [ Define to 1 if you want serial passthrough support (Win32, Posix and OS/2 only).])
        if test x$have_sdl_net_lib = xyes -a x$have_sdl_net_h = xyes ; then
          LIBS="$LIBS -lws2_32"

--- a/include/setup.h
+++ b/include/setup.h
@@ -170,7 +170,7 @@ public:
 	}
 	int getMin() { return min;}
 	int getMax() { return max;}
-	void SetMinMax(Value const& min,Value const& max) {this->min = min; this->max=max;}
+	void SetMinMax(Value const& _min,Value const& _max) {this->min = _min; this->max=_max;}
 	bool SetValue(std::string const& in);
 	~Prop_int(){ }
 	virtual bool CheckValue(Value const& in, bool warn);

--- a/include/support.h
+++ b/include/support.h
@@ -20,6 +20,7 @@
 #ifndef DOSBOX_SUPPORT_H
 #define DOSBOX_SUPPORT_H
 
+#include <algorithm>
 #include <string.h>
 #include <string>
 #include <ctype.h>
@@ -37,6 +38,14 @@
 #ifdef HAVE_STRINGS_H
 #include <strings.h>
 #endif
+
+// Clamp: given a value that can be compared with the given minimum and maximum
+//        values, this function will:
+//          * return the value if it's in-between or equal to either bounds, or
+//          * return either bound depending on which bound the value is beyond
+template <class T> T clamp(const T& n, const T& lower, const T& upper) {
+	return std::max<T>(lower, std::min<T>(n, upper));
+}
 
 void strreplace(char * str,char o,char n);
 char *ltrim(char *str);

--- a/src/dos/cdrom_ioctl_win32.cpp
+++ b/src/dos/cdrom_ioctl_win32.cpp
@@ -495,18 +495,18 @@ bool CDROM_Interface_Ioctl::ReadSector(Bit8u *buffer, bool raw, unsigned long se
 	BOOL  bStat;
 	DWORD byteCount = 0;
 
-	Bitu	buflen	= raw ? RAW_SECTOR_SIZE : COOKED_SECTOR_SIZE;
+	Bitu	buflen	= raw ? BYTES_PER_RAW_REDBOOK_FRAME : BYTES_PER_COOKED_REDBOOK_FRAME;
 
 	if (!raw) {
 		// Cooked
 		int	  success = 0;
-		DWORD newPos  = SetFilePointer(hIOCTL, sector*COOKED_SECTOR_SIZE, 0, FILE_BEGIN);
+		DWORD newPos  = SetFilePointer(hIOCTL, sector*BYTES_PER_COOKED_REDBOOK_FRAME, 0, FILE_BEGIN);
 		if (newPos != 0xFFFFFFFF) success = ReadFile(hIOCTL, buffer, buflen, &byteCount, NULL);
 		bStat = (success!=0);
 	} else {
 		// Raw
 		RAW_READ_INFO in;
-		in.DiskOffset.LowPart	= sector*COOKED_SECTOR_SIZE;
+		in.DiskOffset.LowPart	= sector*BYTES_PER_COOKED_REDBOOK_FRAME;
 		in.DiskOffset.HighPart	= 0;
 		in.SectorCount			= 1;
 		in.TrackMode			= CDDA;		
@@ -521,19 +521,19 @@ bool CDROM_Interface_Ioctl::ReadSectors(PhysPt buffer, bool raw, unsigned long s
 	BOOL  bStat;
 	DWORD byteCount = 0;
 
-	Bitu	buflen	= raw ? num*RAW_SECTOR_SIZE : num*COOKED_SECTOR_SIZE;
+	Bitu	buflen	= raw ? num*BYTES_PER_RAW_REDBOOK_FRAME : num*BYTES_PER_COOKED_REDBOOK_FRAME;
 	Bit8u*	bufdata = new Bit8u[buflen];
 
 	if (!raw) {
 		// Cooked
 		int	  success = 0;
-		DWORD newPos  = SetFilePointer(hIOCTL, sector*COOKED_SECTOR_SIZE, 0, FILE_BEGIN);
+		DWORD newPos  = SetFilePointer(hIOCTL, sector*BYTES_PER_COOKED_REDBOOK_FRAME, 0, FILE_BEGIN);
 		if (newPos != 0xFFFFFFFF) success = ReadFile(hIOCTL, bufdata, buflen, &byteCount, NULL);
 		bStat = (success!=0);
 	} else {
 		// Raw
 		RAW_READ_INFO in;
-		in.DiskOffset.LowPart	= sector*COOKED_SECTOR_SIZE;
+		in.DiskOffset.LowPart	= sector*BYTES_PER_COOKED_REDBOOK_FRAME;
 		in.DiskOffset.HighPart	= 0;
 		in.SectorCount			= num;
 		in.TrackMode			= CDDA;		
@@ -563,7 +563,7 @@ void CDROM_Interface_Ioctl::dx_CDAudioCallBack(Bitu len) {
 		
 		if (success) {
 			player.currFrame++;
-			player.bufLen += RAW_SECTOR_SIZE;
+			player.bufLen += BYTES_PER_RAW_REDBOOK_FRAME;
 		} else {
 			memset(&player.buffer[player.bufLen], 0, len - player.bufLen);
 			player.bufLen = len;

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -512,7 +512,7 @@ int isoDrive :: readDirEntry(isoDirEntry *de, Bit8u *data) {
 }
 
 bool isoDrive :: loadImage() {
-	Bit8u pvd[COOKED_SECTOR_SIZE];
+	Bit8u pvd[BYTES_PER_COOKED_REDBOOK_FRAME];
 	dataCD = false;
 	readSector(pvd, ISO_FIRST_VD);
 	if (pvd[0] == 1 && !strncmp((char*)(&pvd[1]), "CD001", 5) && pvd[6] == 1) iso = true;

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -34,8 +34,6 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-// prevent the Windows header from clobbering std::min and max
-#define NOMINMAX
 #include <windows.h>
 #include <mmsystem.h>
 #endif
@@ -154,11 +152,6 @@ void MIXER_DelChannel(MixerChannel* delchan) {
 void MixerChannel::UpdateVolume(void) {
 	volmul[0]=(Bits)((1 << MIXER_VOLSHIFT)*scale[0]*volmain[0]*mixer.mastervol[0]);
 	volmul[1]=(Bits)((1 << MIXER_VOLSHIFT)*scale[1]*volmain[1]*mixer.mastervol[1]);
-}
-
-template <typename T>
-T clamp(const T& n, const T& lower, const T& upper) {
-  return std::max(lower, std::min(n, upper));
 }
 
 void MixerChannel::SetVolume(float _left,float _right) {

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -17,16 +17,15 @@
  */
 
 
-#include <string.h>
-#include <stdlib.h>
+#include <algorithm>
 #include <assert.h>
+#include <cctype>
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <string.h>
-#include <algorithm>
-#include <cctype>
+#include <stdlib.h>
 #include <string>
+#include <cstring>
   
 #include "dosbox.h"
 #include "debug.h"


### PR DESCRIPTION
Fixes #50

In debugging and performing this fix, many debug messages were improved as well as making some small small code adjustments to improve readability, such as using iterators for a given track, `track->attribute` instead of subtracting into the array vector `tracks[track -1].attribute`  