### PR TITLE
Add new features to warning counter script

### DIFF
--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -7,7 +7,7 @@
 # pylint: disable=missing-docstring
 
 """
-This script counts all compiler warnings and prints a summary.
+Count all compiler warnings and print a summary.
 
 It returns success to the shell if the number or warnings encountered
 is less than or equal to the desired maximum warnings (default: 0).
@@ -42,11 +42,12 @@ def remove_colors(line):
     return re.sub(ANSI_COLOR_PATTERN, '', line)
 
 
-def count_warning(line, warning_types, warning_files):
+def count_warning(line, warning_types, warning_files, warning_lines):
     line = remove_colors(line)
     match = WARNING_PATTERN.match(line)
     if not match:
         return 0
+    warning_lines.append(line.strip())
     file = match.group(1)
     # line = match.group(2)
     wtype = match.group(3)
@@ -103,16 +104,30 @@ def parse_args():
         action='store_true',
         help='Group warnings by filename.')
 
+    parser.add_argument(
+        '-l', '--list',
+        action='store_true',
+        help='Display sorted list of all warnings.')
+
     return parser.parse_args()
+
 
 def main():
     rcode = 0
     total = 0
     warning_types = {}
     warning_files = {}
+    warning_lines = []
     args = parse_args()
     for line in get_input_lines(args.logfile):
-        total += count_warning(line, warning_types, warning_files)
+        total += count_warning(line,
+                               warning_types,
+                               warning_files,
+                               warning_lines)
+    if args.list:
+        for line in sorted(warning_lines):
+            print(line)
+        print()
     if args.files and warning_files:
         print("Warnings grouped by file:\n")
         print_summary(warning_files)

--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -10,8 +10,11 @@
 This script counts all compiler warnings and prints a summary.
 
 It returns success to the shell if the number or warnings encountered
-is less than or equal to the desired maximum warnings. See --help
-for a description of how to set the maximum.
+is less than or equal to the desired maximum warnings (default: 0).
+
+You can override the default limit with MAX_WARNINGS environment variable or
+using --max-warnings option (see the description of argument in --help for
+details).
 
 note: new compilers include additional flag -fdiagnostics-format=[text|json],
 which could be used instead of parsing using regex, but we want to preserve
@@ -74,8 +77,6 @@ def print_summary(issues):
             text=warning, count=count, field_size=size))
     print()
 
-def to_int(value):
-    return int(value) if value is not None else None
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -86,18 +87,13 @@ def parse_args():
         metavar='LOGFILE',
         help=("Path to the logfile, or use - to read from stdin"))
 
-    max_warnings = to_int(os.getenv('MAX_WARNINGS', None))
+    max_warnings = int(os.getenv('MAX_WARNINGS', '0'))
     parser.add_argument(
         '-m', '--max-warnings',
         type=int,
-        required=not isinstance(max_warnings, int),
         default=max_warnings,
-        help='Defines the maximum number of warnings permitted to exist\n'
-             'in the log file before returning a failure to the shell.\n'
-             'If not provided, the script will attempt to read it from\n'
-             'the MAX_WARNINGS environment variable, which is currently\n'
-             'set to: {}.  If a maximum of -1 is set then success is\n'
-             'always returned to the shell.\n\n'.format(str(max_warnings)))
+        help='Override the maximum number of warnings.\n'
+             'Use value -1 to disable the check.')
 
     return parser.parse_args()
 

--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -74,11 +74,11 @@ def find_longest_name_length(names):
 
 
 def print_summary(issues):
-    summary = list(issues.items())
     size = find_longest_name_length(issues.keys()) + 1
-    for warning, count in sorted(summary, key=lambda x: -x[1]):
+    items = list(issues.items())
+    for name, count in sorted(items, key=lambda x: (x[1], x[0]), reverse=True):
         print('  {text:{field_size}s}: {count}'.format(
-            text=warning, count=count, field_size=size))
+            text=name, count=count, field_size=size))
     print()
 
 


### PR DESCRIPTION
I started using -Weffc++ for my local builds, and better way of summarizing warnings is necessary. Initially I tried to be clever about filtering warnings based on git history, but in practice it didn't work so well. Decided to make it much simpler:

New options:
```
  -f, --files           Group warnings by filename.
  -l, --list            Display sorted list of all warnings.
```
Also made `-m` optional. In practice it looks like this (I skipped 211 intermediary warnings for brevity):
```
$ ./scripts/count-warnings.py -lf build.log 
adlib.cpp:337:15: warning: taking address of packed member of ‘Adlib::RawHeader’ may result in an unaligned pointer value [-Waddress-of-packed-member]
(…)
ymf262.cpp:760:22: warning: comparison of integer expressions of different signedness: ‘int32_t’ {aka ‘int’} and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]

Warnings grouped by file:

  int10_modes.cpp         : 63
  render_templates.h      : 25
  sdl_mapper.cpp          : 24
  int10_vesa.cpp          : 19
  vga_xga.cpp             : 10
  nullmodem.cpp           : 9
  serialport.cpp          : 8
  int10_pal.cpp           : 7
  fmopl.cpp               : 6
  emu.h                   : 6
  directserial.cpp        : 5
  adlib.cpp               : 5
  misc_util.cpp           : 3
  fpu.cpp                 : 2
  ymf262.cpp              : 2
  iohandler.cpp           : 2
  pic.cpp                 : 2
  vga_s3.cpp              : 2
  int10_char.cpp          : 2
  dos_keyboard_layout.cpp : 1
  render.cpp              : 1
  sn76496.cpp             : 1
  hardware.cpp            : 1
  memory.cpp              : 1
  tandy_sound.cpp         : 1
  ipxserver.cpp           : 1
  ipx.cpp                 : 1
  ems.cpp                 : 1
  setup.cpp               : 1
  dosbox.cpp              : 1

Warnings grouped by type:

  switch                   : 72
  format=                  : 67
  unused-function          : 33
  address-of-packed-member : 23
  sign-compare             : 11
  unused-but-set-variable  : 5
  int-in-bool-context      : 2

Total: 213 warnings (out of 0 allowed)

Error: upper limit of allowed warnings is 0
```