### PR TITLE
Move checks from autoconfig to headers and stop silencing MSVC warnings

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -335,17 +335,8 @@ AH_BOTTOM([#if C_ATTRIBUTE_FASTCALL
 #define DB_FASTCALL
 #endif])
 
-
 AH_BOTTOM([#if C_HAS_ATTRIBUTE
 #define GCC_ATTRIBUTE(x) __attribute__ ((x))
 #else
 #define GCC_ATTRIBUTE(x) /* attribute not supported */
-#endif])
-
-AH_BOTTOM([#if C_HAS_BUILTIN_EXPECT
-#define GCC_UNLIKELY(x) __builtin_expect((x),0)
-#define GCC_LIKELY(x) __builtin_expect((x),1)
-#else
-#define GCC_UNLIKELY(x) (x)
-#define GCC_LIKELY(x) (x)
 #endif])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -334,9 +334,3 @@ AH_BOTTOM([#if C_ATTRIBUTE_FASTCALL
 #else
 #define DB_FASTCALL
 #endif])
-
-AH_BOTTOM([#if C_HAS_ATTRIBUTE
-#define GCC_ATTRIBUTE(x) __attribute__ ((x))
-#else
-#define GCC_ATTRIBUTE(x) /* attribute not supported */
-#endif])

--- a/configure.ac
+++ b/configure.ac
@@ -456,18 +456,6 @@ PKG_CHECK_MODULES([OPUSFILE], [opusfile],
   [ LIBS="$LIBS ${OPUSFILE_LIBS}"
     CPPFLAGS="$CPPFLAGS ${OPUSFILE_CFLAGS}" ], [])
 
-AH_TEMPLATE(C_X11_XKB,[define to 1 if you have XKBlib.h and X11 lib])
-AC_CHECK_LIB(X11, main, have_x11_lib=yes, have_x11_lib=no, )
-AC_CHECK_HEADER(X11/XKBlib.h, have_x11_h=yes, have_x11_h=no, )
-AC_MSG_CHECKING(for XKBlib support)
-if test x$have_x11_lib = xyes -a x$have_x11_h = xyes ; then
-   LIBS="$LIBS -lX11"
-   AC_DEFINE(C_X11_XKB,1)
-   AC_MSG_RESULT(yes)
-else
-   AC_MSG_RESULT(no)
-fi
-
 AH_TEMPLATE(C_OPENGL,[Define to 1 to use opengl display output support])
 AC_CHECK_LIB(GL, main, have_gl_lib=yes, have_gl_lib=no , )
 AC_CHECK_LIB(opengl32, main, have_opengl32_lib=yes,have_opengl32_lib=no , )

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,21 +1,22 @@
 noinst_HEADERS =  \
-bios.h \
 bios_disk.h \
+bios.h \
 callback.h \
+compiler.h \
+control.h \
 cpu.h \
 cross.h \
-control.h \
 debug.h \
 dma.h \
+dosbox.h \
 dos_inc.h \
 dos_system.h \
-dosbox.h \
 fpu.h \
 hardware.h \
 inout.h \
-joystick.h \
 ipx.h \
 ipxserver.h \
+joystick.h \
 keyboard.h \
 logging.h \
 mapper.h \
@@ -27,7 +28,6 @@ paging.h \
 pci_bus.h \
 pic.h \
 programs.h \
-render.h \
 regs.h \
 render.h \
 serialport.h \
@@ -35,6 +35,6 @@ setup.h \
 shell.h \
 support.h \
 timer.h \
+types.h \
 vga.h \
 video.h
-

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2019  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_COMPILER_H
+#define DOSBOX_COMPILER_H
+
+// This header wraps compiler-specific features, so they won't need to
+// be hacked into the buildsystem.
+
+// GCC_LIKELY macro is incorrectly named, because other compilers support
+// this feature as well (e.g. Clang, Intel); leave it be for now, at
+// least until full support for C++20 [[likely]] attribute will start arriving
+// in new compilers.
+//
+// Note: '!!' trick is used, to convert non-boolean values to 1 or 0
+// to prevent accidental incorrect usage (e.g. when user wraps macro
+// around a pointer or an integer, expecting usual C semantics).
+
+#if C_HAS_BUILTIN_EXPECT
+#define GCC_LIKELY(x)   __builtin_expect(!!(x), 1)
+#define GCC_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define GCC_LIKELY
+#define GCC_UNLIKELY
+#endif
+
+#endif /* DOSBOX_COMPILER_H */

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -22,6 +22,25 @@
 // This header wraps compiler-specific features, so they won't need to
 // be hacked into the buildsystem.
 
+// Modern C++ compilers have better support for feature testing using GNU
+// extension __has_attribute but C++20 introduces even better alternative:
+// standard-defined __has_cpp_attribute, which will remove the need for
+// defining C_HAS_* macros on a buildsystem level (at some point).
+
+// The __attribute__ syntax is supported by GCC, Clang, and IBM compilers.
+//
+// TODO: C++11 introduces standard syntax for implementation-defined attributes,
+//       it should allow for removal of C_HAS_ATTRIBUTE from the buildsystem.
+//       However, the vast majority of GCC_ATTRIBUTEs in DOSBox code need
+//       to be reviewed, as many of them seem to be incorrectly/unnecessarily
+//       used.
+
+#if C_HAS_ATTRIBUTE
+#define GCC_ATTRIBUTE(x) __attribute__ ((x))
+#else
+#define GCC_ATTRIBUTE(x) /* attribute not supported */
+#endif
+
 // GCC_LIKELY macro is incorrectly named, because other compilers support
 // this feature as well (e.g. Clang, Intel); leave it be for now, at
 // least until full support for C++20 [[likely]] attribute will start arriving

--- a/include/control.h
+++ b/include/control.h
@@ -16,13 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef DOSBOX_CONTROL_H
 #define DOSBOX_CONTROL_H
-
-#ifdef _MSC_VER
-#pragma warning ( disable : 4786 )
-#endif
 
 #ifndef DOSBOX_PROGRAMS_H
 #include "programs.h"

--- a/include/control.h
+++ b/include/control.h
@@ -22,7 +22,6 @@
 
 #ifdef _MSC_VER
 #pragma warning ( disable : 4786 )
-#pragma warning ( disable : 4290 )
 #endif
 
 #ifndef DOSBOX_PROGRAMS_H

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -21,6 +21,7 @@
 #define DOSBOX_DOSBOX_H
 
 #include "config.h"
+#include "compiler.h"
 #include "types.h"
 
 GCC_ATTRIBUTE(noreturn) void E_Exit(const char * message,...) GCC_ATTRIBUTE( __format__(__printf__, 1, 2));

--- a/include/setup.h
+++ b/include/setup.h
@@ -16,14 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef DOSBOX_SETUP_H
 #define DOSBOX_SETUP_H
-
-#ifdef _MSC_VER
-#pragma warning ( disable : 4786 )
-#endif
-
 
 #ifndef CH_LIST
 #define CH_LIST

--- a/include/setup.h
+++ b/include/setup.h
@@ -22,7 +22,6 @@
 
 #ifdef _MSC_VER
 #pragma warning ( disable : 4786 )
-#pragma warning ( disable : 4290 )
 #endif
 
 

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -63,8 +63,6 @@
 /* Define to 1 if you want serial passthrough support. */
 #define C_DIRECTSERIAL 1
 
-#define GCC_ATTRIBUTE(x) /* attribute not supported */
-
 #define INLINE __forceinline
 #define DB_FASTCALL __fastcall
 

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -65,7 +65,3 @@
 
 #define INLINE __forceinline
 #define DB_FASTCALL __fastcall
-
-#if defined(_MSC_VER) && (_MSC_VER >= 1400) 
-#pragma warning(disable : 4996) 
-#endif

--- a/src/platform/visualc/config.h
+++ b/src/platform/visualc/config.h
@@ -64,8 +64,6 @@
 #define C_DIRECTSERIAL 1
 
 #define GCC_ATTRIBUTE(x) /* attribute not supported */
-#define GCC_UNLIKELY(x) (x)
-#define GCC_LIKELY(x) (x)
 
 #define INLINE __forceinline
 #define DB_FASTCALL __fastcall


### PR DESCRIPTION
Detailed descriptions and motivation are mentioned in every commit or included in comments, but overall this is part of the preparation for sunsetting autoconf.

These changes have two larger implications:

## Fixes usage of 'likely' macros throughout the code

This is done via introducing `!!` trick in `GCC_LIKELY`, `GCC_UNLIKELY` macro. Majority of uses throughout code were correct already, but not all of them. Whenever an author wrote a code like this:
```
if (GCC_LIKELY(pointer)) { … }
```
instead of
```
if (GCC_LIKELY(pointer != nullptr)) { … }
```
it would result in opposite effect to expected (because of how `__builtin_expect` works).

I just copied kernel definitions of these macros, which converts wrapped value to `1` or `0`, which makes it work according to the expectations of C/C++ programmers.

In testing I saw no real difference - I benchmarked Quake 1 and saw ~1FPS improvement (<1% difference), but it might've been just a fluke.

## No more silencing of warning via #pragma for MSVC

This brings-in ~700 warnings (only for MSVC builds), but almost all of them result from deprecated defintions in macros (usually security warnings around `strcpy` and such).

We definitely don't want to silence e.g. deprecation warnings, because they inform us about deprecated language features (such as `throw` specifications).