### PR TITLE
Permit the use of protected game data files

### DIFF
--- a/include/drives.h
+++ b/include/drives.h
@@ -22,6 +22,7 @@
 #include "dosbox.h"
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -75,6 +76,7 @@ public:
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
 	const char* getBasedir() {return basedir;};
+	virtual bool isNewWriteProtectedFile(const std::string& filename);
 protected:
 	char basedir[CROSS_LEN];
 	struct {
@@ -82,6 +84,7 @@ protected:
 	} srchInfo[MAX_OPENDIRS];
 
 private:
+	std::set<std::string> write_protected_files;
 	struct {
 		Bit16u bytes_sector;
 		Bit8u sectors_cluster;

--- a/include/drives.h
+++ b/include/drives.h
@@ -22,7 +22,7 @@
 #include "dosbox.h"
 
 #include <memory>
-#include <set>
+#include <unordered_set>
 #include <string>
 #include <vector>
 
@@ -83,8 +83,8 @@ protected:
 	} srchInfo[MAX_OPENDIRS];
 
 private:
-	virtual bool IsFirstEncounter(const std::string& filename);
-	std::set<std::string> write_protected_files;
+	bool IsFirstEncounter(const std::string& filename);
+	std::unordered_set<std::string> write_protected_files;
 	struct {
 		Bit16u bytes_sector;
 		Bit8u sectors_cluster;

--- a/include/drives.h
+++ b/include/drives.h
@@ -76,7 +76,6 @@ public:
 	virtual bool isRemovable(void);
 	virtual Bits UnMount(void);
 	const char* getBasedir() {return basedir;};
-	virtual bool isNewWriteProtectedFile(const std::string& filename);
 protected:
 	char basedir[CROSS_LEN];
 	struct {
@@ -84,6 +83,7 @@ protected:
 	} srchInfo[MAX_OPENDIRS];
 
 private:
+	virtual bool IsFirstEncounter(const std::string& filename);
 	std::set<std::string> write_protected_files;
 	struct {
 		Bit16u bytes_sector;

--- a/include/drives.h
+++ b/include/drives.h
@@ -217,7 +217,7 @@ private:
 class cdromDrive : public localDrive
 {
 public:
-	cdromDrive(const char driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error);
+	cdromDrive(const char _driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error);
 	virtual bool FileOpen(DOS_File * * file,char * name,Bit32u flags);
 	virtual bool FileCreate(DOS_File * * file,char * name,Bit16u attributes);
 	virtual bool FileUnlink(char * name);

--- a/include/inout.h
+++ b/include/inout.h
@@ -54,7 +54,11 @@ protected:
 	bool installed;
 	Bitu m_port, m_mask,m_range;
 public:
-	IO_Base():installed(false){};
+	IO_Base()
+	: installed(false),
+	  m_port(0),
+	  m_mask(0),
+	  m_range(0) {};
 };
 class IO_ReadHandleObject: private IO_Base{
 public:

--- a/include/inout.h
+++ b/include/inout.h
@@ -58,7 +58,8 @@ public:
 	: installed(false),
 	  m_port(0),
 	  m_mask(0),
-	  m_range(0) {};
+	  m_range(0)
+{}
 };
 class IO_ReadHandleObject: private IO_Base{
 public:

--- a/include/support.h
+++ b/include/support.h
@@ -32,6 +32,8 @@
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
 #endif
 
+std::string get_basename(const std::string& filename);
+
 // Include a message in assert, similar to static_assert:
 #define assertm(exp, msg) assert(((void)msg, exp))
 // Use (void) to silent unused warnings.

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -65,9 +65,9 @@ bool localDrive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/)
 }
 
 bool localDrive::IsFirstEncounter(const std::string& filename) {
-	const std::pair<std::set<std::string>::iterator, bool> \
-		ret(write_protected_files.insert(filename));
-	return ret.second;
+	const auto ret = write_protected_files.insert(filename);
+	const bool was_inserted = ret.second;
+	return was_inserted;
 }
 
 bool localDrive::FileOpen(DOS_File** file, char * name, Bit32u flags) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -42,19 +42,19 @@ bool localDrive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/)
 	bool existing_file = false;
 	
 	FILE * test = fopen_wrap(temp_name,"rb+");
