### PR TITLE
Ignore PVS-Studio false-positives

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Analyze
         run:  |
           set -xeu
-          pvs-studio-analyzer analyze -o pvs-analysis.log -j "$(nproc)"
+          pvs-studio-analyzer analyze -s .pvs-suppress -o pvs-analysis.log -j "$(nproc)"
           criteria="GA:1,2;64:1;OP:1,2,3;CS:1;MISRA:1,2"
           plog-converter -a "${criteria}" -d V1042 -t csv -o pvs-report.csv pvs-analysis.log
           plog-converter -a "${criteria}" -d V1042 -t fullhtml -p dosbox-staging \
@@ -115,7 +115,7 @@ jobs:
           path: pvs-analysis-report
       - name: Summarize report
         env:
-          MAX_BUGS: 356
+          MAX_BUGS: 339
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ make.log
 *.swp
 *.tmp
 
+# PVS static analysis outputs or ephemerals
+pvs-*
+strace_out
+suppress_base.json

--- a/.pvs-suppress
+++ b/.pvs-suppress
@@ -1,0 +1,150 @@
+{
+    "version": 1,
+    "warnings": [
+        {
+            "CodeCurrent": 4109900279,
+            "CodeNext": 355817,
+            "CodePrev": 1212132082,
+            "ErrorCode": "V512",
+            "FileName": "xxhash.c",
+            "Message": "A call of the 'memcpy' function will lead to underflow of the buffer 'statePtr'."
+        },
+        {
+            "CodeCurrent": 4109900279,
+            "CodeNext": 355817,
+            "CodePrev": 1212132082,
+            "ErrorCode": "V512",
+            "FileName": "xxhash.c",
+            "Message": "A call of the 'memcpy' function will lead to underflow of the buffer '& state'."
+        },
+        {
+            "CodeCurrent": 3924832320,
+            "CodeNext": 355817,
+            "CodePrev": 1162686117,
+            "ErrorCode": "V512",
+            "FileName": "xxhash.c",
+            "Message": "A call of the 'memcpy' function will lead to underflow of the buffer 'statePtr'."
+        },
+        {
+            "CodeCurrent": 3924832320,
+            "CodeNext": 355817,
+            "CodePrev": 1162686117,
+            "ErrorCode": "V512",
+            "FileName": "xxhash.c",
+            "Message": "A call of the 'memcpy' function will lead to underflow of the buffer '& state'."
+        },
+        {
+            "CodeCurrent": 2009695132,
+            "CodeNext": 17733,
+            "CodePrev": 3053,
+            "ErrorCode": "V547",
+            "FileName": "dr_flac.h",
+            "Message": "Expression 'result == - _' is always false."
+        },
+        {
+            "CodeCurrent": 297803,
+            "CodeNext": 123,
+            "CodePrev": 100,
+            "ErrorCode": "V1008",
+            "FileName": "dr_mp3.h",
+            "Message": "Consider inspecting the 'for' operator. No more than one iteration of the loop will be performed."
+        },
+        {
+            "CodeCurrent": 2405264725,
+            "CodeNext": 2337,
+            "CodePrev": 3887730028,
+            "ErrorCode": "V547",
+            "FileName": "dr_mp3.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 2405264725,
+            "CodeNext": 2337,
+            "CodePrev": 4148287113,
+            "ErrorCode": "V547",
+            "FileName": "dr_mp3.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 3210175261,
+            "CodeNext": 11069,
+            "CodePrev": 2952291276,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression 'bytesToWrite > (_UL)' is always false."
+        },
+        {
+            "CodeCurrent": 3210175261,
+            "CodeNext": 11069,
+            "CodePrev": 2952291276,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression 'bytesToWrite > (_UL)' is always false."
+        },
+        {
+            "CodeCurrent": 4053293179,
+            "CodeNext": 1281436681,
+            "CodePrev": 1315862117,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 4130149219,
+            "CodeNext": 2064091136,
+            "CodePrev": 1315862117,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 2514112691,
+            "CodeNext": 720070676,
+            "CodePrev": 1315862117,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 4130149219,
+            "CodeNext": 2064091136,
+            "CodePrev": 1315862117,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 2835309445,
+            "CodeNext": 18933961,
+            "CodePrev": 1964014948,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 2835309445,
+            "CodeNext": 18933961,
+            "CodePrev": 2343076287,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 2835309445,
+            "CodeNext": 18933961,
+            "CodePrev": 1964014948,
+            "ErrorCode": "V547",
+            "FileName": "dr_wav.h",
+            "Message": "Expression is always false."
+        },
+        {
+            "CodeCurrent": 2405264725,
+            "CodeNext": 2337,
+            "CodePrev": 3887730028,
+            "ErrorCode": "V547",
+            "FileName": "dr_mp3.h",
+            "Message": "Expression is always false."
+        }
+    ]
+}
+


### PR DESCRIPTION
This adds a `.pvs-suppress` file (in JSON format) of issues deemed as "wont fix" by upstream authors. 

These were originally reported upstream and feedback received from the authors, as follows:
- **dr_libs:** [multiple issues](https://github.com/mackron/dr_libs/issues?q=is%3Aissue+is%3Aclosed+author%3Akrcroft+label%3Awontfix) discussed on 2020-Jan-20
- **xxhash:** https://github.com/Cyan4973/xxHash/issues/292

If/when more are needed:

1. run the PVS commands in the workflow,
2. run `pvs-studio-analyzer suppress pvs-analysis.log` to generate `suppress_base.json`
3. copy-and-paste issues from `suppress_base.json` into `.pvs-suppress`