### PR TITLE
STB Vorbis: fixes for confirmed-bugs in Coverity Scan results

### DIFF
--- a/src/libs/decoders/stb_vorbis.h
+++ b/src/libs/decoders/stb_vorbis.h
@@ -1333,14 +1333,20 @@ static int STBV_CDECL point_compare(const void *p, const void *q)
 static uint8 get8(vorb *z)
 {
    if (USE_MEMORY(z)) {
-      if (z->stream >= z->stream_end) { z->eof = TRUE; return 0; }
+      if (z->stream >= z->stream_end) {
+          z->eof = TRUE;
+          return 0;
+      }
       return *z->stream++;
    }
 
    #ifdef __SDL_SOUND_INTERNAL__
    {
       uint8 c;
-      if (SDL_RWread(z->rwops, &c, 1, 1) != 1) { z->eof = TRUE; return 0; }
+      if (z->rwops == NULL || SDL_RWread(z->rwops, &c, 1, 1) != 1) {
+          z->eof = TRUE;
+          return 0;
+      }
       return c;
    }
    #endif

--- a/src/libs/decoders/stb_vorbis.h
+++ b/src/libs/decoders/stb_vorbis.h
@@ -2253,7 +2253,7 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                ++class_set;
                #endif
             }
-         } else {
+         } else if (ch > 2) {
             while (pcount < part_read) {
                int z = r->begin + pcount*r->part_size;
                int c_inter = z % ch, p_inter = z/ch;

--- a/src/libs/decoders/stb_vorbis.h
+++ b/src/libs/decoders/stb_vorbis.h
@@ -2213,46 +2213,6 @@ static void decode_residue(vorb *f, float *residue_buffers[], int ch, int n, int
                ++class_set;
                #endif
             }
-         } else if (ch == 1) {
-            while (pcount < part_read) {
-               int z = r->begin + pcount*r->part_size;
-               int c_inter = 0, p_inter = z;
-               if (pass == 0) {
-                  Codebook *c = f->codebooks+r->classbook;
-                  int q;
-                  DECODE(q,f,c);
-                  if (q == EOP) goto done;
-                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-                  part_classdata[0][class_set] = r->classdata[q];
-                  #else
-                  for (i=classwords-1; i >= 0; --i) {
-                     classifications[0][i+pcount] = q % r->classifications;
-                     q /= r->classifications;
-                  }
-                  #endif
-               }
-               for (i=0; i < classwords && pcount < part_read; ++i, ++pcount) {
-                  int z = r->begin + pcount*r->part_size;
-                  #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-                  int c = part_classdata[0][class_set][i];
-                  #else
-                  int c = classifications[0][pcount];
-                  #endif
-                  int b = r->residue_books[c][pass];
-                  if (b >= 0) {
-                     Codebook *book = f->codebooks + b;
-                     if (!codebook_decode_deinterleave_repeat(f, book, residue_buffers, ch, &c_inter, &p_inter, n, r->part_size))
-                        goto done;
-                  } else {
-                     z += r->part_size;
-                     c_inter = 0;
-                     p_inter = z;
-                  }
-               }
-               #ifndef STB_VORBIS_DIVIDES_IN_RESIDUE
-               ++class_set;
-               #endif
-            }
          } else if (ch > 2) {
             while (pcount < part_read) {
                int z = r->begin + pcount*r->part_size;


### PR DESCRIPTION
This PR mirrors the upstream PR here, https://github.com/nothings/stb/pull/854, and consists of three commits. 
- Commit https://github.com/dreamer/dosbox-staging/pull/71/commits/a229467b59297086bbe6dc5141519a90a2b2970c fixes https://github.com/nothings/stb/issues/842
- Commit a384a12 fixes https://github.com/nothings/stb/issues/839
- Commit 517444c prevent a null-dereference in code we added to stb_vorbis to meet the SDL_Sound API.

This will fix some issues in https://github.com/dreamer/dosbox-staging/issues/10. 

Tested and confirmed good with various vorbis encodings including stereo and mono. 

When upstream merges their equivalent PR, we will rebase our stb_vorbis header against it (accepting the upstream changes over those from this earlier PR).