### PR TITLE
Prevent double-close bug when unmounting FAT images (floppy and disk)

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1353,6 +1353,7 @@ public:
 			for (i = 0; i < paths.size(); i++) {
 				DOS_Drive* newDrive = new fatDrive(paths[i].c_str(),sizes[0],sizes[1],sizes[2],sizes[3],0);
 				imgDisks.push_back(newDrive);
+
 				if(!(dynamic_cast<fatDrive*>(newDrive))->created_successfully) {
 					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE"));
 					for(ct = 0; ct < imgDisks.size(); ct++) {
@@ -1394,14 +1395,14 @@ public:
 				switch (drive - 'A') {
 				case 0:
 				case 1:
-					if (!((fatDrive *)newdrive)->loadedDisk->hardDrive) {
-						imageDiskList[drive - 'A'].reset(((fatDrive *)newdrive)->loadedDisk.get());
+					if (!((fatDrive *)newdrive)->getLoadedDisk()->hardDrive) {
+						imageDiskList[drive - 'A'].reset(((fatDrive *)newdrive)->handOffLoadedDisk());
 					}
 					break;
 				case 2:
 				case 3:
-					if (((fatDrive *)newdrive)->loadedDisk->hardDrive) {
-						imageDiskList[drive - 'A'].reset(((fatDrive *)newdrive)->loadedDisk.get());
+					if (((fatDrive *)newdrive)->getLoadedDisk()->hardDrive) {
+						imageDiskList[drive - 'A'].reset(((fatDrive *)newdrive)->handOffLoadedDisk());
 						updateDPT();
 					}
 					break;

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -153,6 +153,8 @@ class imageDisk;
 class fatDrive : public DOS_Drive {
 public:
 	fatDrive(const char * sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit32u startSector);
+	~fatDrive();
+	fatDrive() = delete; // prevent default construction
 	fatDrive(const fatDrive&) = delete; // prevent copying
 	fatDrive& operator= (const fatDrive&) = delete; // prevent assignment
 	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
@@ -172,7 +174,7 @@ public:
 	virtual bool isRemote(void);
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
-public:
+
 	Bit8u readSector(Bit32u sectnum, void * data);
 	Bit8u writeSector(Bit32u sectnum, void * data);
 	Bit32u getAbsoluteSectFromBytePos(Bit32u startClustNum, Bit32u bytePos);
@@ -185,7 +187,8 @@ public:
 	Bit32u getFirstFreeClust(void);
 	bool directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start=0);
 	bool directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum);
-	std::unique_ptr<imageDisk> loadedDisk;
+	imageDisk* handOffLoadedDisk();
+	const imageDisk* getLoadedDisk() const;
 	bool created_successfully;
 private:
 	Bit32u getClusterValue(Bit32u clustNum);
@@ -211,6 +214,8 @@ private:
 	} allocation;
 	
 	bootstrap bootbuffer;
+	imageDisk* loadedDisk;
+	bool responsibleForLoadedDisk;
 	bool absolute;
 	Bit8u fattype;
 	Bit32u CountOfClusters;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -199,14 +199,15 @@ Bit8u imageDisk::Write_AbsoluteSector(Bit32u sectnum, void *data) {
 
 }
 
-imageDisk::imageDisk(FILE *imgFile, const char *imgName, Bit32u imgSizeK, bool isHardDisk) {
+imageDisk::imageDisk(FILE *imgFile, const char *imgName, Bit32u imgSizeK, bool isHardDisk)
+	: diskimg(imgFile)
+{
 	heads = 0;
 	cylinders = 0;
 	sectors = 0;
 	sector_size = 512;
 	current_fpos = 0;
 	last_action = NONE;
-	diskimg = imgFile;
 	fseek(diskimg,0,SEEK_SET);
 	memset(diskname,0,512);
 	safe_strncpy(diskname, imgName, sizeof(diskname));


### PR DESCRIPTION
@dreamer flagged #94 ; a functional regression caused by adjusting one of the drive classes to use exclusive memory-safe containers, which became incompatible with other (non-adjusted) code.

This PR makes a minimal change to restore the prior behavior without having to ripple more significant changes (or overhaul more classes to using memory-safe containers) throughout the code. 

It also retains the logic that lead to this issue, so it's clear for future refactoring attempts and can be thoroughly addressed when safe pointers are used. 