### PR TITLE
Unify Windows installations

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -60,7 +60,7 @@ jobs:
           steps.repo-meta.outputs.has-commits == 'true'
         with:
           path: 'C:/tools/msys64'
-          key: msys2-GCC-64-${{ steps.get-date.outputs.date }}-2
+          key: msys2-64-${{ steps.get-date.outputs.date }}-2
 
       - name:  Install MSYS2 (Windows)
         if:    >
@@ -76,7 +76,7 @@ jobs:
           steps.repo-meta.outputs.has-commits == 'true'
         shell: python scripts\msys-bash.py {0}
         run:   |
-           scripts/list-build-dependencies.sh -m msys2 -c gcc ${{ matrix.conf.without_packages }} | xargs pacman -S --noconfirm
+           scripts/list-build-dependencies.sh -m msys2 -c clang ${{ matrix.conf.without_packages }} | xargs pacman -S --noconfirm
            .github/scripts/shrink-msys2.sh
 
       - name:  Install dependencies ${{ matrix.conf.without_packages }} (Linux)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,7 @@ jobs:
       - name:  Install C++ compiler and libraries
         if:    steps.cache-msys2.outputs.cache-hit != 'true'
         shell: python scripts\msys-bash.py {0}
-        run:   ./scripts/list-build-dependencies.sh -m msys2 -c ${{ matrix.conf.compiler }} -b ${{ matrix.conf.bits }} | xargs pacman -S --noconfirm
+        run:   ./scripts/list-build-dependencies.sh -m msys2 -c clang -b ${{ matrix.conf.bits }} | xargs pacman -S --noconfirm
       - name:  Shrink MSYS2 for cache
         if:    steps.cache-msys2.outputs.cache-hit != 'true'
         shell: python scripts\msys-bash.py {0}


### PR DESCRIPTION
This PR switches the three Windows workflows that previously installed either GCC **_or_** Clang (depending on their build needs) to now _always_ installing Clang, which also happens to install GCC as a dependency.

In doing so, now all of our Windows workflows (regardless if they're building with GCC or Clang) will generate a compatible cache that can be used for either compiler.