### PR TITLE
Fix unsafe memory operations and warnings in the fatDrive class

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -19,7 +19,9 @@
 #ifndef DOSBOX_BIOS_DISK_H
 #define DOSBOX_BIOS_DISK_H
 
+#include <memory>
 #include <stdio.h>
+#include <vector>
 #ifndef DOSBOX_MEM_H
 #include "mem.h"
 #endif
@@ -55,6 +57,8 @@ public:
 	Bit8u GetBiosType(void);
 	Bit32u getSectSize(void);
 	imageDisk(FILE *imgFile, const char *imgName, Bit32u imgSizeK, bool isHardDisk);
+	imageDisk(const imageDisk&) = delete; // prevent copy
+	imageDisk& operator=(const imageDisk&) = delete; // prevent assignment
 	~imageDisk() { if(diskimg != NULL) { fclose(diskimg); }	};
 
 	bool hardDrive;
@@ -77,8 +81,8 @@ void incrementFDD(void);
 
 #define MAX_DISK_IMAGES (2 + MAX_HDD_IMAGES)
 
-extern imageDisk *imageDiskList[MAX_DISK_IMAGES];
-extern imageDisk *diskSwap[MAX_SWAPPABLE_DISKS];
+extern std::vector<std::unique_ptr<imageDisk>> imageDiskList;
+extern std::vector<std::unique_ptr<imageDisk>> diskSwap;
 extern Bit32s swapPosition;
 extern Bit16u imgDTASeg; /* Real memory location of temporary DTA pointer for fat image disk access */
 extern RealPt imgDTAPtr; /* Real memory location of temporary DTA pointer for fat image disk access */

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -279,7 +279,12 @@ protected:
 
 class DOS_PSP :public MemStruct {
 public:
-	DOS_PSP						(Bit16u segment)		{ SetPt(segment);seg=segment;};
+	DOS_PSP(Bit16u segment)
+		: seg(0)
+	{
+		SetPt(segment);
+		seg = segment;
+	}
 	void	MakeNew				(Bit16u memSize);
 	void	CopyFileTable		(DOS_PSP* srcpsp,bool createchildpsp);
 	Bit16u	FindFreeFileEntry	(void);
@@ -311,32 +316,32 @@ private:
 	#pragma pack(1)
 	#endif
 	struct sPSP {
-		Bit8u	exit[2];			/* CP/M-like exit poimt */
-		Bit16u	next_seg;			/* Segment of first byte beyond memory allocated or program */
-		Bit8u	fill_1;				/* single char fill */
-		Bit8u	far_call;			/* far call opcode */
-		RealPt	cpm_entry;			/* CPM Service Request address*/
-		RealPt	int_22;				/* Terminate Address */
-		RealPt	int_23;				/* Break Address */
-		RealPt	int_24;				/* Critical Error Address */
-		Bit16u	psp_parent;			/* Parent PSP Segment */
-		Bit8u	files[20];			/* File Table - 0xff is unused */
-		Bit16u	environment;		/* Segment of evironment table */
-		RealPt	stack;				/* SS:SP Save point for int 0x21 calls */
-		Bit16u	max_files;			/* Maximum open files */
-		RealPt	file_table;			/* Pointer to File Table PSP:0x18 */
-		RealPt	prev_psp;			/* Pointer to previous PSP */
-		Bit8u interim_flag;
-		Bit8u truename_flag;
-		Bit16u nn_flags;
-		Bit16u dos_version;
-		Bit8u	fill_2[14];			/* Lot's of unused stuff i can't care aboue */
-		Bit8u	service[3];			/* INT 0x21 Service call int 0x21;retf; */
-		Bit8u	fill_3[9];			/* This has some blocks with FCB info */
-		Bit8u	fcb1[16];			/* first FCB */
-		Bit8u	fcb2[16];			/* second FCB */
-		Bit8u	fill_4[4];			/* unused */
-		CommandTail cmdtail;		
+		Bit8u   exit[2];     /* CP/M-like exit poimt */
+		Bit16u  next_seg;    /* Segment of first byte beyond memory allocated or program */
+		Bit8u   fill_1;      /* single char fill */
+		Bit8u   far_call;    /* far call opcode */
+		RealPt  cpm_entry;   /* CPM Service Request address*/
+		RealPt  int_22;      /* Terminate Address */
+		RealPt  int_23;      /* Break Address */
+		RealPt  int_24;      /* Critical Error Address */
+		Bit16u  psp_parent;  /* Parent PSP Segment */
+		Bit8u   files[20];   /* File Table - 0xff is unused */
+		Bit16u  environment; /* Segment of evironment table */
+		RealPt  stack;       /* SS:SP Save point for int 0x21 calls */
+		Bit16u  max_files;   /* Maximum open files */
+		RealPt  file_table;  /* Pointer to File Table PSP:0x18 */
+		RealPt  prev_psp;    /* Pointer to previous PSP */
+		Bit8u   interim_flag;
+		Bit8u   truename_flag;
+		Bit16u  nn_flags;
+		Bit16u  dos_version;
+		Bit8u   fill_2[14];  /* Lot's of unused stuff i can't care aboue */
+		Bit8u   service[3];  /* INT 0x21 Service call int 0x21;retf; */
+		Bit8u   fill_3[9];   /* This has some blocks with FCB info */
+		Bit8u   fcb1[16];    /* first FCB */
+		Bit8u   fcb2[16];    /* second FCB */
+		Bit8u   fill_4[4];   /* unused */
+		CommandTail cmdtail;
 	} GCC_ATTRIBUTE(packed);
 	#ifdef _MSC_VER
 	#pragma pack()
@@ -348,7 +353,12 @@ public:
 
 class DOS_ParamBlock:public MemStruct {
 public:
-	DOS_ParamBlock(PhysPt addr) {pt=addr;}
+	DOS_ParamBlock(PhysPt addr)
+		: exec{0, 0, 0, 0, 0, 0},
+		  overlay{0, 0}
+	{
+		pt = addr;
+	}
 	void Clear(void);
 	void LoadData(void);
 	void SaveData(void);		/* Save it as an exec block */
@@ -376,7 +386,9 @@ public:
 
 class DOS_InfoBlock:public MemStruct {
 public:
-	DOS_InfoBlock			() {};
+	DOS_InfoBlock()
+		: seg(0)
+	{}
 	void SetLocation(Bit16u  seg);
 	void SetFirstMCB(Bit16u _first_mcb);
 	void SetBuffers(Bit16u x,Bit16u y);

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -94,9 +94,11 @@ private:
 
 class DOS_Device : public DOS_File {
 public:
-	DOS_Device(const DOS_Device& orig):DOS_File(orig) {
-		devnum=orig.devnum;
-		open=true;
+	DOS_Device(const DOS_Device& orig)
+		: DOS_File(orig),
+		  devnum(orig.devnum)
+	{
+		open = true;
 	}
 	DOS_Device & operator= (const DOS_Device & orig) {
 		DOS_File::operator=(orig);

--- a/include/mem.h
+++ b/include/mem.h
@@ -85,7 +85,7 @@ static INLINE void host_writed(HostPt off,Bit32u val) {
 #else
 
 static INLINE Bit8u host_readb(HostPt off) {
-	return *(Bit8u *)off;
+	return *off;
 }
 static INLINE Bit16u host_readw(HostPt off) {
 	return *(Bit16u *)off;
@@ -94,7 +94,7 @@ static INLINE Bit32u host_readd(HostPt off) {
 	return *(Bit32u *)off;
 }
 static INLINE void host_writeb(HostPt off,Bit8u val) {
-	*(Bit8u *)(off)=val;
+	*off = val;
 }
 static INLINE void host_writew(HostPt off,Bit16u val) {
 	*(Bit16u *)(off)=val;
@@ -107,7 +107,7 @@ static INLINE void host_writed(HostPt off,Bit32u val) {
 
 
 static INLINE void var_write(Bit8u * var, Bit8u val) {
-	host_writeb((HostPt)var, val);
+	host_writeb(var, val);
 }
 
 static INLINE void var_write(Bit16u * var, Bit16u val) {

--- a/include/programs.h
+++ b/include/programs.h
@@ -68,6 +68,8 @@ private:
 class Program {
 public:
 	Program();
+	Program(const Program&) = delete; // prevent copy
+	Program& operator=(const Program&) = delete; // prevent assignment
 	virtual ~Program(){
 		delete cmd;
 		delete psp;

--- a/include/shell.h
+++ b/include/shell.h
@@ -45,6 +45,8 @@ extern DOS_Shell * first_shell;
 class BatchFile {
 public:
 	BatchFile(DOS_Shell * host,char const* const resolved_name,char const* const entered_name, char const * const cmd_line);
+	BatchFile(const BatchFile&) = delete; // prevent copying
+	BatchFile& operator=(const BatchFile&) = delete; // prevent assignment
 	virtual ~BatchFile();
 	virtual bool ReadLine(char * line);
 	bool Goto(char * where);
@@ -70,7 +72,8 @@ private:
 public:
 
 	DOS_Shell();
-
+	DOS_Shell(const DOS_Shell&) = delete; // prevent copy
+	DOS_Shell& operator=(const DOS_Shell&) = delete; // prevent assignment
 	void Run(void);
 	void RunInternal(void); //for command /C
 /* A load of subfunctions */
@@ -136,7 +139,10 @@ private:
 	bool installed;
 	std::string buf;
 public:
-	AutoexecObject():installed(false){ };
+	AutoexecObject()
+		: installed(false),
+		  buf("")
+	{}
 	void Install(std::string const &in);
 	void InstallBefore(std::string const &in);
 	~AutoexecObject();

--- a/include/support.h
+++ b/include/support.h
@@ -55,6 +55,13 @@ char * safe_strcpy(char (& dst)[N], const char * src) noexcept {
 	return & dst[0];
 }
 
+template<size_t N>
+char * safe_strcat(char (& dst)[N], const char * src) noexcept {
+	const size_t dst_size = sizeof(dst);
+	strncat(dst, src, dst_size - strnlen(dst, dst_size) - 1);
+	return & dst[0];
+}
+
 #define safe_strncpy(a,b,n) do { strncpy((a),(b),(n)-1); (a)[(n)-1] = 0; } while (0)
 
 #ifdef HAVE_STRINGS_H

--- a/include/support.h
+++ b/include/support.h
@@ -57,8 +57,7 @@ char * safe_strcpy(char (& dst)[N], const char * src) noexcept {
 
 template<size_t N>
 char * safe_strcat(char (& dst)[N], const char * src) noexcept {
-	const size_t dst_size = sizeof(dst);
-	strncat(dst, src, dst_size - strnlen(dst, dst_size) - 1);
+	strncat(dst, src, N - strnlen(dst, N) - 1);
 	return & dst[0];
 }
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -69,7 +69,7 @@ static const char* UnmountHelper(char umount) {
 	if (i_drive >= DOS_DRIVES || i_drive < 0)
 		return MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED");
 
-	if (i_drive < MAX_DISK_IMAGES && Drives[i_drive] == NULL && imageDiskList[i_drive] == NULL)
+	if (i_drive < MAX_DISK_IMAGES && Drives[i_drive] == NULL && !imageDiskList[i_drive])
 		return MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED");
 
 	if (i_drive >= MAX_DISK_IMAGES && Drives[i_drive] == NULL)
@@ -89,8 +89,7 @@ static const char* UnmountHelper(char umount) {
 	}
 
 	if (i_drive < MAX_DISK_IMAGES && imageDiskList[i_drive]) {
-		delete imageDiskList[i_drive];
-		imageDiskList[i_drive] = NULL;
+		imageDiskList[i_drive].reset(nullptr);
 	}
 
 	return MSG_Get("PROGRAM_MOUNT_UMOUNT_SUCCESS");
@@ -717,8 +716,7 @@ public:
 				Bit32u rombytesize;
 				FILE *usefile = getFSFile(temp_line.c_str(), &floppysize, &rombytesize);
 				if(usefile != NULL) {
-					if(diskSwap[i] != NULL) delete diskSwap[i];
-					diskSwap[i] = new imageDisk(usefile, temp_line.c_str(), floppysize, false);
+					diskSwap[i].reset(new imageDisk(usefile, temp_line.c_str(), floppysize, false));
 					if (usefile_1==NULL) {
 						usefile_1=usefile;
 						rombytesize_1=rombytesize;
@@ -739,7 +737,7 @@ public:
 
 		swapInDisks();
 
-		if(imageDiskList[drive-65]==NULL) {
+		if(!imageDiskList[drive-65]) {
 			WriteOut(MSG_Get("PROGRAM_BOOT_UNABLE"), drive);
 			return;
 		}
@@ -778,10 +776,7 @@ public:
 							WriteOut(MSG_Get("PROGRAM_BOOT_CART_NO_CMDS"));
 						}
 						for(Bitu dct=0;dct<MAX_SWAPPABLE_DISKS;dct++) {
-							if(diskSwap[dct]!=NULL) {
-								delete diskSwap[dct];
-								diskSwap[dct]=NULL;
-							}
+							diskSwap[dct].reset(nullptr);
 						}
 						//fclose(usefile_1); //delete diskSwap closes the file
 						return;
@@ -810,10 +805,7 @@ public:
 								WriteOut(MSG_Get("PROGRAM_BOOT_CART_NO_CMDS"));
 							}
 							for(Bitu dct=0;dct<MAX_SWAPPABLE_DISKS;dct++) {
-								if(diskSwap[dct]!=NULL) {
-									delete diskSwap[dct];
-									diskSwap[dct]=NULL;
-								}
+								diskSwap[dct].reset(nullptr);
 							}
 							//fclose(usefile_1); //Delete diskSwap closes the file
 							return;
@@ -866,10 +858,7 @@ public:
 
 				//Close cardridges
 				for(Bitu dct=0;dct<MAX_SWAPPABLE_DISKS;dct++) {
-					if(diskSwap[dct]!=NULL) {
-						delete diskSwap[dct];
-						diskSwap[dct]=NULL;
-					}
+					diskSwap[dct].reset(nullptr);
 				}
 
 
@@ -1450,15 +1439,13 @@ public:
 				case 0:
 				case 1:
 					if(!((fatDrive *)newdrive)->loadedDisk->hardDrive) {
-						if(imageDiskList[drive - 'A'] != NULL) delete imageDiskList[drive - 'A'];
-						imageDiskList[drive - 'A'] = ((fatDrive *)newdrive)->loadedDisk;
+						imageDiskList[drive - 'A'].reset(((fatDrive *)newdrive)->loadedDisk.get());
 					}
 					break;
 				case 2:
 				case 3:
 					if(((fatDrive *)newdrive)->loadedDisk->hardDrive) {
-						if(imageDiskList[drive - 'A'] != NULL) delete imageDiskList[drive - 'A'];
-						imageDiskList[drive - 'A'] = ((fatDrive *)newdrive)->loadedDisk;
+						imageDiskList[drive - 'A'].reset(((fatDrive *)newdrive)->loadedDisk.get());
 						updateDPT();
 					}
 					break;
@@ -1534,8 +1521,7 @@ public:
 			imageDisk * newImage = new imageDisk(newDisk, temp_line.c_str(), imagesize, hdd);
 
 			if (hdd) newImage->Set_Geometry(sizes[2],sizes[3],sizes[1],sizes[0]);
-			if(imageDiskList[drive - '0'] != NULL) delete imageDiskList[drive - '0'];
-			imageDiskList[drive - '0'] = newImage;
+			imageDiskList[drive - '0'].reset(newImage);
 			updateDPT();
 			WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"),drive - '0',temp_line.c_str());
 		}

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -204,7 +204,7 @@ char* DOS_Drive_Cache::GetExpandName(const char* path) {
 		// Last Entry = File
 		safe_strcpy(dir, pos+1);
 		(void) GetLongName(dirInfo, dir, sizeof(dir)); // ignore the return code
-		strncat(work, dir, sizeof(work) - strlen(work) - 1);
+		safe_strcat(work, dir);
 	}
 
 	if (*work) {
@@ -790,7 +790,7 @@ bool DOS_Drive_Cache::OpenDir(CFileInfo* dir, const char* expand, Bit16u& id) {
 	// Add "/"
 	char end[2]={CROSS_FILESPLIT,0};
 	if (expandcopy[strlen(expandcopy)-1] != CROSS_FILESPLIT) {
-		strncat(expandcopy, end, sizeof(expandcopy) - strlen(expandcopy) - 1);
+		safe_strcat(expandcopy, end);
 	}
 	// open dir
 	if (dirSearch[id]) {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -746,7 +746,7 @@ fatDrive::fatDrive(const char *sysFilename,
 	}
 
 	diskfile = fopen_wrap(sysFilename, "rb+");
-	if(!diskfile) {
+	if (!diskfile) {
 		created_successfully = false;
 		return;
 	}
@@ -932,8 +932,8 @@ bool fatDrive::AllocationInfo(Bit16u *_bytes_sector, Bit8u *_sectors_cluster, Bi
 		*_total_clusters = 65535;
 	}
 
-	for(i=0;i<CountOfClusters;i++) {
-		if(!getClusterValue(i+2)) {
+	for (i=0; i<CountOfClusters; i++) {
+		if (!getClusterValue(i + 2)) {
 			countFree++;
 		}
 	}

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -20,8 +20,9 @@
 #ifndef _DRIVES_H__
 #define _DRIVES_H__
 
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 #include <sys/types.h>
 #include "dos_system.h"
 #include "shell.h" /* for DOS_Shell */
@@ -152,6 +153,8 @@ class imageDisk;
 class fatDrive : public DOS_Drive {
 public:
 	fatDrive(const char * sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit32u startSector);
+	fatDrive(const fatDrive&) = delete; // prevent copying
+	fatDrive& operator= (const fatDrive&) = delete; // prevent assignment
 	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
 	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u attributes);
 	virtual bool FileUnlink(char * name);
@@ -182,11 +185,9 @@ public:
 	Bit32u getFirstFreeClust(void);
 	bool directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start=0);
 	bool directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum);
-	imageDisk *loadedDisk;
+	std::unique_ptr<imageDisk> loadedDisk;
 	bool created_successfully;
 private:
-	fatDrive(const fatDrive&); // prevent copying
-	fatDrive& operator= (const fatDrive&); // prevent assignment
 	Bit32u getClusterValue(Bit32u clustNum);
 	void setClusterValue(Bit32u clustNum, Bit32u clustValue);
 	Bit32u getClustFirstSect(Bit32u clustNum);


### PR DESCRIPTION
- Move imageDiskList and swapDisks from pointer arrays to vectors of unique_ptrs
- Replace string operations with size-limited versions
- Initialize members
- Eliminate unnecessary casts
- Eliminate memory-leak on pointer assignment
- Fix issues in headers that drive_fat.cpp depends on (mostly warnings)
