### PR TITLE
Use GNU make < 4.x define syntax

### DIFF
--- a/contrib/static-opus/Makefile
+++ b/contrib/static-opus/Makefile
@@ -61,7 +61,7 @@ distclean:
 #  one download fails then we assume they all will and therefore
 #  give the user the full list up-front.
 #
-define download =
+define download
 	echo "Downloading $(URL) to ./$@"                                        \
 	&& $(CURL) "$(URL)" -o "$@"                                              \
 	|| $(WGET) "$(URL)" -O "$@"                                              \
@@ -204,7 +204,7 @@ lib/libopusfile.a: opusfile/Makefile
 	&& cp -v include/*.h ../include/opus \
 	&& cp -v .libs/*.a ../lib
 
-define OPUSFILE_EXPORTS =
+define OPUSFILE_EXPORTS
 
 Export the following to configure DOSBox without pkg-config
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Versions of GNU make prior to 4 do not support `define =` syntax, but do however support `define` without the equals operator.  This commit removes the equals operator to ensure this Makefile is compatible with older versions of GNU make.

Reported and tested on Windows XP-MinGW with GNU make 3.81 by @ant-222 ; thank you!