### PR TITLE
Enable Coverity "streams"

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -50,6 +50,7 @@ jobs:
           --form token="${COVERITY_TOKEN}" \
           --form email="${COVERITY_EMAIL}" \
           --form file=@package.tar.gz \
-          --form version="${GITHUB_REF}" \
+          --form version="${GITHUB_SHA}" \
           --form description="${GITHUB_REPOSITORY}" \
+          --form stream="${GITHUB_REF}" \
           "https://scan.coverity.com/builds?project=dosbox-staging"


### PR DESCRIPTION
Disclaimer: I don't know if this works!

I tried to define views inside coverity report, that would allow us correctly track trends and this is what I found:
1) Coverity's nomenclature for branch is "Stream": https://community.synopsys.com/s/article/Five-Common-Misconceptions-How-best-to-use-Coverity-to-detect-defects
2) I found no way to define "stream" via Coverity interface at all
3) Supposedly, it can be declared during upload when builds are uploaded `cov-commit-defects` (?) https://community.synopsys.com/s/question/0D53400003tHtG6CAK/quick-start-guide-covconfigure-covbuild-and-covcommit
4) I hoped that maybe it can be defined during upload (but I can't find no documentation at all - I have no idea if this will work or not). If it will work, then it'll make sense to change version to point to commit id maybe?