### PR TITLE
Fix --enabled-debug on Windows MSYS2

### DIFF
--- a/.github/scripts/shrink-msys2.sh
+++ b/.github/scripts/shrink-msys2.sh
@@ -37,8 +37,9 @@ for dir in /usr /mingw32 /mingw64; do
 	| xargs -0 ./bin/strip.exe --strip-unneeded
 done
 
-# Delete MinGW's share directories
-rm -rf /mingw*/share
+# Delete documentation directories
+rm -rf /mingw*/share/man
+rm -rf /mingw*/share/doc
 
 # This entire script is best-effort, so always return success
 exit 0

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -20,11 +20,9 @@ jobs:
           - name: Linux
             os: ubuntu-latest
             compiler: gcc
-
-        # Disabled temporarily due to https://github.com/dreamer/dosbox-staging/issues/86
-        # - configure_flags:  --enable-debug
-        # - configure_flags:  --enable-debug-heavy
         conf:
+          - configure_flags:  --enable-debug
+          - configure_flags:  --enable-debug=heavy
           - configure_flags:  --enable-alsa-midi
           - configure_flags:  --disable-core-inline
           - configure_flags:  --disable-dynamic-x86
@@ -56,7 +54,7 @@ jobs:
         id:    cache-msys2
         with:
           path: 'C:/tools/msys64'
-          key: msys2-GCC-64-${{ steps.get-date.outputs.date }}-1
+          key: msys2-GCC-64-${{ steps.get-date.outputs.date }}-2
 
       - name:  Install MSYS2 (Windows)
         if:    matrix.system.name == 'Windows' && steps.cache-msys2.outputs.cache-hit != 'true'
@@ -84,6 +82,12 @@ jobs:
         shell: python scripts\msys-bash.py {0}
         run:   scripts/build.sh -c ${{ matrix.system.compiler }} -t debug --bin-path /mingw64/bin ${{ matrix.conf.configure_flags }}
 
-      - name:  Build ${{ matrix.conf.configure_flags }} (non-Windows)
-        if:    matrix.system.name != 'Windows'
+      - name:  Build ${{ matrix.conf.configure_flags }} (macOS)
+        if:    matrix.system.name == 'macOS'
+        run:   |
+          export PKG_CONFIG_PATH="/usr/local/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
+          ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug ${{ matrix.conf.configure_flags }}
+
+      - name:  Build ${{ matrix.conf.configure_flags }} (Linux)
+        if:    matrix.system.name == 'Linux'
         run:   ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug ${{ matrix.conf.configure_flags }}

--- a/INSTALL
+++ b/INSTALL
@@ -23,9 +23,13 @@ Opusfile, by Xiph
 
 Curses (optional)
     If you want to enable the debugger you need a curses library.
-    ncurses should be installed on just about every unix distro.
-    For win32 get pdcurses at https://pdcurses.org/
-    License: Public Domain
+    On Linux, install ncurses-devel via your distro package manager.
+    On macOS, install ncurses via brew or macports.
+    On Windows, install pdcurses at https://pdcurses.org/, or ncurses
+    via package-manager such as pacman within an MSYS2 environment.
+    Licenses:
+      ncurses - MIT License
+      pdcurses - Public Domain
 
 Libpng (optional)
     Needed for the screenshots.

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,9 @@ AC_DEFINE([CONF_BRAND],["staging-git"],[Suffix of the .conf file.])
 AC_PREREQ(2.50)
 AC_CONFIG_SRCDIR(README)
 
+dnl Check for pkg-config
+PKG_PROG_PKG_CONFIG
+
 dnl Detect the canonical host and target build environment
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
@@ -230,38 +233,35 @@ fi
 AC_C_BIGENDIAN
 
 #Features to enable/disable
