### PR TITLE
Strip trailing white-space as a pre-commit hook

### DIFF
--- a/scripts/git-prehook-whitespace.sh
+++ b/scripts/git-prehook-whitespace.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# A git hook script to find and fix trailing whitespace
+# in your commits. Bypass it with the --no-verify option
+# to git-commit
+#
+# Copyright Oldman <imoldman.com@gmail.com> and contributors:
+#   https://github.com/imoldman/config
+#
+# Add this to a project's pre-hooks using:
+#  git rev-parse --show-toplevel
+#  ln -s ../../scripts/git-prehook-whitespace.sh .git/hooks/pre-commit
+
+set -euo pipefail
+
+# detect platform
+platform="win"
+uname_result="$(uname)"
+if [ "$uname_result" = "Linux" ]; then
+	platform="linux"
+elif [ "$uname_result" = "Darwin" ]; then
+	platform="mac"
+fi
+
+# change IFS to ignore filename's space in |for|
+IFS="
+"
+# autoremove trailing whitespace
+for line in $(git diff --check --cached | sed '/^[+-]/d') ; do
+	# get file name
+	if [ "$platform" = "mac" ]; then
+		file="$(echo "$line" | sed -E 's/:[0-9]+: .*//')"
+	else
+		file="$(echo "$line" | sed -r 's/:[0-9]+: .*//')"
+	fi
+	# display tips
+	echo -e "auto remove trailing whitespace in \\033[31m$file\\033[0m!"
+	# since $file in working directory isn't always equal to $file in index, so we backup it
+	mv -f "$file" "${file}.save"
+	# discard changes in working directory
+	git checkout -- "$file"
+	# remove trailing whitespace
+	if [ "$platform" = "win" ]; then
+		# sed in msys 1.x does not support -i
+		sed 's/[[:space:]]*$//' "$file" > "${file}.bak"
+		mv -f "${file}.bak" "$file"
+	elif [ "$platform" == "mac" ]; then
+		sed -i "" 's/[[:space:]]*$//' "$file"
+	else
+		sed -i 's/[[:space:]]*$//' "$file"
+	fi
+	git add "$file"
+	# restore the $file
+	sed 's/[[:space:]]*$//' "${file}.save" > "$file"
+	rm "${file}.save"
+done
+
+# Now we can commit
+exit


### PR DESCRIPTION
After working on the scripts and markdown files in the coverage PR, I grew tired of my commits failing the `verify-markdown.sh` and `verify-bash.sh` steps with trailing whitespace errors.

This PR adds an (optional) git pre-commit hook that strips trailing whitespace on commit events, and only to 'added' files.

The script comes from the most up-voted answer here: https://stackoverflow.com/a/592014, in the last paragraph:

> You could however build a better pre-commit hook, especially when you consider that:
>> Committing in Git with only some changes added to the staging area still results in an “atomic” revision that may never have existed as a working copy and may not work.

> For instance, oldman proposes in another answer a pre-commit hook which detects and remove whitespace.

I've updated @imoldman's script to comply w/ shellcheck.

Git hooks are not part of the SCM, so each `dosbox-staging` developer can choose to use this or not.  To activate it, run:

``` bash
cd "$(git rev-parse --show-toplevel)"
ln -s ../../scripts/git-prehook-whitespace.sh .git/hooks/pre-commit
```

Here's how it works in action:

![2020-01-12_12-56](https://user-images.githubusercontent.com/1557255/72225637-88f09700-353c-11ea-9723-a60bbc3193e3.png)
