### PR TITLE
Perform a daily Coverity Scan of the master branch

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,55 @@
+name: Coverity Scan
+env:
+  COVERITY_EMAIL: ${{ secrets.CoverityEmail }}
+  COVERITY_TOKEN: ${{ secrets.CoverityToken }}
+  PACKAGE_VERSION: "2019.03"
+  TARBALL_SHA256: "0bec2d12e7fca3fe4b6df843d9584e2a58e273970a8549c100541f86dbc0da4e"
+  TARBALL_GDRIVE_ID: ${{ secrets.GoogleDriveId }}
+
+on:
+  schedule:
+    # Every day at 415am
+    - cron:  '15 4 * * *'
+jobs:
+  coverity_scan:
+    name: Coverity static analyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run:  sudo apt-get update
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+
+      - name: Install C++ compiler and dependencies
+        run:  |
+          sudo apt-get install zstd python3-setuptools $(./scripts/list-build-dependencies.sh -m apt -c gcc)
+          sudo pip3 install gdown
+
+      - name: Fetch the Coverity instrumenteur
+        run:  |
+          set -xeuo pipefail
+          gdown --id "${TARBALL_GDRIVE_ID}" -O - \
+          | tee >(tar -I zstd -C /dev/shm -x) \
+          | sha256sum -c <(echo "${TARBALL_SHA256} -" )
+
+      - name: Build and instrument the project
+        run:  |
+          set -xeu
+          g++ --version
+          ./autogen.sh
+          export CFLAGS="-g -Og"
+          export CXXFLAGS="${CFLAGS}"
+          ./configure
+          PATH="/dev/shm/cov-analysis-linux64-${PACKAGE_VERSION}/bin:${PATH}"
+          cov-build --dir cov-int make -j "$(nproc)"
+          tar -cvaf package.tar.gz cov-int
+
+      - name: Upload the package to Coverity
+        run:  |
+          curl \
+          --form token="${COVERITY_TOKEN}" \
+          --form email="${COVERITY_EMAIL}" \
+          --form file=@package.tar.gz \
+          --form version="${GITHUB_REF}" \
+          --form description="${GITHUB_REPOSITORY}" \
+          "https://scan.coverity.com/builds?project=dosbox-staging"


### PR DESCRIPTION
Details at: https://scan.coverity.com/dashboard

The Coverity software (Roughly 1.5GB worth unpacked from a tarball)
can only be downloaded from an authenticated web sessions, so I've
uploaded it to my Google drive and use the handy python pip `gdown`
to pull it inside the workflow. This sounds ugly, but it's not too bad:
Coverity last updated their software nine months ago, so this will be a
once-a-year change, maybe twice.

The Google drive ID, SHA256 checksum, and other specifics are all
variables at the top YAML, so they're easy to adjust when Coverity
makes their next update. The download, extraction, and sha256
verification are all done simultaneously via pipes, and extracted to
/dev/shm. It should be pretty quick. Edit: it is; 4 seconds.

To keep the tarball small, I remove unnecessary bits (but this is
optional), before tar & zstd compressing it:
``` bash
rm -rf closure-compiler jars jdk11 jre node support-angularjs
cd bin
rm *java* *js* *php* *python* *ruby*
```