### PR TITLE
Set BASH shell in Config Heavy's commit-check

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Check repo for commits
         id:   repo-meta
+        shell: bash
         run:  'echo ::set-output name=has-commits::$(./scripts/has-commits-since.sh "24 hours ago")'
 
       - name:  Get Date


### PR DESCRIPTION
The commit-check step run a bash script however its `shell:`
directive was unset, meaning that under Windows the script
would be executed by PowerShell. This commit fixes this by
explicitly setting `shell: bash`.