### PR TITLE
Remove Coverity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![](https://github.com/dreamer/dosbox-staging/workflows/Linux%20builds/badge.svg)](https://github.com/dreamer/dosbox-staging/actions?query=workflow%3A%22Linux+builds%22)
 [![](https://github.com/dreamer/dosbox-staging/workflows/Windows%20builds/badge.svg)](https://github.com/dreamer/dosbox-staging/actions?query=workflow%3A%22Windows+builds%22)
 [![](https://github.com/dreamer/dosbox-staging/workflows/macOS%20builds/badge.svg)](https://github.com/dreamer/dosbox-staging/actions?query=workflow%3A%22macOS+builds%22)
-[![](https://img.shields.io/coverity/scan/19891)](https://scan.coverity.com/projects/dosbox-staging)
 
 This repository attempts to modernize the [DOSBox](https://www.dosbox.com/)
 project by using current development practices and tools, fixing issues, adding


### PR DESCRIPTION
This badge is useful link straight to the Coverity report, but Coverity
decides to present the scan results in quite misleading way - mixing
runs from master with runs from other branches.

It's better to show no info at all than to show misleading info.

Link to Coverity scan is accessible in README.md, as a reference [3] in
the comparison table.