-AH_TEMPLATE(C_DEBUG,[Define to 1 to enable internal debugger, requires libcurses])
-AH_TEMPLATE(C_HEAVY_DEBUG,[Define to 1 to enable heavy debugging, also have to enable C_DEBUG])
-AC_ARG_ENABLE(debug,AC_HELP_STRING([--enable-debug],[Enable debug mode]),[
-   AC_CHECK_HEADER(curses.h,have_curses_h=yes,)
-   AC_CHECK_LIB(curses, initscr, have_curses_lib=yes, , )
-   AC_CHECK_LIB(ncurses, initscr, have_ncurses_lib=yes, , )
-   AC_CHECK_LIB(pdcurses, initscr, have_pdcurses_lib=yes, , )
-
-   if test x$enable_debug = xno; then
-     AC_MSG_RESULT([Debugger not enabled])
-   elif test x$have_ncurses_lib = xyes -a x$have_curses_h = xyes ; then
-     LIBS="$LIBS -lncurses"
-     AC_DEFINE(C_DEBUG,1)
-     if test x$enable_debug = xheavy ; then 
-       AC_DEFINE(C_HEAVY_DEBUG,1)
-     fi
-   elif test x$have_curses_lib = xyes -a x$have_curses_h = xyes ; then
-     LIBS="$LIBS -lcurses"
-     AC_DEFINE(C_DEBUG,1)
-     if test x$enable_debug = xheavy ; then 
-       AC_DEFINE(C_HEAVY_DEBUG,1)
-     fi
-   elif test x$have_pdcurses_lib = xyes -a x$have_curses_h = xyes ; then
-     LIBS="$LIBS -lpdcurses"
-     AC_DEFINE(C_DEBUG,1)
-     if test x$enable_debug = xheavy ; then 
-       AC_DEFINE(C_HEAVY_DEBUG,1)
-     fi
-   else 
-     AC_MSG_ERROR([Can't find curses, which is required for debug mode])
-   fi
-],)
+AH_TEMPLATE(C_DEBUG,[Define to 1 to enable internal debugger, requires ncurses or pdcurses])
+AH_TEMPLATE(C_HEAVY_DEBUG,[Define to 1 to enable heavy debugging, requires C_DEBUG])
+AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug], [Enable internal debugger]),,)
+AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug=heavy], [Enable internal debugger with heavy debugging]),,)
+if test x$enable_debug = xyes -o x$enable_debug = xheavy; then
+    AC_MSG_NOTICE([debugger was requested, finding curses library ...])
+    PKG_CHECK_MODULES(NCURSES, ncurses, [
+        curses=ncurses
+        LIBS="$LIBS ${NCURSES_LIBS}"
+        CPPFLAGS="$CPPFLAGS ${NCURSES_CFLAGS}"], [
+    PKG_CHECK_MODULES(NCURSESW, ncursesw, [
+        curses=ncursesw
+        LIBS="$LIBS ${NCURSESW_LIBS}"
+        CPPFLAGS="$CPPFLAGS ${NCURSESW_CFLAGS}"], [
+    PKG_CHECK_MODULES(PDCURSES, pdcurses, [
+        curses=pdcurses
+        LIBS="$LIBS ${PDCURSES_LIBS}"
+        CPPFLAGS="$CPPFLAGS ${PDCURSES_CFLAGS}"],[]) ]) ])
+    if test x$enable_debug = xyes; then
+        AC_DEFINE(C_DEBUG,1)
+        AC_MSG_NOTICE([debugger enabled using the $curses library])
+    else
+        AC_DEFINE(C_DEBUG,1)
+        AC_DEFINE(C_HEAVY_DEBUG,1)
+        AC_MSG_NOTICE([debugger with heavy debugging enabled using the $curses library])
+    fi
+elif test empty$enable_debug != empty -a x$enable_debug != xno; then
+    AC_MSG_ERROR(--enable-debug=$enable_debug was requested but the value "$enable_debug" is invalid)
+fi
 
 AH_TEMPLATE(C_CORE_INLINE,[Define to 1 to use inlined memory functions in cpu core])
 AC_ARG_ENABLE(core-inline,AC_HELP_STRING([--disable-core-inline],[Disable inlined memory handling in CPU Core]),,enable_core_inline=yes)


### PR DESCRIPTION
This fixes the prior logic that relies on the (*)curses library and header existing in compiler-derived default locations such as `/usr/include`, and `/usr/lib`. However, if the package manager
happens to not install them there, then they will not be found and the check will fail - such as is the case for ncurses under MSYS2.

This PR makes use of autotools' pkgconfig module to determine the exact, as-installed  include path for the header, any `#define` variables needed by the header (which ncurses uses), and the library path and name.

Four scenarios were tested:

1. `./configure` or `./configure --enable-debug=no` produce:
    (no mention of debugger; configure continues)

2. `./configure --enable-debug=wrong` produces:
    ```
    configure: error: --enable-debug=wrong was requested but the value "wrong" is invalid
    (terminates with exit code 1)
    ```
3. `./configure --enable-debug` produces:

    config.h: `#define C_DEBUG 1`

    With only ncurses library installed:
    ```
    configure: debugger was requested, finding curses library ...
    checking for NCURSES... yes
    configure: debugger enabled using the ncurses library
    ````
    Makefile:
    ```
    CPPFLAGS = ... -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -I/usr/local/ncurses ...
    LIBS = ...  -L/usr/local/ncurses -lncurses -ltinfo ...
    ```
    With only ncursesw installed:
    ```
    configure: debugger was requested, finding curses library ...
    checking for NCURSES... no
    checking for NCURSESW... yes
    configure: debugger enabled using the ncursesw library
    ```
    Makefile:
    ```
    CPPFLAGS = ... -I/opt/ncursesw ...
    LIBS = ... -L/opt/ncursesw -lncursesw ...
    ```
    With only pdcurses isntalled:
    ```
    configure: debugger was requested, finding curses library ...
    checking for NCURSES... no
    checking for NCURSESW... no
    checking for PDCURSES... yes
    configure: debugger enabled using the pdcurses library
    ```

    Makefile:
    ```
    CPPFLAGS = ... -I/usr/local/pdcurses ...
    LIBS = ...  -L/usr/local/pdcurses -lpdcurses -ltinfo ...
    ```

    Without any curses library installed:
    ```
    configure: debugger was requested, finding curses library ...
    checking for NCURSES... no
    checking for NCURSESW... no
    checking for PDCURSES... no
    configure: error: Package requirements were not met:
    <pkg-info prints info about missing package>
    (terminates with exit code 1)
    ```
4. `./configure --enable-debug=heavy` produces same as above, but:

    config.h:
    ```
    #define C_DEBUG 1
    #define C_HEAVY_DEBUG 1
    ```
    The configure message mentions heavy, for example:
    ```
    configure: debugger was requested, finding curses library ...
    checking for NCURSES... yes
    configure: debugger with heavy debugging enabled using the ncurses library
    ```

Fixes #86