### PR TITLE
Improve 'pause' and 'dir' commands

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -358,7 +358,6 @@ void DOS_Shell::Run(void) {
 			if (echo) ShowPrompt();
 			InputCommand(input_line);
 			ParseLine(input_line);
-			if (echo && !bf) WriteOut_NoParsing("\n");
 		}
 	} while (!exit);
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -581,9 +581,9 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_GOTO_LABEL_NOT_FOUND","GOTO: Label %s not found.\n");
 	MSG_Add("SHELL_CMD_FILE_NOT_FOUND","File %s not found.\n");
 	MSG_Add("SHELL_CMD_FILE_EXISTS","File %s already exists.\n");
-	MSG_Add("SHELL_CMD_DIR_INTRO","Directory of %s.\n");
-	MSG_Add("SHELL_CMD_DIR_BYTES_USED","%5d File(s) %17s Bytes.\n");
-	MSG_Add("SHELL_CMD_DIR_BYTES_FREE","%5d Dir(s)  %17s Bytes free.\n");
+	MSG_Add("SHELL_CMD_DIR_INTRO"," Directory of %s\n");
+	MSG_Add("SHELL_CMD_DIR_BYTES_USED","%16d file(s) %17s bytes\n");
+	MSG_Add("SHELL_CMD_DIR_BYTES_FREE","%16d dir(s)  %17s bytes free\n");
 	MSG_Add("SHELL_EXECUTE_DRIVE_NOT_FOUND","Drive %c does not exist!\nYou must \033[31mmount\033[0m it first. Type \033[1;33mintro\033[0m or \033[1;33mintro mount\033[0m for more information.\n");
 	MSG_Add("SHELL_EXECUTE_ILLEGAL_COMMAND","Illegal command: %s.\n");
 	MSG_Add("SHELL_CMD_PAUSE","Press any key to continue...");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -587,7 +587,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_DIR_BYTES_FREE","%5d Dir(s)  %17s Bytes free.\n");
 	MSG_Add("SHELL_EXECUTE_DRIVE_NOT_FOUND","Drive %c does not exist!\nYou must \033[31mmount\033[0m it first. Type \033[1;33mintro\033[0m or \033[1;33mintro mount\033[0m for more information.\n");
 	MSG_Add("SHELL_EXECUTE_ILLEGAL_COMMAND","Illegal command: %s.\n");
-	MSG_Add("SHELL_CMD_PAUSE","Press any key to continue.\n");
+	MSG_Add("SHELL_CMD_PAUSE","Press any key to continue...");
 	MSG_Add("SHELL_CMD_PAUSE_HELP","Waits for 1 keystroke to continue.\n");
 	MSG_Add("SHELL_CMD_COPY_FAILURE","Copy failure : %s.\n");
 	MSG_Add("SHELL_CMD_COPY_SUCCESS","   %d File(s) copied.\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -230,7 +230,8 @@ void DOS_Shell::CMD_HELP(char * args){
 	while (cmd_list[cmd_index].name) {
 		if (optall || !cmd_list[cmd_index].flags) {
 			WriteOut("<\033[34;1m%-8s\033[0m> %s",cmd_list[cmd_index].name,MSG_Get(cmd_list[cmd_index].help));
-			if(!(++write_count%22)) CMD_PAUSE(empty_string);
+			if (!(++write_count % 24))
+				CMD_PAUSE(empty_string);
 		}
 		cmd_index++;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -489,11 +489,9 @@ void DOS_Shell::CMD_DIR(char * args) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
 		return;
 	}
-	Bit32u byte_count,file_count,dir_count;
-	Bitu w_count=0;
-	Bitu p_count=0;
+	Bitu w_count = 0;
+	Bitu p_count = 0;
 	Bitu w_size = optW?5:1;
-	byte_count=file_count=dir_count=0;
 
 	char buffer[CROSS_LEN];
 	args = trim(args);
@@ -529,7 +527,11 @@ void DOS_Shell::CMD_DIR(char * args) {
 		return;
 	}
 	*(strrchr(path,'\\')+1)=0;
-	if (!optB) WriteOut(MSG_Get("SHELL_CMD_DIR_INTRO"),path);
+	if (!optB) {
+		WriteOut(MSG_Get("SHELL_CMD_DIR_INTRO"), path);
+		WriteOut_NoParsing("\n");
+		p_count += 2;
+	}
 
 	/* Command uses dta so set it to our internal dta */
 	RealPt save_dta=dos.dta();
@@ -573,6 +575,10 @@ void DOS_Shell::CMD_DIR(char * args) {
 		std::reverse(results.begin(), results.end());
 	}
 
+	uint32_t byte_count = 0;
+	uint32_t file_count = 0;
+	uint32_t dir_count = 0;
+
 	for (std::vector<DtaResult>::iterator iter = results.begin(); iter != results.end(); iter++) {
 
 		char * name = iter->name;
@@ -586,6 +592,10 @@ void DOS_Shell::CMD_DIR(char * args) {
 			// this overrides pretty much everything
 			if (strcmp(".",name) && strcmp("..",name)) {
 				WriteOut("%s\n",name);
+			} else {
+				// skip to the next file, otherwise this file
+				// will be counted as printed for pause cmd
+				continue;
 			}
 		} else {
 			char * ext = empty_string;
@@ -625,7 +635,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 				w_count++;
 			}
 		}
-		if (optP && !(++p_count%(22*w_size))) {
+		if (optP && !(++p_count % (24 * w_size))) {
 			CMD_PAUSE(empty_string);
 		}
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1047,12 +1047,15 @@ void DOS_Shell::CMD_REM(char * args) {
 	HELP("REM");
 }
 
-void DOS_Shell::CMD_PAUSE(char * args){
+void DOS_Shell::CMD_PAUSE(char *args) {
 	HELP("PAUSE");
 	WriteOut(MSG_Get("SHELL_CMD_PAUSE"));
-	Bit8u c;Bit16u n=1;
-	DOS_ReadFile(STDIN,&c,&n);
-	if (c==0) DOS_ReadFile(STDIN,&c,&n); // read extended key
+	uint8_t c;
+	uint16_t n = 1;
+	DOS_ReadFile(STDIN, &c, &n);
+	if (c == 0)
+		DOS_ReadFile(STDIN, &c, &n); // read extended key
+	WriteOut_NoParsing("\n");
 }
 
 void DOS_Shell::CMD_CALL(char * args){


### PR DESCRIPTION
This solves most of the tiny inconsistencies, that irritate me when I look at dir output (#75).

 I have more improvements lined up (fixing `dir /w /p`, displaying drive label in `dir`, simplifying code and more), but those will work better in another PR.