### PR TITLE
Reinstate Coverity scanning

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -2,14 +2,15 @@ name: Coverity Scan
 env:
   COVERITY_EMAIL: ${{ secrets.CoverityEmail }}
   COVERITY_TOKEN: ${{ secrets.CoverityToken }}
+  # Latest package: https://scan.coverity.com/download
   PACKAGE_VERSION: "2019.03"
   TARBALL_SHA256: "0bec2d12e7fca3fe4b6df843d9584e2a58e273970a8549c100541f86dbc0da4e"
   TARBALL_GDRIVE_ID: ${{ secrets.GoogleDriveId }}
 
 on:
-  schedule:
-    # Every day at 415am
-    - cron:  '15 4 * * *'
+  push:
+    branches:
+      - master
 jobs:
   coverity_scan:
     name: Coverity static analyzer


### PR DESCRIPTION
Coverity is back in business!  Open-source jobs are now being processed quickly. 
This PR now runs a scan on-push to the `master` branch. 

The previous nightly cron could "waste" scans when no changes were made; this scan-on-change approach makes better use of Coverity's resources.  It also avoids running scans on other branches, which caused the Coverity badge to be ambiguous and misinformative as to what exactly it was tracking.