### PR TITLE
Batch of compiler and static analysis fixes

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -46,11 +46,13 @@ jobs:
           name: report
           path: report
       - name: Summarize report
+        env:
+          MAX_BUGS: 81
         run: |
           # summary
           echo "Full report is included in build Artifacts"
           echo
-          ./scripts/count-bugs.py -m 85 report/*/index.html
+          ./scripts/count-bugs.py report/*/index.html
 
   dynamic_matrix:
     name: ${{ matrix.compiler }} dynamic sanitizers

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,21 +1,10 @@
 name: Linux builds
 on: push
 env:
-  MAX_WARNINGS_GCC_5_Debug:     370
-  MAX_WARNINGS_GCC_6_Debug:     378
-  MAX_WARNINGS_GCC_7_Debug:     377
-  MAX_WARNINGS_GCC_8_Debug:     380
-  MAX_WARNINGS_GCC_9_Debug:     400
-  MAX_WARNINGS_Clang_7_Debug:   193
-  MAX_WARNINGS_Clang_8_Debug:   191
-
-  MAX_WARNINGS_GCC_5_Release:    -1
-  MAX_WARNINGS_GCC_6_Release:   661
-  MAX_WARNINGS_GCC_7_Release:   329
-  MAX_WARNINGS_GCC_8_Release:   330
-  MAX_WARNINGS_GCC_9_Release:   358
-  MAX_WARNINGS_Clang_7_Release: 193
-  MAX_WARNINGS_Clang_8_Release: 193
+  MAX_WARNINGS_GCC_5_Debug:     309
+  MAX_WARNINGS_GCC_7_Debug:     316
+  MAX_WARNINGS_GCC_9_Debug:     339
+  MAX_WARNINGS_Clang_8_Debug:   175
 
 jobs:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,11 +1,8 @@
 name: macOS builds
 on: push
 env:
-  MAX_WARNINGS_Clang_Debug:   243
-  MAX_WARNINGS_GCC_9_Debug:   358
-
-  MAX_WARNINGS_Clang_Release: 243
-  MAX_WARNINGS_GCC_9_Release: 316
+  MAX_WARNINGS_Clang_Debug:   227
+  MAX_WARNINGS_GCC_9_Debug:   326
 
 jobs:
   clang_xcode:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,15 +1,10 @@
 name: Windows builds
 on: push
 env:
-  MAX_WARNINGS_GCC_32bit_Debug:     307
-  MAX_WARNINGS_GCC_64bit_Debug:     420
-  MAX_WARNINGS_Clang_32bit_Debug:   129
-  MAX_WARNINGS_Clang_64bit_Debug:   190
-
-  MAX_WARNINGS_GCC_32bit_Release:   284
-  MAX_WARNINGS_GCC_64bit_Release:   369
-  MAX_WARNINGS_Clang_32bit_Release: 129
-  MAX_WARNINGS_Clang_64bit_Release: 190
+  MAX_WARNINGS_GCC_32bit_Debug:     246
+  MAX_WARNINGS_GCC_64bit_Debug:     359
+  MAX_WARNINGS_Clang_32bit_Debug:   101
+  MAX_WARNINGS_Clang_64bit_Debug:   160
 
 jobs:
 

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -217,7 +217,6 @@ private:
 	CFileInfo*	dirBase;
 	char		dirPath				[CROSS_LEN];
 	char		basePath			[CROSS_LEN];
-	bool		dirFirstTime;
 	TDirSort	sortDirType;
 	CFileInfo*	save_dir;
 	char		save_path			[CROSS_LEN];
@@ -225,7 +224,6 @@ private:
 
 	Bit16u		srchNr;
 	CFileInfo*	dirSearch			[MAX_OPENDIRS];
-	char		dirSearchName		[MAX_OPENDIRS];
 	CFileInfo*	dirFindFirst		[MAX_OPENDIRS];
 	Bit16u		nextFreeFindFirst;
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -60,7 +60,6 @@ public:
 	bool loadedSector;
 	fatDrive *myDrive;
 private:
-	enum { NONE,READ,WRITE } last_action;
 	Bit16u info;
 };
 

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -45,7 +45,6 @@ private:
 	Bit32u fileBegin;
 	Bit32u filePos;
 	Bit32u fileEnd;
