### PR TITLE
Fix corner-case issues involving memory accesses in the dr_flac, mp3, and wav codecs

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -52,8 +52,8 @@ using track_const_iter = vector<CDROM_Interface_Image::Track>::const_iterator;
 using tracks_size_t    = vector<CDROM_Interface_Image::Track>::size_type;
 
 CDROM_Interface_Image::BinaryFile::BinaryFile(const char *filename, bool &error)
-                                  :TrackFile(BYTES_PER_RAW_REDBOOK_FRAME),
-                                   file(nullptr)
+	: TrackFile(BYTES_PER_RAW_REDBOOK_FRAME),
+	  file(nullptr)
 {
 	file = new ifstream(filename, ios::in | ios::binary);
 	error = (file == nullptr) || (file->fail());
@@ -117,8 +117,8 @@ Bit32u CDROM_Interface_Image::BinaryFile::decode(Bit16s *buffer, Bit32u desired_
 }
 
 CDROM_Interface_Image::AudioFile::AudioFile(const char *filename, bool &error)
-                                 :TrackFile(4096),
-                                  sample(nullptr)
+	: TrackFile(4096),
+	  sample(nullptr)
 {
 	// Use the audio file's actual sample rate and number of channels as opposed to overriding
 	Sound_AudioInfo desired = {AUDIO_S16, 0, 0};
@@ -131,7 +131,7 @@ CDROM_Interface_Image::AudioFile::AudioFile(const char *filename, bool &error)
 		        filename_only.c_str(),
 		        getRate(),
 		        getChannels(),
-		        getLength()/static_cast<float>(REDBOOK_PCM_BYTES_PER_MS * 1000 * 60));
+		        getLength()/static_cast<double>(REDBOOK_PCM_BYTES_PER_MS * 1000 * 60));
 	} else {
 		error = true;
 	}
@@ -215,7 +215,9 @@ CDROM_Interface_Image::imagePlayer CDROM_Interface_Image::player = {
 };
 
 CDROM_Interface_Image::CDROM_Interface_Image(Bit8u _subUnit)
