### PR TITLE
Fix wrong function name in the exception log

### DIFF
--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -319,7 +319,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bit8u di1=0) {
 	case 2:cache_addb(0x66);		//mov word
 	case 4:cache_addb(0x8b);break;	//mov
 	default:
-		IllegalOption("gen_load_host");
+		IllegalOption("gen_mov_host");
 	}
 	cache_addb(0x5+((gr1->index+(di1?4:0))<<3));
 	cache_addd((Bit32u)data);


### PR DESCRIPTION
Bug report: https://sourceforge.net/p/dosbox/bugs/518/

I looked through all other uses of `IllegalOption` function and this was the only such occurence.