### PR TITLE
Add PVS-Studio to our static-analysis workflow

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Upload report
         uses: actions/upload-artifact@master
         with:
-          name: report
+          name: clang-analysis-report
           path: report
       - name: Summarize report
         env:
@@ -65,6 +65,39 @@ jobs:
           echo "Full report is included in build Artifacts"
           echo
           ./scripts/count-bugs.py report/*/index.html
+
+  build_pvs_studio_analyzer:
+    name: PVS-Studio static analyzer
+    runs-on: ubuntu-latest
+    needs: run_linters
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - run:  sudo apt-get update
+      - name: Log environment
+        run:  ./scripts/log-env.sh
+      - name: Install packages
+        run:  |
+          set -xeu
+          wget -nv "https://files.viva64.com/pvs-studio-7.05.35582.25-amd64.deb" -O "pvs.deb" &
+          sudo apt-get install strace $(./scripts/list-build-dependencies.sh -m apt -c gcc)
+          wait && sudo dpkg -i "pvs.deb"
+          pvs-studio-analyzer credentials "${{ secrets.PvsStudioName }}" "${{ secrets.PvsStudioKey }}"
+      - name: Build
+        run:  pvs-studio-analyzer trace -- ./scripts/build.sh -c gcc -t debug
+      - name: Analyze
+        run:  |
+          set -xeu
+          pvs-studio-analyzer analyze -o pvs-analysis.log -j "$(nproc)"
+          plog-converter -a "64:1;OP:1,2,3;CS:1;MISRA:1,2" \
+          -p "dosbox-staging" -v "${GITHUB_SHA:0:8}" -t "fullhtml" \
+          -d "V1042" -o "pvs-analysis-report" "pvs-analysis.log"
+      - name: Upload report
+        uses: actions/upload-artifact@master
+        with:
+          name: pvs-analysis-report
+          path: pvs-analysis-report
 
   dynamic_matrix:
     name: ${{ matrix.compiler }} dynamic sanitizers
@@ -101,5 +134,5 @@ jobs:
       - name: Upload logs
         uses: actions/upload-artifact@master
         with:
-          name: ${{ matrix.compiler }}-logs
+          name: ${{ matrix.compiler }}-sanitizer-logs
           path: ${{ matrix.compiler }}-logs

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,8 +1,6 @@
 name: Code analysis
 on: push
-
 jobs:
-
   run_linters:
     name: Script linters
     runs-on: ubuntu-18.04
@@ -70,19 +68,30 @@ jobs:
     name: PVS-Studio static analyzer
     runs-on: ubuntu-latest
     needs: run_linters
+    env:
+      debfile: pvs-studio-7.05.35582.25-amd64.deb
     steps:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
       - run:  sudo apt-get update
-      - name: Log environment
-        run:  ./scripts/log-env.sh
+      - name: Log and setup environment
+        run:  |
+          ./scripts/log-env.sh
+          mkdir -p pvs-package
+      - uses: actions/cache@v1
+        id: cache-pvs
+        with:
+          path: pvs-package
+          key: ${{ env.debfile }}
+      - name:  Fetch PVS-Studio package
+        if:    steps.cache-pvs.outputs.cache-hit != 'true'
+        run:   wget "https://files.viva64.com/${debfile}" -O "pvs-package/pvs.deb"
       - name: Install packages
         run:  |
           set -xeu
-          wget -nv "https://files.viva64.com/pvs-studio-7.05.35582.25-amd64.deb" -O "pvs.deb" &
           sudo apt-get install strace $(./scripts/list-build-dependencies.sh -m apt -c gcc)
-          wait && sudo dpkg -i "pvs.deb"
+          sudo dpkg -i "pvs-package/pvs.deb"
           pvs-studio-analyzer credentials "${{ secrets.PvsStudioName }}" "${{ secrets.PvsStudioKey }}"
       - name: Build
         run:  pvs-studio-analyzer trace -- ./scripts/build.sh -c gcc -t debug


### PR DESCRIPTION
This PR adds PVS-Studio static analysis to our existing analysis workflow. It's a stand-alone tool and generates a nice HTML report with embedded source snippets (uploaded as a zipped asset). 

It flags errors that appear to be relatively unique versus those reported by Clang's and Coverity's checkers, so it's valuable and interesting in that regard.

Output can be customized in various formats (stdout, gcc-error format, or HTML), and it produces a nice summary of results that (for a later PR) we can capture and compare against a maximum warning count similar to our other checkers.

---

From their website: PVS-Studio is a tool for detecting bugs and security weaknesses in the
source code of programs, written in C, C++, C# and Java. It works under
64-bit systems in Windows, Linux and macOS environments, and can analyze
source code intended for 32-bit, 64-bit and embedded ARM platforms.

https://www.viva64.com/en/pvs-studio/