### PR TITLE
Fix a resource leak

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -317,6 +317,7 @@ Bitu keyboard_layout::read_keyboard_file(const char* keyboard_file_name, Bit32s 
 		Bit32u dr=(Bit32u)fread(read_buf, sizeof(Bit8u), 4, tempfile);
 		if ((dr<4) || (read_buf[0]!=0x4b) || (read_buf[1]!=0x4c) || (read_buf[2]!=0x46)) {
 			LOG(LOG_BIOS,LOG_ERROR)("Invalid keyboard layout file %s",keyboard_file_name);
+			fclose(tempfile);
 			return KEYB_INVALIDFILE;
 		}
 		
@@ -670,6 +671,7 @@ Bit16u keyboard_layout::extract_codepage(const char* keyboard_file_name) {
 		Bit32u dr=(Bit32u)fread(read_buf, sizeof(Bit8u), 4, tempfile);
 		if ((dr<4) || (read_buf[0]!=0x4b) || (read_buf[1]!=0x4c) || (read_buf[2]!=0x46)) {
 			LOG(LOG_BIOS,LOG_ERROR)("Invalid keyboard layout file %s",keyboard_file_name);
+			fclose(tempfile);
 			return 437;
 		}
 


### PR DESCRIPTION
I was perusing Coverity report to see, if there are any easy-to-fix bugs detected and I managed to find one (or maybe 2, not sure).

https://scan8.coverity.com/reports.htm#v37766/p12412/fileInstanceId=29441662&defectInstanceId=10081550&mergedDefectId=277165

Steps to reproduce correct behaviour:
Download [PL214.zip](https://github.com/dreamer/dosbox-staging/files/3901988/PL214.zip), unpack it (file PL214.KL needs to be in working dir), then:

    $ dosbox .
    C:\>keyb pl214

DOSBox should report success; in second terminal run `lsof -p <pid-of-dosbox-process>` and verify, that KL file is not being held open.

Steps to reproduce leak:

The leak happens when invalid keyboard layout file is being loaded:

    $ touch xx.kl
    $ dosbox .
    C:\>keyb xx

Loading file will fail, but `lsof` will indicate, that file is still open. Each invocation of `keyb` will leave another open file descriptor.