### PR TITLE
Use make's output-sync to prevent log corruption

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,49 +1,29 @@
 name: macOS builds
 on: push
-env:
-  MAX_WARNINGS_Clang_Debug:   227
-  MAX_WARNINGS_GCC_9_Debug:   326
 
 jobs:
-  clang_xcode:
-    name: Clang (Xcode)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install C++ compiler and libraries
-        run:  brew install $(./scripts/list-build-dependencies.sh -m brew -c clang)
-      - name: Log environment
-        run:  ./scripts/log-env.sh
-      - name: Debug build
-        run:  ./scripts/build.sh --compiler clang --build-type Debug
-      - name: Debug warnings
-        run:  python3 ./scripts/count-warnings.py -m $MAX_WARNINGS_Clang_Debug build.log
 
-  gcc_brew:
-    name: GCC-${{ matrix.compiler_version }} (HomeBrew)
+  build_macos:
+    name: ${{ matrix.conf.name }}
     runs-on: macos-latest
     strategy:
       matrix:
-        compiler_version: [9]
+        conf:
+          - name: Clang
+            flags: -c clang
+            max_warnings: 227
+          - name: GCC-9
+            flags: -c gcc -v 9
+            max_warnings: 326
     steps:
       - uses: actions/checkout@v1
-      - name: Prepare tar-zstd for the cache
-        run:  |
-          brew install zstd gnu-tar
-          cp .github/scripts/tar /usr/local/bin/tar
-      - uses: actions/cache@v1
-        id:   cache-brew
-        with: {path: /usr/local, key: brew-gcc-2019-v18}
       - name: Install C++ compiler and libraries
-        if:   steps.cache-brew.outputs.cache-hit != 'true'
-        run:  |
-          ./.github/scripts/reset-brew.sh
-          brew install $(./scripts/list-build-dependencies.sh -m brew -c gcc -v ${{ matrix.compiler_version }})
-          sudo ./.github/scripts/shrink-brew.sh
+        run:  brew install $(./scripts/list-build-dependencies.sh -m brew ${{ matrix.conf.flags}})
       - name: Log environment
         run:  ./scripts/log-env.sh
-      - name: Debug build
-        run: ./scripts/build.sh --compiler gcc --version-postfix ${CC_PREFIX}${{ matrix.compiler_version }} --build-type Debug
-      - name: Debug warnings
-        run:  python3 ./scripts/count-warnings.py -m $MAX_WARNINGS_GCC_${{ matrix.compiler_version }}_Debug build.log
-
+      - name: Build
+        run:  ./scripts/build.sh --build-type Debug ${{ matrix.conf.flags }}
+      - name: Summarize warnings
+        env:
+          MAX_WARNINGS: ${{ matrix.conf.max_warnings }}
+        run:  python3 ./scripts/count-warnings.py build.log

--- a/scripts/automator/build/os-darwin
+++ b/scripts/automator/build/os-darwin
@@ -1,5 +1,10 @@
 # Tool additions and overrides for Darwin, regardless of compiler
 ar="ar"
 ranlib="ranlib"
-function make_binary() { make -j$(sysctl -n hw.physicalcpu) 2>&1 | tee build.log; }
+function make_binary() {
+	gmake \
+		--jobs="$(sysctl -n hw.physicalcpu)" \
+		--output-sync=line \
+		2>&1 | tee build.log
+}
 dependencies=("otool" "-L" "${executable}")

--- a/scripts/automator/build/os-linux
+++ b/scripts/automator/build/os-linux
@@ -1,2 +1,7 @@
-function make_binary() { make -j$(nproc) 2>&1 | tee build.log; }
-
+#!/bin/bash
+function make_binary() {
+	make \
+		--jobs="$(nproc)" \
+		--output-sync=line \
+		|& tee build.log
+}

--- a/scripts/automator/build/os-msys_nt
+++ b/scripts/automator/build/os-msys_nt
@@ -1,3 +1,7 @@
-function make_binary() { make -j$(nproc) 2>&1 | tee build.log; }
+function make_binary() {
+	make \
+		--jobs=$(nproc) \
+		--output-sync=line \
+		|& tee build.log
+}
 executable="src/dosbox.exe"
-

--- a/scripts/automator/packages/manager-brew
+++ b/scripts/automator/packages/manager-brew
@@ -1,3 +1,3 @@
 # Package repo: https://formulae.brew.sh/
 delim="@"
-packages+=(coreutils autogen autoconf automake pkg-config libpng sdl sdl_net opusfile)
+packages+=(coreutils autogen autoconf automake make pkg-config libpng sdl sdl_net opusfile)


### PR DESCRIPTION
This works out of the box on Linux and MSYS2, but does not work on
macOS - Xcode supplied make does not support this option, so GNU make is
used instead.

Unfortunately, adding new package on macOS did not invalidate the cache,
this package removes the brew cache from macOS job to avoid this problem
in the future.

Fixes: #53