### PR TITLE
Override architecture and host for 32-bit windows builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,9 @@
 name: Windows builds
 on: push
 env:
-  MAX_WARNINGS_GCC_32bit_Debug:     246
+  MAX_WARNINGS_GCC_32bit_Debug:     243
   MAX_WARNINGS_GCC_64bit_Debug:     359
-  MAX_WARNINGS_Clang_32bit_Debug:   101
+  MAX_WARNINGS_Clang_32bit_Debug:   105
   MAX_WARNINGS_Clang_64bit_Debug:   160
 
 jobs:
@@ -66,6 +66,12 @@ jobs:
         run:  ./scripts/log-env.sh
       - name:  Debug Build
         shell: python scripts\msys-bash.py {0}
-        run:   ./scripts/build.sh --compiler ${{ matrix.compiler }} --build-type Debug --bin-path /mingw${{ matrix.bits }}/bin
+        env:
+          ARCH_32: i686
+          ARCH_64: x86_64
+        run:  |
+          export MSYSTEM_CARCH="$ARCH_${{ matrix.bits }}"
+          export MSYSTEM_CHOST="$ARCH_${{ matrix.bits }}-pc-msys"
+          ./scripts/build.sh --compiler ${{ matrix.compiler }} --build-type Debug --bin-path /mingw${{ matrix.bits }}/bin
       - name:  Debug Warnings
         run:   '.\scripts\count-warnings.py -m $env:MAX_WARNINGS_${{ matrix.compiler }}_${{ matrix.bits }}bit_Debug build.log'


### PR DESCRIPTION
When compiling inside a 64-bit MSYS2 environment, 32-bit windows builds were erroneously including DOSBox's 64-bit dynamic recompiling backend, despite being configured with a 32-bit compiler and bin tools.  

This is because autotools, under Windows, detects the architecture via the MSYSTEM_CARCH and MSYSTEM_CHOST environment variables.  This change overrides these two to match a pure 32-bit system.

Flagged and confirmed by vogons.org user **jmarsh**; thank you.