### PR TITLE
Trigger CI on pull_request event

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,6 +1,8 @@
 name: Code analysis
-on: push
+on: [push, pull_request]
+
 jobs:
+
   run_linters:
     name: Script linters
     runs-on: ubuntu-18.04

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,5 @@
 name: Linux builds
-on: push
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,5 @@
 name: macOS builds
-on: push
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,5 @@
 name: Windows builds
-on: push
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
So far, all our CIs for review were triggered via push event only,
and it doesn' work for users sending PRs from their own forks
(using default GitHub workflow).