### PR TITLE
Redefine fileno for Windows

### DIFF
--- a/include/cross.h
+++ b/include/cross.h
@@ -16,18 +16,15 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef DOSBOX_CROSS_H
 #define DOSBOX_CROSS_H
 
-#ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
-#endif
 
-#include <stdio.h>
+#include <cstdio>
+#include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <string>
 
 #if defined (_MSC_VER)						/* MS Visual C++ */
 #include <direct.h>
@@ -56,8 +53,20 @@
 #define CROSS_NONE	0
 #define CROSS_FILE	1
 #define CROSS_DIR	2
+
 #if defined (WIN32)
 #define ftruncate(blah,blah2) chsize(blah,blah2)
+#endif
+
+// fileno is a POSIX function (not mentioned in ISO/C++), which means old
+// versions of various Windows compilers (old MSVC or old MinGW) might be
+// missing it when using C++11; New MSVC issues "deprecation" warning when
+// fileno is used and recommends using (platform-specific) _fileno.
+// Provide our own redefines to avoid this mess.
+#if defined(WIN32)
+#define cross_fileno(s) _fileno(s)
+#else
+#define cross_fileno(s) fileno(s)
 #endif
 
 //Solaris maybe others
@@ -106,4 +115,5 @@ bool read_directory_next(dir_information* dirp, char* entry_name, bool& is_direc
 void close_directory(dir_information* dirp);
 
 FILE *fopen_wrap(const char *path, const char *mode);
+
 #endif

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -457,14 +457,12 @@ bool localFile::Write(Bit8u * data,Bit16u * size) {
 	}
 	if (last_action==READ) fseek(fhandle,ftell(fhandle),SEEK_SET);
 	last_action=WRITE;
-	if(*size==0){  
-        return (!ftruncate(fileno(fhandle),ftell(fhandle)));
-    }
-    else 
-    {
-		*size=(Bit16u)fwrite(data,1,*size,fhandle);
+	if (*size == 0) {
+		return !ftruncate(cross_fileno(fhandle), ftell(fhandle));
+	} else {
+		*size = (Bit16u)fwrite(data, 1, *size, fhandle);
 		return true;
-    }
+	}
 }
 
 bool localFile::Seek(Bit32u * pos,Bit32u type) {
@@ -529,7 +527,7 @@ void localFile::FlagReadOnlyMedium(void) {
 bool localFile::UpdateDateTimeFromHost(void) {
 	if(!open) return false;
 	struct stat temp_stat;
-	fstat(fileno(fhandle),&temp_stat);
+	fstat(cross_fileno(fhandle), &temp_stat);
 	struct tm * ltime;
 	if((ltime=localtime(&temp_stat.st_mtime))!=0) {
 		time=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);


### PR DESCRIPTION
This redefine prevents fake deprecation warning on Windows (C4996) and
prevents a compilation problem when using old MinGW and Windows XP.