-	if(test) {
+	if (test) {
 		fclose(test);
 		existing_file=true;
 
 	}
 	
 	FILE * hand = fopen_wrap(temp_name,"wb+");
-	if (!hand){
+	if (!hand) {
 		LOG_MSG("Warning: file creation failed: %s",newname);
 		return false;
 	}
    
-	if(!existing_file) dirCache.AddEntry(newname, true);
+	if (!existing_file) dirCache.AddEntry(newname, true);
 	/* Make the 16 bit device information */
 	*file=new localFile(name,hand);
 	(*file)->flags=OPEN_READWRITE;
@@ -62,7 +62,7 @@ bool localDrive::FileCreate(DOS_File * * file,char * name,Bit16u /*attributes*/)
 	return true;
 }
 
-bool localDrive::isNewWriteProtectedFile(const std::string& filename){
+bool localDrive::isNewWriteProtectedFile(const std::string& filename) {
 	const std::pair<std::set<std::string>::iterator, bool> \
 		ret(write_protected_files.insert(filename));
 	return ret.second;
@@ -102,15 +102,16 @@ bool localDrive::FileOpen(DOS_File** file, char * name, Bit32u flags) {
 	}
 
 	FILE* fhandle = fopen(newname, type);
-	// Was the file was opened with the desired type?
+	// Was the file opened with the desired type?
 	if (!fhandle) {
 		// No; but do the requested flags require write-access?
 		if ((flags & 0xf) != OPEN_READ) {
-			// Yes; maybe the local file is simply be protected, so try again with read-only
+			// Yes; then maybe the local file is simply write-protected, so try again.
 			fhandle = fopen_wrap(newname, "rb");
 			if (fhandle) {
-				// Ok! so the file is protected file; fool the DOS program into thinking its OK
+				// Ok! so the file is protected file; update the flags to indicate a normal open.
 				flags &= ~OPEN_READWRITE;
+
 				// Inform the user that the file is being protected against modification.
 				// If the DOS program /really/ needs to write to the file, it will crash/exit
 				// and this will be one of the last messages on the screen, so the user can
@@ -158,27 +159,27 @@ bool localDrive::FileUnlink(char * name) {
 	if (unlink(fullname)) {
 		//Unlink failed for some reason try finding it.
 		struct stat buffer;
-		if(stat(fullname,&buffer)) return false; // File not found.
+		if (stat(fullname,&buffer)) return false; // File not found.
 
 		FILE* file_writable = fopen_wrap(fullname,"rb+");
-		if(!file_writable) return false; //No acces ? ERROR MESSAGE NOT SET. FIXME ?
+		if (!file_writable) return false; //No acces ? ERROR MESSAGE NOT SET. FIXME ?
 		fclose(file_writable);
 
 		//File exists and can technically be deleted, nevertheless it failed.
 		//This means that the file is probably open by some process.
 		//See if We have it open.
 		bool found_file = false;
-		for(Bitu i = 0;i < DOS_FILES;i++){
-			if(Files[i] && Files[i]->IsName(name)) {
+		for (Bitu i = 0;i < DOS_FILES;i++) {
+			if (Files[i] && Files[i]->IsName(name)) {
 				Bitu max = DOS_FILES;
-				while(Files[i]->IsOpen() && max--) {
+				while (Files[i]->IsOpen() && max--) {
 					Files[i]->Close();
 					if (Files[i]->RemoveRef()<=0) break;
 				}
 				found_file=true;
 			}
 		}
-		if(!found_file) return false;
+		if (!found_file) return false;
 		if (!unlink(fullname)) {
 			dirCache.DeleteEntry(newname);
 			return true;
@@ -196,7 +197,7 @@ bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 	strcat(tempDir,_dir);
 	CROSS_FILENAME(tempDir);
 
-	if (allocation.mediaid==0xF0 ) {
+	if (allocation.mediaid==0xF0) {
 		EmptyCache(); //rescan floppie-content on each findfirst
 	}
     
@@ -222,7 +223,7 @@ bool localDrive::FindFirst(char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 		}
 	} else {
 		if (sAttr == DOS_ATTR_VOLUME) {
-			if ( strcmp(dirCache.GetLabel(), "") == 0 ) {
+			if (strcmp(dirCache.GetLabel(), "") == 0) {
 //				LOG(LOG_DOSMISC,LOG_ERROR)("DRIVELABEL REQUESTED: none present, returned  NOLABEL");
 //				dta.SetResult("NO_LABEL",0,0,0,DOS_ATTR_VOLUME);
 //				return true;
@@ -261,7 +262,7 @@ again:
 		DOS_SetError(DOSERR_NO_MORE_FILES);
 		return false;
 	}
-	if(!WildFileCmp(dir_ent,srch_pattern)) goto again;
+	if (!WildFileCmp(dir_ent,srch_pattern)) goto again;
 
 	strcpy(full_name,srchInfo[id].srch_dir);
 	strcat(full_name,dir_ent);
@@ -274,21 +275,21 @@ again:
 		goto again;//No symlinks and such
 	}	
 
-	if(stat_block.st_mode & S_IFDIR) find_attr=DOS_ATTR_DIRECTORY;
+	if (stat_block.st_mode & S_IFDIR) find_attr=DOS_ATTR_DIRECTORY;
 	else find_attr=DOS_ATTR_ARCHIVE;
  	if (~srch_attr & find_attr & (DOS_ATTR_DIRECTORY | DOS_ATTR_HIDDEN | DOS_ATTR_SYSTEM)) goto again;
 	
 	/*file is okay, setup everything to be copied in DTA Block */
 	char find_name[DOS_NAMELENGTH_ASCII];Bit16u find_date,find_time;Bit32u find_size;
 
-	if(strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII){
+	if (strlen(dir_entcopy)<DOS_NAMELENGTH_ASCII) {
 		strcpy(find_name,dir_entcopy);
 		upcase(find_name);
 	} 
 
 	find_size=(Bit32u) stat_block.st_size;
 	struct tm *time;
-	if((time=localtime(&stat_block.st_mtime))!=0){
+	if ((time=localtime(&stat_block.st_mtime))!=0) {
 		find_date=DOS_PackDate((Bit16u)(time->tm_year+1900),(Bit16u)(time->tm_mon+1),(Bit16u)time->tm_mday);
 		find_time=DOS_PackTime((Bit16u)time->tm_hour,(Bit16u)time->tm_min,(Bit16u)time->tm_sec);
 	} else {
@@ -309,7 +310,7 @@ bool localDrive::GetFileAttr(char * name,Bit16u * attr) {
 	struct stat status;
 	if (stat(newname,&status)==0) {
 		*attr=DOS_ATTR_ARCHIVE;
-		if(status.st_mode & S_IFDIR) *attr|=DOS_ATTR_DIRECTORY;
+		if (status.st_mode & S_IFDIR) *attr|=DOS_ATTR_DIRECTORY;
 		return true;
 	}
 	*attr=0;
@@ -391,8 +392,8 @@ bool localDrive::FileExists(const char* name) {
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 	struct stat temp_stat;
-	if(stat(newname,&temp_stat)!=0) return false;
-	if(temp_stat.st_mode & S_IFDIR) return false;
+	if (stat(newname,&temp_stat)!=0) return false;
+	if (temp_stat.st_mode & S_IFDIR) return false;
 	return true;
 }
 
@@ -403,10 +404,10 @@ bool localDrive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	CROSS_FILENAME(newname);
 	dirCache.ExpandName(newname);
 	struct stat temp_stat;
-	if(stat(newname,&temp_stat)!=0) return false;
+	if (stat(newname,&temp_stat)!=0) return false;
 	/* Convert the stat to a FileStat */
 	struct tm *time;
-	if((time=localtime(&temp_stat.st_mtime))!=0) {
+	if ((time=localtime(&temp_stat.st_mtime))!=0) {
 		stat_block->time=DOS_PackTime((Bit16u)time->tm_hour,(Bit16u)time->tm_min,(Bit16u)time->tm_sec);
 		stat_block->date=DOS_PackDate((Bit16u)(time->tm_year+1900),(Bit16u)(time->tm_mon+1),(Bit16u)time->tm_mday);
 	} else {
@@ -434,15 +435,21 @@ Bits localDrive::UnMount(void) {
 	return 0; 
 }
 
-localDrive::localDrive(const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid) {
-	strcpy(basedir,startdir);
+localDrive::localDrive(const char * startdir,
+                       Bit16u _bytes_sector,
+                       Bit8u _sectors_cluster,
+                       Bit16u _total_clusters,
+                       Bit16u _free_clusters,
+                       Bit8u _mediaid)
+	: write_protected_files{},
+	  allocation{_bytes_sector,
+	             _sectors_cluster,
+	             _total_clusters,
+	             _free_clusters,
+	             _mediaid}
+{
+	strcpy(basedir, startdir);
 	sprintf(info,"local directory %s",startdir);
-	allocation.bytes_sector=_bytes_sector;
-	allocation.sectors_cluster=_sectors_cluster;
-	allocation.total_clusters=_total_clusters;
-	allocation.free_clusters=_free_clusters;
-	allocation.mediaid=_mediaid;
-
 	dirCache.SetBaseDir(basedir);
 }
 
@@ -460,7 +467,7 @@ bool localFile::Read(Bit8u * data,Bit16u * size) {
 	/* Same for Igor */
 	/* hardrive motion => unmask irq 2. Only do it when it's masked as unmasking is realitively heavy to emulate */
 	Bit8u mask = IO_Read(0x21);
-	if(mask & 0x4 ) IO_Write(0x21,mask&0xfb);
+	if (mask & 0x4) IO_Write(0x21,mask&0xfb);
 	return true;
 }
 
@@ -510,7 +517,7 @@ bool localFile::Seek(Bit32u * pos,Bit32u type) {
 bool localFile::Close() {
 	// only close if one reference left
 	if (refCtr==1) {
-		if(fhandle) fclose(fhandle);
+		if (fhandle) fclose(fhandle);
 		fhandle = 0;
 		open = false;
 	};
@@ -522,25 +529,26 @@ Bit16u localFile::GetInformation(void) {
 }
 	
 
-localFile::localFile(const char* _name, FILE * handle) {
-	fhandle=handle;
+localFile::localFile(const char* _name, FILE * handle)
+	: fhandle(handle),
+	  read_only_medium(false),
+	  last_action(NONE)
+{
 	open=true;
 	UpdateDateTimeFromHost();
 
 	attr=DOS_ATTR_ARCHIVE;
-	last_action=NONE;
-	read_only_medium=false;
 
 	name=0;
 	SetName(_name);
 }
 
 bool localFile::UpdateDateTimeFromHost(void) {
-	if(!open) return false;
+	if (!open) return false;
 	struct stat temp_stat;
 	fstat(cross_fileno(fhandle), &temp_stat);
 	struct tm * ltime;
-	if((ltime=localtime(&temp_stat.st_mtime))!=0) {
+	if ((ltime=localtime(&temp_stat.st_mtime))!=0) {
 		time=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);
 		date=DOS_PackDate((Bit16u)(ltime->tm_year+1900),(Bit16u)(ltime->tm_mon+1),(Bit16u)ltime->tm_mday);
 	} else {
@@ -561,16 +569,27 @@ void localFile::Flush(void) {
 // CDROM DRIVE
 // ********************************************
 
-cdromDrive::cdromDrive(const char driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error)
-		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid),
-		    subUnit(0),
-		    driveLetter('\0')
+cdromDrive::cdromDrive(const char _driveLetter,
+                       const char * startdir,
+                       Bit16u _bytes_sector,
+                       Bit8u _sectors_cluster,
+                       Bit16u _total_clusters,
+                       Bit16u _free_clusters,
+                       Bit8u _mediaid,
+                       int& error)
+	: localDrive(startdir,
+	             _bytes_sector,
+	             _sectors_cluster,
+	             _total_clusters,
+	             _free_clusters,
+	             _mediaid),
+	  subUnit(0),
+	  driveLetter(_driveLetter)
 {
 	// Init mscdex
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
 	strcpy(info, "CDRom ");
 	strcat(info, startdir);
-	this->driveLetter = driveLetter;
 	// Get Volume Label
 	char name[32];
 	if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);
@@ -651,7 +670,7 @@ bool cdromDrive::isRemovable(void) {
 }
 
 Bits cdromDrive::UnMount(void) {
-	if(MSCDEX_RemoveDrive(driveLetter)) {
+	if (MSCDEX_RemoveDrive(driveLetter)) {
 		delete this;
 		return 0;
 	}

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -34,6 +34,24 @@
 #include "support.h"
 #include "video.h"
 
+std::string get_basename(const std::string& filename) {
+	// Guard against corner cases: '', '/', '\', 'a'
+	if (filename.length() <= 1)
+		return filename;
+
+	// Find the last slash, but if not is set to zero
+	size_t slash_pos = filename.find_last_of("/\\");
+
+	// If the slash is the last character
+	if (slash_pos == filename.length() - 1)
+		slash_pos = 0;
+
+	// Otherwise if the slash is found mid-string
+	else if (slash_pos > 0)
+		slash_pos++;
+	return filename.substr(slash_pos);
+}
+
 
 void upcase(std::string &str) {
 	int (*tf)(int) = std::toupper;


### PR DESCRIPTION
Many DOS games open all their files in write-mode regardless if the game actually intends to write to them or not. This may result the files' metadata being updated (losing the original date-stamp) as well as putting the file at-risk of corruption if the game crashes with the file open for writing.  Also, host-filesystems that employ copy-on-write behavior detect the write flag and read a full copy of the file into memory and allocate space for the write, such as the OverlayFS filesystem on Linux (see 'Use Cases', 2nd para: https://windsock.io/the-overlay-filesystem/) 

Under the existing DOSBox implementation, if a user attempts to write-protect their data files then DOSBox will withhold the file from the game, giving it an empty file handle typically resulting in a crash or hang. For example, AD&D Dragonlance II Death Knights of Krynn attempts to open all its files in write-mode even though it never writes to its `.dax` and `.ovr` files (it only writes to the `save` and `prevsave` directories), and will hang:
 
``` text
Warning: file /path/to/Krynn/8x8d1.dax exists and failed to open in write mode.
Please Remove write-protection
```
Game hangs.

This commit allows the use of write-protected files (similar to running a game from CDROM) and indicates when a file is being protected against modification.

```
FILESYSTEM: protected from modification: /path/to/Krynn/8x8d1.dax
FILESYSTEM: protected from modification: /path/to/Krynn/comspr.dax
FILESYSTEM: protected from modification: /path/to/Krynn/skygrnd.dax
FILESYSTEM: protected from modification: /path/to/Krynn/items
FILESYSTEM: protected from modification: /path/to/Krynn/item0.dax
FILESYSTEM: protected from modification: /path/to/Krynn/music.dax
FILESYSTEM: protected from modification: /path/to/Krynn/title.dax
<and so on as needed>
```
Game continues without issue.

Typically the only files that need to be left writable are those that are actually changed, such as: save-game files, highscore files, in-game settings, and so on.  If they're also protected, then the game will quit/crash immediately after the protected message is printed, and thus indicate which file requires write-allowance.

Also did some spacing cleanup around if/while/for, and some effc++ cleanup.