### PR TITLE
Avoid libpng 1.2 dependency for Ubuntu releases

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,10 +58,15 @@ jobs:
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo ::set-env name=VERSION::$VERSION
       - name: Build
+        env:
+          FLAGS: -O3 -DNDEBUG -pipe
         run: |
           set -x
           ./autogen.sh
-          ./configure CFLAGS="-O3 -DNDEBUG -pipe" CXXFLAGS="-O3 -DNDEBUG -pipe"
+          ./configure \
+              --disable-screenshots \
+              CFLAGS="$FLAGS" \
+              CXXFLAGS="$FLAGS"
           make -j "$(nproc)"
           strip src/dosbox
       - name: Package


### PR DESCRIPTION
This is a temporary fix for Ubuntu-based distributions. When SDL1 will
be replaced by SDL2, we'll be able to revert this change.

Fixes: #84