### PR TITLE
Adjust time at which "Config heavy" workflow runs

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,7 +1,7 @@
 name: Config heavy
 on:
   # push
-  schedule: [cron: '15 5 * * *']
+  schedule: [cron: '0 16 * * *']
 
 jobs:
   config_all:


### PR DESCRIPTION
An unfortunately pattern has emerged where Chocolately's repository servers have been offline or returning error-codes at roughly 5am GMT.  

This commit moves the start inside "office hours" for the majority of Chocolatey's user-base:
- 9am in California and Vancouver
- 11am in New York
- 4pm in London
- 5pm in Poland and Germany