-	Bit16u info;
 };
 
 isoFile::isoFile(isoDrive *drive, const char *name, FileStat_Block *stat, Bit32u offset) {

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -825,6 +825,9 @@ Module::Module( Section* configuration ) : Module_base(configuration) {
 	case OPL_opl3gold:
 		Init( Adlib::MODE_OPL3GOLD );
 		break;
+	case OPL_cms:
+	case OPL_none:
+		break;
 	}
 	//0x388 range
 	WriteHandler[0].Install(0x388,OPL_Write,IO_MB, 4 );

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -631,8 +631,7 @@ static void DSP_RaiseIRQEvent(Bitu /*val*/) {
 	SB_RaiseIRQ(SB_IRQ_8);
 }
 
-static void DSP_DoDMATransfer(DMA_MODES mode,Bitu freq,bool autoinit, bool stereo) {
-	char const * type;
+static void DSP_DoDMATransfer(const DMA_MODES mode, Bitu freq, bool autoinit, bool stereo) {
 	//Fill up before changing state?
 	sb.chan->FillUp();
 
@@ -642,32 +641,14 @@ static void DSP_DoDMATransfer(DMA_MODES mode,Bitu freq,bool autoinit, bool stere
 	PIC_DeActivateIRQ(sb.hw.irq);
 
 	switch (mode) {
-	case DSP_DMA_2:
-		type="2-bits ADPCM";
-		sb.dma.mul=(1 << SB_SH)/4;
-		break;
-	case DSP_DMA_3:
-		type="3-bits ADPCM";
-		sb.dma.mul=(1 << SB_SH)/3;
-		break;
-	case DSP_DMA_4:
-		type="4-bits ADPCM";
-		sb.dma.mul=(1 << SB_SH)/2;
-		break;
-	case DSP_DMA_8:
-		type="8-bits PCM";
-		sb.dma.mul=(1 << SB_SH);
-		break;
-	case DSP_DMA_16_ALIASED:
-		type="16-bits(aliased) PCM";
-		sb.dma.mul=(1 << SB_SH)*2;
-		break;
-	case DSP_DMA_16:
-		type="16-bits PCM";
-		sb.dma.mul=(1 << SB_SH);
-		break;
+	case DSP_DMA_2:          sb.dma.mul = (1 << SB_SH) / 4; break;
+	case DSP_DMA_3:          sb.dma.mul = (1 << SB_SH) / 3; break;
+	case DSP_DMA_4:          sb.dma.mul = (1 << SB_SH) / 2; break;
+	case DSP_DMA_8:          sb.dma.mul = (1 << SB_SH); break;
+	case DSP_DMA_16:         sb.dma.mul = (1 << SB_SH); break;
+	case DSP_DMA_16_ALIASED: sb.dma.mul = (1 << SB_SH) * 2; break;
 	default:
-		LOG(LOG_SB,LOG_ERROR)("DSP:Illegal transfer mode %d",mode);
+		LOG(LOG_SB,LOG_ERROR)("DSP:Illegal transfer mode %d", mode);
 		return;
 	}
 
@@ -701,14 +682,22 @@ static void DSP_DoDMATransfer(DMA_MODES mode,Bitu freq,bool autoinit, bool stere
 	sb.dma.chan->Register_Callback(DSP_DMA_CallBack);
 
 #if (C_DEBUG)
+	const char *type;
+	switch (mode) {
+	case DSP_DMA_2:          type = "2-bits ADPCM"; break;
+	case DSP_DMA_3:          type = "3-bits ADPCM"; break;
+	case DSP_DMA_4:          type = "4-bits ADPCM"; break;
+	case DSP_DMA_8:          type = "8-bits PCM"; break;
+	case DSP_DMA_16:         type = "16-bits PCM"; break;
+	case DSP_DMA_16_ALIASED: type = "16-bits (aliased) PCM"; break;
+	case DSP_DMA_NONE:       type = ""; break;
+	};
 	LOG(LOG_SB, LOG_NORMAL)("DMA Transfer:%s %s %s freq %d rate %d size %d",
 		type,
 		stereo ? "Stereo" : "Mono",
 		autoinit ? "Auto-Init" : "Single-Cycle",
 		freq, sb.dma.rate, sb.dma.left
 		);
-#else
-	type = *&type;
 #endif
 }
 

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -987,6 +987,8 @@ void XGA_SetDualReg(Bit32u& reg, Bitu val) {
 			reg = (reg&0xffff0000)|(val&0x0000ffff);
 		xga.control1 ^= 0x10;
 		break;
+	default:
+		break;
 	}
 }
 
@@ -1001,6 +1003,8 @@ Bitu XGA_GetDualReg(Bit32u reg) {
 		xga.control1 ^= 0x10;
 		if (xga.control1 & 0x10) return reg&0x0000ffff;
 		else return reg>>16;
+	default:
+		break;
 	}
 	return 0;
 }

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -574,6 +574,8 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 	if(!xga.waitcmd.wait) return;
 	Bitu mixmode = (xga.pix_cntl >> 6) & 0x3;
 	Bitu srcval;
+	Bitu chunksize = 0;
+	Bitu chunks = 0;
 	switch(xga.waitcmd.cmd) {
 		case 2: /* Rectangle */
 			switch(mixmode) {
@@ -645,8 +647,6 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 					break;
 			
 				case 0x02: // Data from PIX_TRANS selects the mix
-					Bitu chunksize;
-					Bitu chunks;
 					switch(xga.waitcmd.buswidth&0x60) {
 						case 0x0:
 							chunksize=8;
@@ -661,7 +661,7 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 							chunksize=16;
 							if(len==4) chunks=2;
 							else chunks = 1;
-                           	break;
+							break;
 						case 0x60: // undocumented guess (but works)
 							chunksize=8;
 							chunks=4;

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -194,13 +194,9 @@ INLINE void VideoCodec::AddXorBlock(int vx,int vy,FrameBlock * block) {
 
 template<class P>
 void VideoCodec::AddXorFrame(void) {
-	int written=0;
-	int lastvector=0;
 	signed char * vectors=(signed char*)&work[workUsed];
 	/* Align the following xor data on 4 byte boundary*/
 	workUsed=(workUsed + blockcount*2 +3) & ~3;
-	int totalx=0;
-	int totaly=0;
 	for (int b=0;b<blockcount;b++) {
 		FrameBlock * block=&blocks[b];
 		int bestvx = 0;
@@ -362,7 +358,7 @@ int VideoCodec::FinishCompressFrame( void ) {
 	zstream.next_out = (Bytef *)(compress.writeBuf + compress.writeDone);
 	zstream.avail_out = compress.writeSize - compress.writeDone;
 	zstream.total_out = 0;
-	int res = deflate(&zstream, Z_SYNC_FLUSH);
+	deflate(&zstream, Z_SYNC_FLUSH);
 	return compress.writeDone + zstream.total_out;
 }
 
@@ -432,7 +428,7 @@ bool VideoCodec::DecompressFrame(void * framedata, int size) {
 	zstream.next_out = (Bytef *)work;
 	zstream.avail_out = bufsize;
 	zstream.total_out = 0;
-	int res = inflate(&zstream, Z_FINISH);
+	inflate(&zstream, Z_FINISH);
 	workUsed= zstream.total_out;
 	workPos = 0;
 	if (tag & Mask_KeyFrame) {

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -350,6 +350,8 @@ int VideoCodec::FinishCompressFrame( void ) {
 		case ZMBV_FORMAT_32BPP:
 			AddXorFrame<long>();
 			break;
+		default:
+			break;
 		}
 	}
 	/* Create the actual frame with compression */
@@ -471,6 +473,8 @@ bool VideoCodec::DecompressFrame(void * framedata, int size) {
 		case ZMBV_FORMAT_32BPP:
 			UnXorFrame<long>();
 			break;
+		default:
+			break;
 		}
 	}
 	return true;
@@ -515,6 +519,8 @@ void VideoCodec::Output_UpsideDown_24(void *output) {
 				*w++ = r[j*4+1];
 				*w++ = r[j*4+2];
 			}
+			break;
+		default:
 			break;
 		}
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -104,17 +104,22 @@ static char* ExpandDot(char*args, char* buffer , size_t bufsize) {
 
 
 
-bool DOS_Shell::CheckConfig(char* cmd_in,char*line) {
+bool DOS_Shell::CheckConfig(char *cmd_in, char *line) {
 	Section* test = control->GetSectionFromProperty(cmd_in);
-	if(!test) return false;
-	if(line && !line[0]) {
+	if (!test)
+		return false;
+
+	if (line && !line[0]) {
 		std::string val = test->GetPropValue(cmd_in);
-		if(val != NO_SUCH_PROPERTY) WriteOut("%s\n",val.c_str());
+		if (val != NO_SUCH_PROPERTY)
+			WriteOut("%s\n", val.c_str());
 		return true;
 	}
-	char newcom[1024]; newcom[0] = 0; strcpy(newcom,"z:\\config -set ");
-	strcat(newcom,test->GetName());	strcat(newcom," ");
-	strcat(newcom,cmd_in);strcat(newcom,line);
+	char newcom[1024];
+	snprintf(newcom, sizeof(newcom), "z:\\config -set %s %s%s",
+	         test->GetName(),
+	         cmd_in,
+	         line ? line : "");
 	DoCommand(newcom);
 	return true;
 }


### PR DESCRIPTION
Recently, some warning fixes started appearing in SVN, touching the same code areas, that were already fixed on master branch… In most cases I opted to resolve conflicts according to upstream version (even if I don't like their fixes) to make future merge-ins easier, but db51b635542c293b5f0f123feab80ba4cb8b5c84 and f923a8e6441c482a59a274316acd0f1afbfb64b8 were too much for me… I prefer to fix the issue instead of deploying `type = *&type;` no-op to fool the compiler.

Bundled in some other warnings fixes/silencing as well.