### PR TITLE
Use _fileno only with MSVC compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,7 @@ AC_CHECK_SIZEOF(unsigned long)
 AC_CHECK_SIZEOF(unsigned long long)
 AC_CHECK_SIZEOF(int *)
 
-dnl Require compiler with C++11 support, do not use GNU extensions.
-AX_CXX_COMPILE_STDCXX_11(noext, mandatory)
+AX_CXX_COMPILE_STDCXX_11(ext, mandatory)
 
 dnl some semi complex check for sys/socket so it works on darwin as well
 AC_CHECK_HEADERS([stdlib.h sys/types.h])

--- a/include/cross.h
+++ b/include/cross.h
@@ -58,12 +58,13 @@
 #define ftruncate(blah,blah2) chsize(blah,blah2)
 #endif
 
-// fileno is a POSIX function (not mentioned in ISO/C++), which means old
-// versions of various Windows compilers (old MSVC or old MinGW) might be
-// missing it when using C++11; New MSVC issues "deprecation" warning when
-// fileno is used and recommends using (platform-specific) _fileno.
-// Provide our own redefines to avoid this mess.
-#if defined(WIN32)
+// fileno is a POSIX function (not mentioned in ISO/C++), which means it might
+// be missing when when using C++11 with strict ANSI compatibility.
+// New MSVC issues "deprecation" warning when fileno is used and recommends
+// using (platform-specific) _fileno. On other platforms we can use fileno
+// because it's either a POSIX-compliant system, or the function is available
+// when compiling with GNU extensions.
+#if defined (_MSC_VER)
 #define cross_fileno(s) _fileno(s)
 #else
 #define cross_fileno(s) fileno(s)


### PR DESCRIPTION
Function fileno is available in POSIX environment out of the box. On
non-POSIX platforms, it might be missing in some cases when compiling
with -std=c++11, as it's outside of strict ANSI compatibility. We work
around this limitation by switching on GNU extensions.