### PR TITLE
Disable screenshots in Linux snapshot builds again

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           set -x
           ./autogen.sh
-          ./configure CFLAGS="$FLAGS" CXXFLAGS="$FLAGS"
+          ./configure CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" --disable-screenshots
           make -j "$(nproc)"
           strip src/dosbox
       - name: Package

--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ packages installed via your package manager.
 
 #### Fedora
 
-    sudo dnf install libpng SDL2 SDL2_net opusfile
+    sudo dnf install SDL2 SDL2_net opusfile
 
 #### Debian, Ubuntu
 
-    sudo apt install libpng16-16 libsdl2-2.0 libsdl2-net-2.0 libopusfile0
+    sudo apt install libsdl2-2.0 libsdl2-net-2.0 libopusfile0
 
 #### Arch, Manjaro
 
-    sudo pacman -S libpng sdl2 sdl2_net opusfile
+    sudo pacman -S sdl2 sdl2_net opusfile
 
 ### [Windows](https://github.com/dreamer/dosbox-staging/actions?query=workflow%3A%22Windows+builds%22+is%3Asuccess)
 


### PR DESCRIPTION
Problem with libpng12/libpng16 strikes again - Steam Runtime is missing
libpng16, so users who want to test dosbox-staging via Steam are not
able to start it.

This is the only library, that needs to be disabled - all other
dependencies are included in Steam Runtime and work fine.