### PR TITLE
Only checkout the target branch

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - run:  sudo apt-get update
       - name: Install pylint
         run:  |
@@ -23,6 +25,8 @@ jobs:
     needs: run_linters
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         run:  sudo apt-get install python3-setuptools $(./scripts/list-build-dependencies.sh -m apt -c gcc)
@@ -63,6 +67,8 @@ jobs:
         compiler: [Clang, GCC]
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,6 +27,8 @@ jobs:
             max_warnings: 150
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         run:  sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt ${{ matrix.conf.flags }})
@@ -44,6 +46,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         run:  sudo apt-get install -y tree $(./scripts/list-build-dependencies.sh -m apt -c gcc)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,8 +46,6 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
       - run:  sudo apt-get update
       - name: Install C++ compiler and libraries
         run:  sudo apt-get install -y tree $(./scripts/list-build-dependencies.sh -m apt -c gcc)

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,8 @@ jobs:
             max_warnings: 277
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name: Install C++ compiler and libraries
         run:  brew install $(./scripts/list-build-dependencies.sh -m brew ${{ matrix.conf.flags}})
       - name: Log environment

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -100,8 +100,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses:  actions/checkout@v1
-        with:
-          fetch-depth: 1
       - name:  Install packages
         shell: pwsh
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,6 +29,8 @@ jobs:
       CHERE_INVOKING: yes
     steps:
       - uses:  actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name:  Get Date
         id:    get-date
         shell: bash
@@ -75,6 +77,8 @@ jobs:
         type: [Debug]
     steps:
       - uses:  actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name:  Install packages
         shell: pwsh
         run: |
@@ -96,6 +100,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses:  actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name:  Install packages
         shell: pwsh
         run: |


### PR DESCRIPTION
This change applies `--depth 1` to all our workflow git checkouts, cutting the checkout time roughly in half.  Justification: our repo has a long SVN history and we're not switching branches mid-build so we only ever want the current branch. 

There were 9 checkouts performed across our `push` workflows, so this cuts about 90 seconds off that combined. Albiet spread across parallel jobs, so we probably won't notice much; but less resource waste is always a good thing :electric_plug:  

**Edit:** interesting.. `--depth 1` is incompatible with the Linux release build. The `autogen.sh` fails with:
```
+ ./autogen.sh
Generating build information using aclocal, autoheader, automake and autoconf
This may take a while ...
configure.ac:12: error: AC_INIT should be called with package and version arguments
(and lots more)
```
https://github.com/dreamer/dosbox-staging/commit/7b959dbfe56b42930583e7969f5844c47e63e40c/checks?check_suite_id=352707330

I've snipped out this change just for this build; all our other targets are `./autogen`'ing and building fine.