### PR TITLE
Run config heavy only if our repo has commits

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,14 +1,12 @@
 name: Config heavy
 on:
-  # push
   schedule: [cron: '0 16 * * *']
-
 jobs:
   config_all:
     name: ${{ matrix.system.name }} ${{ matrix.conf.configure_flags }} ${{ matrix.conf.without_packages }}
     runs-on: ${{ matrix.system.os }}
     strategy:
-      # max-parallel: 1
+      max-parallel: 8
       matrix:
         system:
           - name: Windows
@@ -43,51 +41,75 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check repo for commits
+        id:   repo-meta
+        run:  'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
+
       - name:  Get Date
-        if:    matrix.system.name == 'Windows'
         id:    get-date
+        if:    >
+          matrix.system.name == 'Windows' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         shell: bash
         run:   echo ::set-output name=date::$(date +%Y-%W)
 
       - uses:  actions/cache@v1
-        if:    matrix.system.name == 'Windows'
         id:    cache-msys2
+        if:    >
+          matrix.system.name == 'Windows' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         with:
           path: 'C:/tools/msys64'
           key: msys2-GCC-64-${{ steps.get-date.outputs.date }}-2
 
       - name:  Install MSYS2 (Windows)
-        if:    matrix.system.name == 'Windows' && steps.cache-msys2.outputs.cache-hit != 'true'
+        if:    >
+          matrix.system.name == 'Windows' &&
+          steps.cache-msys2.outputs.cache-hit != 'true' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         run:   choco install msys2 --no-progress
 
       - name:  Install dependencies ${{ matrix.conf.without_packages }} (Windows)
-        if:    matrix.system.name == 'Windows' && steps.cache-msys2.outputs.cache-hit != 'true'
+        if:    >
+          matrix.system.name == 'Windows' &&
+          steps.cache-msys2.outputs.cache-hit != 'true' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         shell: python scripts\msys-bash.py {0}
         run:   |
            scripts/list-build-dependencies.sh -m msys2 -c gcc ${{ matrix.conf.without_packages }} | xargs pacman -S --noconfirm
            .github/scripts/shrink-msys2.sh
 
       - name:  Install dependencies ${{ matrix.conf.without_packages }} (Linux)
-        if:    matrix.system.name == 'Linux'
+        if:    >
+          matrix.system.name == 'Linux' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         run:   |
           sudo apt-get -y update
           sudo apt-get install -y $(./scripts/list-build-dependencies.sh -m apt -c gcc ${{ matrix.conf.without_packages }})
 
       - name:  Install dependencies ${{ matrix.conf.without_packages }} (macOS)
-        if:    matrix.system.name == 'macOS'
+        if:    >
+          matrix.system.name == 'macOS' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         run:   brew install $(./scripts/list-build-dependencies.sh -m brew -c clang ${{ matrix.conf.without_packages }})
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Windows)
-        if:    matrix.system.name == 'Windows'
+        if:    >
+          matrix.system.name == 'Windows' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         shell: python scripts\msys-bash.py {0}
         run:   scripts/build.sh -c ${{ matrix.system.compiler }} -t debug --bin-path /mingw64/bin ${{ matrix.conf.configure_flags }}
 
       - name:  Build ${{ matrix.conf.configure_flags }} (macOS)
-        if:    matrix.system.name == 'macOS'
+        if:    >
+          matrix.system.name == 'macOS' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         run:   |
           export PKG_CONFIG_PATH="/usr/local/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
           ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug ${{ matrix.conf.configure_flags }}
 
       - name:  Build ${{ matrix.conf.configure_flags }} (Linux)
-        if:    matrix.system.name == 'Linux'
+        if:    >
+          matrix.system.name == 'Linux' &&
+          steps.repo-meta.outputs.has-commits == 'true'
         run:   ./scripts/build.sh -c ${{ matrix.system.compiler }} -t debug ${{ matrix.conf.configure_flags }}

--- a/.github/workflows/coverity.md
+++ b/.github/workflows/coverity.md
@@ -1,0 +1,24 @@
+# Steps to Refresh the Coverity Software
+
+1. Every 6 months check <https://scan.coverity.com/download> for
+   a package newer than 2019.03
+1. Download it, extract it, and remove unecessary content:
+
+   ``` shell
+   rm -rf closure-compiler jars jdk11 jre node support-angularjs
+   cd bin
+   rm *java* *js* *php* *python* *ruby*
+   ```
+
+1. Compress and Checksum the archive:
+
+   ``` shell
+   tar -cv cov-analysis-linux64-YYYY-MM | zstd -19 > cov-analysis-linux64-YYYY-MM.tar.zst
+   sha256sum cov-analysis-linux64-YYYY-MM.tar.zst
+   ```
+
+1. Upload it to Google Drive, right-click -> shareable link ->
+   get the ID value from the URL.
+1. Update the `TARBALL_SHA256` and `PACKAGE_VERSION` environment
+   variables in the Workflow YAML.
+1. Update the Repository's secret `GoogleDriveId`.

--- a/scripts/has-commits-since.sh
+++ b/scripts/has-commits-since.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright (C) 2020  Kevin Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# This script indicates if the git repository has had
+# any commits since a given timeframe.
+
+# Usage: ./has-commits-since.sh TIMEFRAME
+# Where TIMEFRAME is provided in git's --since notation
+# Example: ./has-commits-since.sh "24 hours ago"
+
+# The script prints either "true" or "false" indicating
+# if commits were (or weren't) found for the timeframe.
+# The exit code is zero unless the script itself fails.
+
+set -euo pipefail
+
+if [[ "$#" != 1 ]]; then
+	echo "Usage:   $0 TIMEFRAME"
+	echo "Example: $0 \"24 hours ago\""
+	exit 1
+fi
+
+timeframe="${1}"
+commits="$(git --no-pager log --pretty=oneline --since="${timeframe}" | wc -l)"
+
+if [[ "${commits}" -gt "0" ]]; then
+	echo "true"
+else
+	echo "false"
+fi


### PR DESCRIPTION
this PR will check if the repo has had any commits during the prior 24-hour period before running the steps.

This approach uses an `if` conditional in each step, which is less elegant than using job-level `if` conditions, which we will move to when GitHub solves this issue: https://github.com/actions/toolkit/issues/299

This PR also includes a short maintenance doc describing how to update Coverity.