### PR TITLE
Fix double-free in destructor of CDROM_Interface_Image

### DIFF
--- a/scripts/automator/build/clang-msys_nt_x86_64
+++ b/scripts/automator/build/clang-msys_nt_x86_64
@@ -2,4 +2,4 @@
 ar="llvm-ar${postfix}"
 ld="llvm-link${postfix}"
 ranlib="llvm-ranlib${postfix}"
-ldflags+=(-static-libgcc -static-libstdc++)
+ldflags+=(-static-libgcc)

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -183,14 +184,14 @@ private:
 public:
 	// Nested struct definition
 	struct Track {
-		TrackFile *file;
-		int       number;
-		int       attr;
-		int       start;
-		int       length;
-		int       skip;
-		int       sectorSize;
-		bool      mode2;
+		std::shared_ptr<TrackFile> file       = nullptr;
+		int                        number     = 0;
+		int                        attr       = 0;
+		int                        start      = 0;
+		int                        length     = 0;
+		int                        skip       = 0;
+		int                        sectorSize = 0;
+		bool                       mode2      = false;
 	};
 	CDROM_Interface_Image           (Bit8u _subUnit);
 	virtual ~CDROM_Interface_Image  (void);

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -230,7 +230,6 @@ private:
 	} player;
 
 	// Private utility functions
-	void  ClearTracks();
 	bool  LoadIsoFile(char *filename);
 	bool  CanReadPVD(TrackFile *file, int sectorSize, bool mode2);
 	std::vector<Track>::iterator GetTrack(int sector);


### PR DESCRIPTION
Unmounting single binary-file CDROM images would result in a
crash as flagged by @dreamer_ in issue #112, who noted that
multiple tracks point to the same TrackFile (track.file field).

During destruction, the pre-C++11 code used a temporary
`TrackFile* last` variable to store the currently deleted
track.file's value and only delete the next track.file if it's
not equal to `last`. The result of this is that only the
first-encountered track.file was deleted and all subsequent
and back-to-back duplicate track.file values were left as-is.

This commit replaces the Track object's 'file' member pointer
with a shared_ptr, which effectively does the same thing by
only deleting the last reference.

The shared_ptr simplifies some error-cases where we previously
had to delete the Track.file allocation, but can now simply
let the Track object go out-of-scope and let the shared_ptr
delete it's managed object (if it has one).

Fixes #112.