### PR TITLE
Two more newline fixes and few warning fixes

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,5 +1,6 @@
 name: Code analysis
 on: push
+
 jobs:
 
   run_linters:
@@ -51,7 +52,7 @@ jobs:
           path: report
       - name: Summarize report
         env:
-          MAX_BUGS: 77
+          MAX_BUGS: 76
         run: |
           # summary
           echo "Full report is included in build Artifacts"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,19 +12,19 @@ jobs:
           - name: GCC-5 (Ubuntu 16.04)
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 240
+            max_warnings: 224
           - name: GCC-7 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 243
+            max_warnings: 227
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 266
+            max_warnings: 250
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8
-            max_warnings: 124
+            max_warnings: 121
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,10 +11,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 128
+            max_warnings: 125
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 253
+            max_warnings: 237
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,19 +12,19 @@ jobs:
           - compiler: GCC
             bits: 32
             arch: i686
-            max_warnings: 217
+            max_warnings: 202
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 261
+            max_warnings: 245
           - compiler: Clang
             bits: 32
             arch: i686
-            max_warnings: 90
+            max_warnings: 88
           - compiler: Clang
             bits: 64
             arch: x86_64
-            max_warnings: 130
+            max_warnings: 128
     env:
       CHERE_INVOKING: yes
     steps:

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -709,6 +709,7 @@ void OPL_Write(Bitu port,Bitu val,Bitu iolen) {
 /*
 	Save the current state of the operators as instruments in an reality adlib tracker file
 */
+#if 0
 static void SaveRad() {
 	char b[16 * 1024];
 	int w = 0;
@@ -747,7 +748,7 @@ static void SaveRad() {
 	fwrite( b, 1, w, handle );
 	fclose( handle );
 };
-
+#endif // 0
 
 static void OPL_SaveRawEvent(bool pressed) {
 	if (!pressed)

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -557,10 +557,9 @@ bool INT10_SetVideoMode_OTHER(Bit16u mode,bool clearmem) {
 	IO_WriteW(crtc_base,0x06 | (CurMode->vdispend) << 8);
 	//Vertical sync position
 	IO_WriteW(crtc_base,0x07 | (CurMode->vdispend + ((CurMode->vtotal - CurMode->vdispend)/2)-1) << 8);
-	//Maximum scanline
-	Bit8u scanline,crtpage;
-	scanline=8;
-	switch(CurMode->type) {
+	// Maximum scanline
+	uint8_t scanline;
+	switch (CurMode->type) {
 	case M_TEXT:
 		if (machine==MCH_HERC) scanline=14;
 		else scanline=8;
@@ -575,6 +574,9 @@ bool INT10_SetVideoMode_OTHER(Bit16u mode,bool clearmem) {
 	case M_TANDY16:
 		if (CurMode->mode!=0x9) scanline=2;
 		else scanline=4;
+		break;
+	default:
+		scanline = 8;
 		break;
 	}
 	IO_WriteW(crtc_base,0x09 | (scanline-1) << 8);
@@ -594,6 +596,7 @@ bool INT10_SetVideoMode_OTHER(Bit16u mode,bool clearmem) {
 		0x1a,0x1b,0x0b			//8-a
 	};
 	Bit8u mode_control,color_select;
+	uint8_t crtpage;
 	switch (machine) {
 	case MCH_HERC:
 		IO_WriteB(0x3b8,0x28);	// TEXT mode and blinking characters

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -671,8 +671,11 @@ void Section_prop::PrintData(FILE* outfile) const {
 			len = (*tel)->propname.length();
 	}
 
-	for(const_it tel = properties.begin();tel != properties.end();tel++) {
-		fprintf(outfile,"%-*s = %s\n", len, (*tel)->propname.c_str(), (*tel)->GetValue().ToString().c_str());
+	for (const auto &tel : properties) {
+		fprintf(outfile, "%-*s = %s\n",
+		        static_cast<int>(len),
+		        tel->propname.c_str(),
+		        tel->GetValue().ToString().c_str());
 	}
 }
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -16,22 +16,23 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include "dosbox.h"
 #include "shell.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <string>
+#include <vector>
+
 #include "callback.h"
 #include "regs.h"
 #include "bios.h"
 #include "../dos/drives.h"
 #include "support.h"
 #include "control.h"
-#include <algorithm>
-#include <cstring>
-#include <cctype>
-#include <cstdlib>
-#include <vector>
-#include <string>
-#include <time.h>
 
 static SHELL_Cmd cmd_list[]={
 {	"DIR",		0,			&DOS_Shell::CMD_DIR,		"SHELL_CMD_DIR_HELP"},
@@ -1329,7 +1330,10 @@ void DOS_Shell::CMD_CHOICE(char * args){
 			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
 			return;
 		}
-		if (args == rem) args = strchr(rem,0)+1;
+		if (args == rem) {
+			assert(args);
+			args = strchr(rem, '\0') + 1;
+		}
 		if (rem) rem += 2;
 		if(rem && rem[0]==':') rem++; /* optional : after /c */
 		if (args > last) args = NULL;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1389,11 +1389,10 @@ void DOS_Shell::CMD_PATH(char *args){
 		return;
 	} else {
 		std::string line;
-		if(GetEnvStr("PATH",line)) {
-        		WriteOut("%s",line.c_str());
-		} else {
-			WriteOut("PATH=(null)");
-		}
+		if (GetEnvStr("PATH", line))
+			WriteOut("%s\n", line.c_str());
+		else
+			WriteOut("PATH=(null)\n");
 	}
 }
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1367,7 +1367,8 @@ void DOS_Shell::CMD_CHOICE(char * args){
 		DOS_ReadFile (STDIN,&c,&n);
 	} while (!c || !(ptr = strchr(rem,(optS?c:toupper(c)))));
 	c = optS?c:(Bit8u)toupper(c);
-	DOS_WriteFile (STDOUT,&c, &n);
+	DOS_WriteFile(STDOUT, &c, &n);
+	WriteOut_NoParsing("\n");
 	dos.return_code = (Bit8u)(ptr-rem+1);
 }
 


### PR DESCRIPTION
Turns out `path` and `choice` commands (incorrectly) expected newline to be printed by DOS shell.