-		      :subUnit(_subUnit)
+	: tracks({}),
+	  mcn(""),
+	  subUnit(_subUnit)
 {
 	images[subUnit] = this;
 	if (refCount == 0) {

--- a/src/libs/decoders/dr_flac.h
+++ b/src/libs/decoders/dr_flac.h
@@ -1,6 +1,6 @@
 /*
 FLAC audio decoder. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_flac - v0.12.2 - 2019-10-07
+dr_flac - v0.12.3 - 2019-12-02
 
 David Reid - mackron@gmail.com
 */
@@ -555,11 +555,14 @@ typedef struct
 {
     /*
     If the stream uses variable block sizes, this will be set to the index of the first PCM frame. If fixed block sizes are used, this will
-    always be set to 0.
+    always be set to 0. This is 64-bit because the decoded PCM frame number will be 36 bits.
     */
     drflac_uint64 pcmFrameNumber;
 
-    /* If the stream uses fixed block sizes, this will be set to the frame number. If variable block sizes are used, this will always be 0. */
+    /*
+    If the stream uses fixed block sizes, this will be set to the frame number. If variable block sizes are used, this will always be 0. This
+    is 32-bit because in fixed block sizes, the maximum frame number will be 31 bits.
+    */
     drflac_uint32 flacFrameNumber;
 
     /* The sample rate of this frame. */
@@ -3141,14 +3144,14 @@ static drflac_bool32 drflac__decode_samples_with_residual__rice__scalar_zeroorde
 static drflac_bool32 drflac__decode_samples_with_residual__rice__scalar(drflac_bs* bs, drflac_uint32 bitsPerSample, drflac_uint32 count, drflac_uint8 riceParam, drflac_uint32 order, drflac_int32 shift, const drflac_int32* coefficients, drflac_int32* pSamplesOut)
 {
     drflac_uint32 t[2] = {0x00000000, 0xFFFFFFFF};
-    drflac_uint32 zeroCountPart0;
-    drflac_uint32 zeroCountPart1;
-    drflac_uint32 zeroCountPart2;
-    drflac_uint32 zeroCountPart3;
-    drflac_uint32 riceParamPart0;
-    drflac_uint32 riceParamPart1;
-    drflac_uint32 riceParamPart2;
-    drflac_uint32 riceParamPart3;
+    drflac_uint32 zeroCountPart0 = 0;
+    drflac_uint32 zeroCountPart1 = 0;
+    drflac_uint32 zeroCountPart2 = 0;
+    drflac_uint32 zeroCountPart3 = 0;
+    drflac_uint32 riceParamPart0 = 0;
+    drflac_uint32 riceParamPart1 = 0;
+    drflac_uint32 riceParamPart2 = 0;
+    drflac_uint32 riceParamPart3 = 0;
     drflac_uint32 riceParamMask;
     const drflac_int32* pSamplesOutEnd;
     drflac_uint32 i;
@@ -3316,14 +3319,14 @@ static drflac_bool32 drflac__decode_samples_with_residual__rice__sse41_32(drflac
     drflac_uint32 riceParamMask;
     drflac_int32* pDecodedSamples    = pSamplesOut;
     drflac_int32* pDecodedSamplesEnd = pSamplesOut + (count & ~3);
-    drflac_uint32 zeroCountParts0;
-    drflac_uint32 zeroCountParts1;
-    drflac_uint32 zeroCountParts2;
-    drflac_uint32 zeroCountParts3;
-    drflac_uint32 riceParamParts0;
-    drflac_uint32 riceParamParts1;
-    drflac_uint32 riceParamParts2;
-    drflac_uint32 riceParamParts3;
+    drflac_uint32 zeroCountParts0 = 0;
+    drflac_uint32 zeroCountParts1 = 0;
+    drflac_uint32 zeroCountParts2 = 0;
+    drflac_uint32 zeroCountParts3 = 0;
+    drflac_uint32 riceParamParts0 = 0;
+    drflac_uint32 riceParamParts1 = 0;
+    drflac_uint32 riceParamParts2 = 0;
+    drflac_uint32 riceParamParts3 = 0;
     __m128i coefficients128_0;
     __m128i coefficients128_4;
     __m128i coefficients128_8;
@@ -3521,14 +3524,14 @@ static drflac_bool32 drflac__decode_samples_with_residual__rice__sse41_64(drflac
     drflac_uint32 riceParamMask;
     drflac_int32* pDecodedSamples    = pSamplesOut;
     drflac_int32* pDecodedSamplesEnd = pSamplesOut + (count & ~3);
-    drflac_uint32 zeroCountParts0;
-    drflac_uint32 zeroCountParts1;
-    drflac_uint32 zeroCountParts2;
-    drflac_uint32 zeroCountParts3;
-    drflac_uint32 riceParamParts0;
-    drflac_uint32 riceParamParts1;
-    drflac_uint32 riceParamParts2;
-    drflac_uint32 riceParamParts3;
+    drflac_uint32 zeroCountParts0 = 0;
+    drflac_uint32 zeroCountParts1 = 0;
+    drflac_uint32 zeroCountParts2 = 0;
+    drflac_uint32 zeroCountParts3 = 0;
+    drflac_uint32 riceParamParts0 = 0;
+    drflac_uint32 riceParamParts1 = 0;
+    drflac_uint32 riceParamParts2 = 0;
+    drflac_uint32 riceParamParts3 = 0;
     __m128i coefficients128_0;
     __m128i coefficients128_4;
     __m128i coefficients128_8;
@@ -5078,10 +5081,10 @@ static void drflac__get_pcm_frame_range_of_current_flac_frame(drflac* pFlac, drf
 
     firstPCMFrame = pFlac->currentFLACFrame.header.pcmFrameNumber;
     if (firstPCMFrame == 0) {
-        firstPCMFrame = pFlac->currentFLACFrame.header.flacFrameNumber * pFlac->maxBlockSizeInPCMFrames;
+        firstPCMFrame = ((drflac_uint64)pFlac->currentFLACFrame.header.flacFrameNumber) * pFlac->maxBlockSizeInPCMFrames;
     }
 
-    lastPCMFrame = firstPCMFrame + (pFlac->currentFLACFrame.header.blockSizeInPCMFrames);
+    lastPCMFrame = firstPCMFrame + pFlac->currentFLACFrame.header.blockSizeInPCMFrames;
     if (lastPCMFrame > 0) {
         lastPCMFrame -= 1; /* Needs to be zero based. */
     }
@@ -5349,7 +5352,7 @@ static drflac_bool32 drflac__seek_to_pcm_frame__binary_search_internal(drflac* p
     drflac_uint64 closestSeekOffsetBeforeTargetPCMFrame = byteRangeLo;
     drflac_uint32 seekForwardThreshold = (pFlac->maxBlockSizeInPCMFrames != 0) ? pFlac->maxBlockSizeInPCMFrames*2 : 4096;
 
-    targetByte = byteRangeLo + (drflac_uint64)((pcmFrameIndex - pFlac->currentPCMFrame) * pFlac->channels * pFlac->bitsPerSample/8 * DRFLAC_BINARY_SEARCH_APPROX_COMPRESSION_RATIO);
+    targetByte = byteRangeLo + (drflac_uint64)(((pcmFrameIndex - pFlac->currentPCMFrame) * pFlac->channels * pFlac->bitsPerSample/8.0f) * DRFLAC_BINARY_SEARCH_APPROX_COMPRESSION_RATIO);
     if (targetByte > byteRangeHi) {
         targetByte = byteRangeHi;
     }
@@ -5394,7 +5397,6 @@ static drflac_bool32 drflac__seek_to_pcm_frame__binary_search_internal(drflac* p
                         byteRangeLo = byteRangeHi;
                     }
 
-                    /*targetByte = lastSuccessfulSeekOffset - (drflac_uint64)((pcmRangeLo-pcmFrameIndex) * pFlac->channels * pFlac->bitsPerSample/8 * approxCompressionRatio);*/
                     targetByte = byteRangeLo + ((byteRangeHi - byteRangeLo) / 2);
                     if (targetByte < byteRangeLo) {
                         targetByte = byteRangeLo;
@@ -5415,10 +5417,7 @@ static drflac_bool32 drflac__seek_to_pcm_frame__binary_search_internal(drflac* p
                             byteRangeHi = byteRangeLo;
                         }
 
-                        /*targetByte = byteRangeLo + (drflac_uint64)((pcmFrameIndex-pcmRangeLo) * pFlac->channels * pFlac->bitsPerSample/8 * approxCompressionRatio);*/
-                        targetByte = lastSuccessfulSeekOffset + (drflac_uint64)((pcmFrameIndex-pcmRangeLo) * pFlac->channels * pFlac->bitsPerSample/8 * approxCompressionRatio);
-                        /*targetByte = byteRangeLo + ((byteRangeHi - byteRangeLo) / 2);*/
-
+                        targetByte = lastSuccessfulSeekOffset + (drflac_uint64)(((pcmFrameIndex-pcmRangeLo) * pFlac->channels * pFlac->bitsPerSample/8.0f) * approxCompressionRatio);
                         if (targetByte > byteRangeHi) {
                             targetByte = byteRangeHi;
                         }
@@ -5460,7 +5459,7 @@ static drflac_bool32 drflac__seek_to_pcm_frame__binary_search(drflac* pFlac, drf
     the entire file is included, even though most of the time it'll exceed the end of the actual stream. This is OK as the frame searching logic will handle it.
     */
     byteRangeLo = pFlac->firstFLACFramePosInBytes;
-    byteRangeHi = pFlac->firstFLACFramePosInBytes + (drflac_uint64)(pFlac->totalPCMFrameCount * pFlac->channels * pFlac->bitsPerSample/8);
+    byteRangeHi = pFlac->firstFLACFramePosInBytes + (drflac_uint64)(pFlac->totalPCMFrameCount * pFlac->channels * pFlac->bitsPerSample/8.0f);
 
     return drflac__seek_to_pcm_frame__binary_search_internal(pFlac, pcmFrameIndex, byteRangeLo, byteRangeHi);
 }
@@ -5494,7 +5493,7 @@ static drflac_bool32 drflac__seek_to_pcm_frame__seek_table(drflac* pFlac, drflac
         drflac_uint64 byteRangeLo;
         drflac_uint64 byteRangeHi;
 
-        byteRangeHi = pFlac->firstFLACFramePosInBytes + (drflac_uint64)(pFlac->totalPCMFrameCount * pFlac->channels * pFlac->bitsPerSample/8);
+        byteRangeHi = pFlac->firstFLACFramePosInBytes + (drflac_uint64)(pFlac->totalPCMFrameCount * pFlac->channels * pFlac->bitsPerSample/8.0f);
         byteRangeLo = pFlac->firstFLACFramePosInBytes + pFlac->pSeekpoints[iClosestSeekpoint].flacFrameOffset;
 
         if (iClosestSeekpoint < pFlac->seekpointCount-1) {
@@ -5671,6 +5670,8 @@ static DRFLAC_INLINE void drflac__decode_block_header(drflac_uint32 blockHeader,
 static DRFLAC_INLINE drflac_bool32 drflac__read_and_decode_block_header(drflac_read_proc onRead, void* pUserData, drflac_uint8* isLastBlock, drflac_uint8* blockType, drflac_uint32* blockSize)
 {
     drflac_uint32 blockHeader;
+
+    *blockSize = 0;
     if (onRead(pUserData, &blockHeader, 4) != 4) {
         return DRFLAC_FALSE;
     }
@@ -5780,8 +5781,10 @@ static void* drflac__realloc_from_callbacks(void* p, size_t szNew, size_t szOld,
             return NULL;
         }
 
-        DRFLAC_COPY_MEMORY(p2, p, szOld);
-        pAllocationCallbacks->onFree(p, pAllocationCallbacks->pUserData);
+        if (p != NULL) {
+            DRFLAC_COPY_MEMORY(p2, p, szOld);
+            pAllocationCallbacks->onFree(p, pAllocationCallbacks->pUserData);
+        }
 
         return p2;
     }
@@ -5816,7 +5819,7 @@ drflac_bool32 drflac__read_and_decode_metadata(drflac_read_proc onRead, drflac_s
         drflac_uint8 isLastBlock = 0;
         drflac_uint8 blockType;
         drflac_uint32 blockSize;
-        if (!drflac__read_and_decode_block_header(onRead, pUserData, &isLastBlock, &blockType, &blockSize)) {
+        if (drflac__read_and_decode_block_header(onRead, pUserData, &isLastBlock, &blockType, &blockSize) == DRFLAC_FALSE) {
             return DRFLAC_FALSE;
         }
         runningFilePos += 4;
@@ -6383,6 +6386,16 @@ drflac_result drflac_ogg__read_page_header_after_capture_pattern(drflac_read_pro
         return DRFLAC_END_OF_STREAM;
     }
     *pBytesRead += 23;
+
+    /*
+    It's not actually used, but set the capture pattern to 'OggS' for completeness. Not doing this will cause static analysers to complain about
+    us trying to access uninitialized data. We could alternatively just comment out this member of the drflac_ogg_page_header structure, but I
+    like to have it map to the structure of the underlying data.
+    */
+    pHeader->capturePattern[0] = 'O';
+    pHeader->capturePattern[1] = 'g';
+    pHeader->capturePattern[2] = 'g';
+    pHeader->capturePattern[3] = 'S';
 
     pHeader->structureVersion = data[0];
     pHeader->headerType       = data[1];
@@ -7152,7 +7165,7 @@ drflac_bool32 drflac__init_private(drflac_init_info* pInit, drflac_read_proc onR
     return DRFLAC_FALSE;
 }
 
-void drflac__init_from_info(drflac* pFlac, drflac_init_info* pInit)
+void drflac__init_from_info(drflac* pFlac, const drflac_init_info* pInit)
 {
     DRFLAC_ASSERT(pFlac != NULL);
     DRFLAC_ASSERT(pInit != NULL);
@@ -7280,6 +7293,10 @@ drflac* drflac_open_with_metadata_private(drflac_read_proc onRead, drflac_seek_p
 
 
     pFlac = (drflac*)drflac__malloc_from_callbacks(allocationSize, &allocationCallbacks);
+    if (pFlac == NULL) {
+        return NULL;
+    }
+
     drflac__init_from_info(pFlac, &init);
     pFlac->allocationCallbacks = allocationCallbacks;
     pFlac->pDecodedSamples = (drflac_int32*)drflac_align((size_t)pFlac->pExtraData, DRFLAC_MAX_SIMD_VECTOR_SIZE);
@@ -7313,6 +7330,9 @@ drflac* drflac_open_with_metadata_private(drflac_read_proc onRead, drflac_seek_p
         if (seektablePos != 0) {
             pFlac->seekpointCount = seektableSize / sizeof(*pFlac->pSeekpoints);
             pFlac->pSeekpoints = (drflac_seekpoint*)((drflac_uint8*)pFlac->pDecodedSamples + decodedSamplesAllocationSize);
+
+            DRFLAC_ASSERT(pFlac->bs.onSeek != NULL);
+            DRFLAC_ASSERT(pFlac->bs.onRead != NULL);
 
             /* Seek to the seektable, then just read directly into our seektable buffer. */
             if (pFlac->bs.onSeek(pFlac->bs.pUserData, (int)seektablePos, drflac_seek_origin_start)) {
@@ -10717,6 +10737,14 @@ drflac_bool32 drflac_next_cuesheet_track(drflac_cuesheet_track_iterator* pIter, 
 /*
 REVISION HISTORY
 ================
+v0.12.3 - 2019-12-02
+  - Fix some warnings when compiling with GCC and the -Og flag.
+  - Fix a crash in out-of-memory situations.
+  - Fix potential integer overflow bug.
+  - Fix some static analysis warnings.
+  - Fix a possible crash when using custom memory allocators without a custom realloc() implementation.
+  - Fix a bug with binary search seeking where the bits per sample is not a multiple of 8.
+
 v0.12.2 - 2019-10-07
   - Internal code clean up.
 

--- a/src/libs/decoders/dr_mp3.h
+++ b/src/libs/decoders/dr_mp3.h
@@ -1,6 +1,6 @@
 /*
 MP3 audio decoder. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_mp3 - v0.5.2 - 2019-11-02
+dr_mp3 - v0.5.4 - 2019-12-02
 
 David Reid - mackron@gmail.com
 
@@ -41,11 +41,11 @@ To use the new system, you pass in a pointer to a drmp3_allocation_callbacks obj
     allocationCallbacks.onMalloc  = my_malloc;
     allocationCallbacks.onRealloc = my_realloc;
     allocationCallbacks.onFree    = my_free;
-    drmp3_init_file(&mp3, "my_file.wav", NULL, &allocationCallbacks);
+    drmp3_init_file(&mp3, "my_file.mp3", NULL, &allocationCallbacks);
 
 The advantage of this new system is that it allows you to specify user data which will be passed in to the allocation routines.
 
-Passing in null for the allocation callbacks object will cause dr_wav to use defaults which is the same as DRMP3_MALLOC,
+Passing in null for the allocation callbacks object will cause dr_mp3 to use defaults which is the same as DRMP3_MALLOC,
 DRMP3_REALLOC and DRMP3_FREE and the equivalent of how it worked in previous versions.
 
 Every API that opens a drmp3 object now takes this extra parameter. These include the following:
@@ -2423,8 +2423,10 @@ static void* drmp3__realloc_from_callbacks(void* p, size_t szNew, size_t szOld, 
             return NULL;
         }
 
-        DRMP3_COPY_MEMORY(p2, p, szOld);
-        pAllocationCallbacks->onFree(p, pAllocationCallbacks->pUserData);
+        if (p != NULL) {
+            DRMP3_COPY_MEMORY(p2, p, szOld);
+            pAllocationCallbacks->onFree(p, pAllocationCallbacks->pUserData);
+        }
 
         return p2;
     }
@@ -4007,6 +4009,12 @@ DIFFERENCES BETWEEN minimp3 AND dr_mp3
 /*
 REVISION HISTORY
 ================
+v0.5.4 - 2019-12-02
+  - Fix a possible null pointer dereference when using custom memory allocators for realloc().
+
+v0.5.3 - 2019-11-14
+  - Fix typos in documentation.
+
 v0.5.2 - 2019-11-02
   - Bring up to date with minimp3.
 

--- a/src/libs/decoders/dr_wav.h
+++ b/src/libs/decoders/dr_wav.h
@@ -1,6 +1,6 @@
 /*
 WAV audio loader and writer. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_wav - v0.11.1 - 2019-10-07
+dr_wav - v0.11.2 - 2019-12-02
 
 David Reid - mackron@gmail.com
 */
@@ -1076,6 +1076,20 @@ void drwav_free(void* p, const drwav_allocation_callbacks* pAllocationCallbacks)
     #endif
 #endif
 
+/*
+These limits are used for basic validation when initializing the decoder. If you exceed these limits, first of all: what on Earth are
+you doing?! (Let me know, I'd be curious!) Second, you can adjust these by #define-ing them before the dr_wav implementation.
+*/
+#ifndef DRWAV_MAX_SAMPLE_RATE
+#define DRWAV_MAX_SAMPLE_RATE       384000
+#endif
+#ifndef DRWAV_MAX_CHANNELS
+#define DRWAV_MAX_CHANNELS          256
+#endif
+#ifndef DRWAV_MAX_BITS_PER_SAMPLE
+#define DRWAV_MAX_BITS_PER_SAMPLE   64
+#endif
+
 static const drwav_uint8 drwavGUID_W64_RIFF[16] = {0x72,0x69,0x66,0x66, 0x2E,0x91, 0xCF,0x11, 0xA5,0xD6, 0x28,0xDB,0x04,0xC1,0x00,0x00};    /* 66666972-912E-11CF-A5D6-28DB04C10000 */
 static const drwav_uint8 drwavGUID_W64_WAVE[16] = {0x77,0x61,0x76,0x65, 0xF3,0xAC, 0xD3,0x11, 0x8C,0xD1, 0x00,0xC0,0x4F,0x8E,0xDB,0x8A};    /* 65766177-ACF3-11D3-8CD1-00C04F8EDB8A */
 static const drwav_uint8 drwavGUID_W64_JUNK[16] = {0x6A,0x75,0x6E,0x6B, 0xF3,0xAC, 0xD3,0x11, 0x8C,0xD1, 0x00,0xC0,0x4F,0x8E,0xDB,0x8A};    /* 6B6E756A-ACF3-11D3-8CD1-00C04F8EDB8A */
@@ -1446,8 +1460,10 @@ static void* drwav__realloc_from_callbacks(void* p, size_t szNew, size_t szOld, 
             return NULL;
         }
 
-        DRWAV_COPY_MEMORY(p2, p, szOld);
-        pAllocationCallbacks->onFree(p, pAllocationCallbacks->pUserData);
+        if (p != NULL) {
+            DRWAV_COPY_MEMORY(p2, p, szOld);
+            pAllocationCallbacks->onFree(p, pAllocationCallbacks->pUserData);
+        }
 
         return p2;
     }
@@ -1862,8 +1878,11 @@ drwav_bool32 drwav_init__internal(drwav* pWav, drwav_chunk_proc onChunk, void* p
     }
 
     /* Basic validation. */
-    if (fmt.sampleRate == 0 || fmt.channels == 0 || fmt.bitsPerSample == 0 || fmt.blockAlign == 0) {
-        return DRWAV_FALSE; /* Invalid channel count. Probably an invalid WAV file. */
+    if ((fmt.sampleRate    == 0 || fmt.sampleRate    > DRWAV_MAX_SAMPLE_RATE)     ||
+        (fmt.channels      == 0 || fmt.channels      > DRWAV_MAX_CHANNELS)        ||
+        (fmt.bitsPerSample == 0 || fmt.bitsPerSample > DRWAV_MAX_BITS_PER_SAMPLE) ||
+        fmt.blockAlign == 0) {
+        return DRWAV_FALSE; /* Probably an invalid WAV file. */
     }
 
 
@@ -2926,11 +2945,12 @@ drwav_bool32 drwav_seek_to_pcm_frame(drwav* pWav, drwav_uint64 targetFrameIndex)
 {
     /* Seeking should be compatible with wave files > 2GB. */
 
-    if (pWav->onWrite != NULL) {
-        return DRWAV_FALSE; /* No seeking in write mode. */
+    if (pWav == NULL || pWav->onSeek == NULL) {
+        return DRWAV_FALSE;
     }
 
-    if (pWav == NULL || pWav->onSeek == NULL) {
+    /* No seeking in write mode. */
+    if (pWav->onWrite != NULL) {
         return DRWAV_FALSE;
     }
 
@@ -3060,10 +3080,10 @@ drwav_uint64 drwav_write_pcm_frames_le(drwav* pWav, drwav_uint64 framesToWrite, 
 
     while (bytesToWrite > 0) {
         size_t bytesJustWritten;
-        drwav_uint64 bytesToWriteThisIteration = bytesToWrite;
-        if (bytesToWriteThisIteration > DRWAV_SIZE_MAX) {
-            bytesToWriteThisIteration = DRWAV_SIZE_MAX;
-        }
+        drwav_uint64 bytesToWriteThisIteration;
+
+        bytesToWriteThisIteration = bytesToWrite;
+        DRWAV_ASSERT(bytesToWriteThisIteration <= DRWAV_SIZE_MAX);  /* <-- This is checked above. */
 
         bytesJustWritten = drwav_write_raw(pWav, (size_t)bytesToWriteThisIteration, pRunningData);
         if (bytesJustWritten == 0) {
@@ -3106,9 +3126,7 @@ drwav_uint64 drwav_write_pcm_frames_be(drwav* pWav, drwav_uint64 framesToWrite, 
         drwav_uint64 bytesToWriteThisIteration;
 
         bytesToWriteThisIteration = bytesToWrite;
-        if (bytesToWriteThisIteration > DRWAV_SIZE_MAX) {
-            bytesToWriteThisIteration = DRWAV_SIZE_MAX;
-        }
+        DRWAV_ASSERT(bytesToWriteThisIteration <= DRWAV_SIZE_MAX);  /* <-- This is checked above. */
 
         /*
         WAV files are always little-endian. We need to byte swap on big-endian architectures. Since our input buffer is read-only we need
@@ -3116,8 +3134,8 @@ drwav_uint64 drwav_write_pcm_frames_be(drwav* pWav, drwav_uint64 framesToWrite, 
         */
         sampleCount = sizeof(temp)/bytesPerSample;
 
-        if (bytesToWriteThisIteration > sampleCount*bytesPerSample) {
-            bytesToWriteThisIteration = sampleCount*bytesPerSample;
+        if (bytesToWriteThisIteration > ((drwav_uint64)sampleCount)*bytesPerSample) {
+            bytesToWriteThisIteration = ((drwav_uint64)sampleCount)*bytesPerSample;
         }
 
         DRWAV_COPY_MEMORY(temp, pRunningData, (size_t)bytesToWriteThisIteration);
@@ -5033,6 +5051,12 @@ void drwav_free(void* p, const drwav_allocation_callbacks* pAllocationCallbacks)
 /*
 REVISION HISTORY
 ================
+v0.11.2 - 2019-12-02
+  - Fix a possible crash when using custom memory allocators without a custom realloc() implementation.
+  - Fix an integer overflow bug.
+  - Fix a null pointer dereference bug.
+  - Add limits to sample rate, channels and bits per sample to tighten up some validation.
+
 v0.11.1 - 2019-10-07
   - Internal code clean up.
 

--- a/src/libs/decoders/flac.c
+++ b/src/libs/decoders/flac.c
@@ -91,6 +91,7 @@ static void FLAC_quit(void)
 
 static int FLAC_open(Sound_Sample *sample, const char *ext)
 {
+    (void) ext; // deliberately unused, but present for API compliance
     Sound_SampleInternal *internal = (Sound_SampleInternal *) sample->opaque;
     drflac *dr = drflac_open(flac_read, flac_seek, sample, NULL);
 

--- a/src/libs/decoders/mp3.cpp
+++ b/src/libs/decoders/mp3.cpp
@@ -47,7 +47,7 @@
 static size_t mp3_read(void* const pUserData, void* const pBufferOut, const size_t bytesToRead)
 {
     Uint8* ptr = static_cast<Uint8*>(pBufferOut);
-    Sound_Sample* const sample = static_cast<Sound_Sample* const>(pUserData);
+    Sound_Sample* const sample = static_cast<Sound_Sample*>(pUserData);
     const Sound_SampleInternal* const internal = static_cast<const Sound_SampleInternal*>(sample->opaque);
     SDL_RWops* rwops = internal->rw;
     size_t retval = 0;
@@ -88,7 +88,7 @@ static void MP3_quit(void)
 
 static void MP3_close(Sound_Sample* const sample)
 {
-    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal* const>(sample->opaque);
+    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal*>(sample->opaque);
     mp3_t* p_mp3 = static_cast<mp3_t*>(internal->decoder_private);
     if (p_mp3 != nullptr) {
         if (p_mp3->p_dr != nullptr) {
@@ -103,7 +103,7 @@ static void MP3_close(Sound_Sample* const sample)
 
 static Uint32 MP3_read(Sound_Sample* const sample, void* buffer, Uint32 desired_frames)
 {
-    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal* const>(sample->opaque);
+    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal*>(sample->opaque);
     mp3_t* p_mp3 = static_cast<mp3_t*>(internal->decoder_private);
 
     // LOG_MSG("read-while: num_frames: %u", num_frames);
@@ -114,6 +114,7 @@ static Uint32 MP3_read(Sound_Sample* const sample, void* buffer, Uint32 desired_
 
 static Sint32 MP3_open(Sound_Sample* const sample, const char* const ext)
 {
+    (void) ext; // deliberately unused
     Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal*>(sample->opaque);
     Sint32 result(0); // assume failure until proven otherwise
     mp3_t* p_mp3 = (mp3_t*) SDL_calloc(1, sizeof (mp3_t));
@@ -148,7 +149,7 @@ static Sint32 MP3_open(Sound_Sample* const sample, const char* const ext)
         MP3_close(sample);
     }
 
-    return static_cast<Sint32>(result);
+    return result;
 } /* MP3_open */
 
 static Sint32 MP3_rewind(Sound_Sample* const sample)
@@ -160,7 +161,7 @@ static Sint32 MP3_rewind(Sound_Sample* const sample)
 
 static Sint32 MP3_seek(Sound_Sample* const sample, const Uint32 ms)
 {
-    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal* const>(sample->opaque);
+    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal*>(sample->opaque);
     mp3_t* p_mp3 = static_cast<mp3_t*>(internal->decoder_private);
     const float frames_per_ms = sample->actual.rate / 1000.0f;
     const drmp3_uint64 frame_offset = static_cast<drmp3_uint64>(frames_per_ms) * ms;

--- a/src/libs/decoders/mp3_seek_table.cpp
+++ b/src/libs/decoders/mp3_seek_table.cpp
@@ -102,7 +102,7 @@ using std::ofstream;
 #define FRAMES_PER_SEEK_POINT 7
 
 // Returns the size of a file in bytes (if valid), otherwise 0
-const size_t get_file_size(const char* filename) {
+size_t get_file_size(const char* filename) {
     struct stat stat_buf;
     int rc = stat(filename, &stat_buf);
     return rc == 0 ? stat_buf.st_size : -1;
@@ -119,15 +119,14 @@ const size_t get_file_size(const char* filename) {
 // 1. ID3 tag filler content, which might be boiler plate or all empty
 // 2. Trailing silence or similar zero-PCM content
 //
-const Uint64 calculate_stream_hash(struct SDL_RWops* const context) {
-
+Uint64 calculate_stream_hash(struct SDL_RWops* const context) {
     // Save the current stream position, so we can restore it at the end of the function.
     const Sint64 original_pos = SDL_RWtell(context);
 
     // Seek to the end of the file so we can calculate the stream size.
     SDL_RWseek(context, 0, RW_SEEK_END);
 
-    const Sint32 stream_size = (Sint32) SDL_RWtell(context);
+    const Sint32 stream_size = SDL_RWtell(context);
     if (stream_size <= 0) {
         // LOG_MSG("MP3: get_stream_size returned %d, but should be positive", stream_size);
         return 0;
@@ -175,12 +174,12 @@ const Uint64 calculate_stream_hash(struct SDL_RWops* const context) {
 // This function generates a new seek-table for a given mp3 stream and writes
 // the data to the fast-seek file.
 //
-const Uint64 generate_new_seek_points(const char* filename,
-                                      const Uint64& stream_hash,
-                                      drmp3* const p_dr,
-                                      map<Uint64, vector<drmp3_seek_point_serial> >& seek_points_table,
-                                      map<Uint64, drmp3_uint64>& pcm_frame_count_table,
-                                      vector<drmp3_seek_point_serial>& seek_points_vector) {
+Uint64 generate_new_seek_points(const char* filename,
+                                const Uint64& stream_hash,
+                                drmp3* const p_dr,
+                                map<Uint64, vector<drmp3_seek_point_serial> >& seek_points_table,
+                                map<Uint64, drmp3_uint64>& pcm_frame_count_table,
+                                vector<drmp3_seek_point_serial>& seek_points_vector) {
 
     // Initialize our frame counters with zeros.
     drmp3_uint64 mp3_frame_count(0);
@@ -244,11 +243,11 @@ const Uint64 generate_new_seek_points(const char* filename,
 // This function attempts to fetch a seek-table for a given mp3 stream from the fast-seek file.
 // If anything is amiss then this function fails.
 //
-const Uint64 load_existing_seek_points(const char* filename,
-                                       const Uint64& stream_hash,
-                                       map<Uint64, vector<drmp3_seek_point_serial> >& seek_points_table,
-                                       map<Uint64, drmp3_uint64>& pcm_frame_count_table,
-                                       vector<drmp3_seek_point_serial>& seek_points) {
+Uint64 load_existing_seek_points(const char* filename,
+                                 const Uint64& stream_hash,
+                                 map<Uint64, vector<drmp3_seek_point_serial> >& seek_points_table,
+                                 map<Uint64, drmp3_uint64>& pcm_frame_count_table,
+                                 vector<drmp3_seek_point_serial>& seek_points) {
 
     // The below sentinals sanity check and read the incoming
     // file one-by-one until all the data can be trusted.
@@ -301,7 +300,7 @@ const Uint64 load_existing_seek_points(const char* filename,
 // attempting to read it from the fast-seek file and (if it can't be read for any reason), it
 // calculates new data.  It makes use of the above two functions.
 //
-const Uint64 populate_seek_points(struct SDL_RWops* const context, mp3_t* p_mp3, const char* seektable_filename) {
+Uint64 populate_seek_points(struct SDL_RWops* const context, mp3_t* p_mp3, const char* seektable_filename) {
 
     // Calculate the stream's xxHash value.
     Uint64 stream_hash = calculate_stream_hash(context);

--- a/src/libs/decoders/mp3_seek_table.h
+++ b/src/libs/decoders/mp3_seek_table.h
@@ -54,4 +54,4 @@ struct mp3_t {
     std::vector<drmp3_seek_point_serial> seek_points_vector;
 };
 
-const Uint64 populate_seek_points(struct SDL_RWops* const context, mp3_t* p_mp3, const char* seektable_filename);
+Uint64 populate_seek_points(struct SDL_RWops* const context, mp3_t* p_mp3, const char* seektable_filename);

--- a/src/libs/decoders/opus.c
+++ b/src/libs/decoders/opus.c
@@ -140,6 +140,7 @@ static Sint32 RWops_opus_seek(void* stream, const opus_int64 offset, const Sint3
  */
 static Sint32 RWops_opus_close(void* stream)
 {
+    (void) stream; // deliberately unused, but present for API compliance
     /* SDL closes this for us */
     // return SDL_RWclose((SDL_RWops*)stream);
     return 0;
@@ -188,6 +189,9 @@ static __inline__ void output_opus_info(const OggOpusFile* of, const OpusHead* o
             SNDDBG(("Opus: user comment:     '%s'\n", ot->user_comments[i]));
         }
     }
+#else
+    (void) of; // unused if DEBUG_CHATTER not defined
+    (void) oh; // unused if DEBUG_CHATTER not defined
 #endif
 } /* output_opus_comments */
 
@@ -199,6 +203,7 @@ static __inline__ void output_opus_info(const OggOpusFile* of, const OpusHead* o
  */
 static Sint32 opus_open(Sound_Sample* sample, const char* ext)
 {
+    (void) ext; // deliberately unused, but present for API compliance
     Sint32 rcode;
     Sound_SampleInternal* internal = (Sound_SampleInternal*)sample->opaque;
     OggOpusFile* of = op_open_callbacks(internal->rw, &RWops_opus_callbacks, NULL, 0, &rcode);

--- a/src/libs/decoders/stb_vorbis.h
+++ b/src/libs/decoders/stb_vorbis.h
@@ -601,6 +601,10 @@ enum STBVorbisError
    #undef __forceinline
    #endif
    #define __forceinline
+
+   #ifdef alloca
+   #undef alloca
+   #endif
    #define alloca __builtin_alloca
 #elif !defined(_MSC_VER)
    #if __GNUC__

--- a/src/libs/decoders/vorbis.c
+++ b/src/libs/decoders/vorbis.c
@@ -115,6 +115,7 @@ static void VORBIS_quit(void)
 
 static int VORBIS_open(Sound_Sample *sample, const char *ext)
 {
+    (void) ext; // deliberately unused, but present for API compliance
     Sound_SampleInternal *internal = (Sound_SampleInternal *) sample->opaque;
     SDL_RWops *rw = internal->rw;
     int err = 0;

--- a/src/libs/decoders/wav.c
+++ b/src/libs/decoders/wav.c
@@ -89,6 +89,7 @@ static void WAV_close(Sound_Sample *sample)
 
 static int WAV_open(Sound_Sample *sample, const char *ext)
 {
+    (void) ext; // deliberately unused, but present for API compliance
     Sound_SampleInternal *internal = (Sound_SampleInternal *) sample->opaque;
     drwav* dr = SDL_malloc(sizeof(drwav));
     drwav_result result = drwav_init_ex(dr, wav_read, wav_seek, NULL, sample, NULL, 0, NULL);


### PR DESCRIPTION
Fixes #54.  

Functional change: in dr_flac, an accidental integer division that should have been floating point has been fixed. This now results in better estimated initial seek positions producing faster seek times.



