### PR TITLE
Expand mouse capture and release logic

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -127,7 +127,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 627
+          MAX_BUGS: 613
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/callback.h
+++ b/include/callback.h
@@ -87,9 +87,13 @@ private:
 		bool installed;
 	} vectorhandler;
 public:
-	CALLBACK_HandlerObject():installed(false),m_type(NONE) {
-		vectorhandler.installed=false;
-	}
+	CALLBACK_HandlerObject()
+		: installed(false),
+		  m_callback(0),
+		  m_type(NONE),
+		  vectorhandler{0, 0, false}
+	{ }
+
 	~CALLBACK_HandlerObject();
 
 	//Install and allocate a callback.

--- a/include/inout.h
+++ b/include/inout.h
@@ -49,13 +49,19 @@ Bitu IO_ReadD(Bitu port);
 
 /* Classes to manage the IO objects created by the various devices.
  * The io objects will remove itself on destruction.*/
-class IO_Base{
+class IO_Base {
 protected:
 	bool installed;
 	Bitu m_port, m_mask,m_range;
 public:
-	IO_Base():installed(false){};
+	IO_Base()
+		: installed(false),
+		  m_port(0),
+		  m_mask(0),
+		  m_range(0)
+	{ }
 };
+
 class IO_ReadHandleObject: private IO_Base{
 public:
 	void Install(Bitu port,IO_ReadHandler * handler,Bitu mask,Bitu range=1);

--- a/include/regs.h
+++ b/include/regs.h
@@ -98,7 +98,7 @@ static INLINE PhysPt SegPhys(SegNames index) {
 }
 
 static INLINE Bit16u SegValue(SegNames index) {
-	return (Bit16u)Segs.val[index];
+	return Segs.val[index];
 }
 	
 static INLINE RealPt RealMakeSeg(SegNames index,Bit16u off) {

--- a/include/video.h
+++ b/include/video.h
@@ -69,8 +69,4 @@ bool GFX_SDLUsingWinDIB(void);
 void MAPPER_UpdateJoysticks(void);
 #endif
 
-/* Mouse related */
-void GFX_CaptureMouse(void);
-extern bool mouselocked; //true if mouse is confined to window
-
 #endif

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -80,6 +80,10 @@ class CButton;
 class CBind;
 class CBindGroup;
 
+/* Mouse related */
+void GFX_ToggleMouseCapture(void);
+extern SDL_bool mouse_is_captured; //true if mouse is confined to window
+
 static void SetActiveEvent(CEvent * event);
 static void SetActiveBind(CBind * _bind);
 extern Bit8u int10_font_14[256 * 14];
@@ -2478,9 +2482,9 @@ void MAPPER_RunInternal() {
 	int cursor = SDL_ShowCursor(SDL_QUERY);
 	SDL_ShowCursor(SDL_ENABLE);
 	bool mousetoggle=false;
-	if(mouselocked) {
+	if(mouse_is_captured) {
 		mousetoggle=true;
-		GFX_CaptureMouse();
+		GFX_ToggleMouseCapture();
 	}
 
 	/* Be sure that there is no update in progress */
@@ -2530,7 +2534,7 @@ void MAPPER_RunInternal() {
 #if defined (REDUCE_JOYSTICK_POLLING)
 	SDL_JoystickEventState(SDL_DISABLE);
 #endif
-	if(mousetoggle) GFX_CaptureMouse();
+	if(mousetoggle) GFX_ToggleMouseCapture();
 	SDL_ShowCursor(cursor);
 	GFX_ResetScreen();
 }

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -120,7 +120,7 @@ public:
 	virtual void ActivateEvent(bool ev_trigger,bool skip_action)=0;
 	virtual void DeActivateEvent(bool ev_trigger)=0;
 	void DeActivateAll(void);
-	void SetValue(Bits value){
+	void SetValue(Bits value) {
 		current_value=value;
 	}
 	Bits GetValue(void) {
@@ -538,7 +538,7 @@ public:
 			button_autofire[i]=0;
 			old_button_state[i]=0;
 		}
-		for(i=0;i<16;i++) old_hat_state[i]=0;
+		for (i=0;i<16;i++) old_hat_state[i]=0;
 		for (i=0; i<4; i++) {
 			old_pos_axis_state[i]=false;
 			old_neg_axis_state[i]=false;
@@ -647,10 +647,10 @@ public:
 		switch(event->type) {
 			case SDL_JOYAXISMOTION:
 				jaxis = &event->jaxis;
-				if(jaxis->which == stick) {
-					if(jaxis->axis == 0)
+				if (jaxis->which == stick) {
+					if (jaxis->axis == 0)
 						JOYSTICK_Move_X(emustick,(float)(jaxis->value/32768.0));
-					else if(jaxis->axis == 1)
+					else if (jaxis->axis == 1)
 						JOYSTICK_Move_Y(emustick,(float)(jaxis->value/32768.0));
 				}
 				break;
@@ -844,7 +844,7 @@ protected:
 
 class C4AxisBindGroup : public  CStickBindGroup {
 public:
-	C4AxisBindGroup(Bitu _stick,Bitu _emustick) : CStickBindGroup (_stick,_emustick){
+	C4AxisBindGroup(Bitu _stick,Bitu _emustick) : CStickBindGroup (_stick,_emustick) {
 		emulated_axes=4;
 		emulated_buttons=4;
 		if (button_wrapping_enabled) button_wrap=emulated_buttons;
@@ -865,8 +865,8 @@ public:
 		switch(event->type) {
 			case SDL_JOYAXISMOTION:
 				jaxis = &event->jaxis;
-				if(jaxis->which == stick && jaxis->axis < 4) {
-					if(jaxis->axis & 1)
+				if (jaxis->which == stick && jaxis->axis < 4) {
+					if (jaxis->axis & 1)
 						JOYSTICK_Move_Y(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
 					else
 						JOYSTICK_Move_X(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
@@ -938,18 +938,18 @@ public:
 		switch(event->type) {
 			case SDL_JOYAXISMOTION:
 				jaxis = &event->jaxis;
-				if(jaxis->which == stick) {
-					if(jaxis->axis == 0)
+				if (jaxis->which == stick) {
+					if (jaxis->axis == 0)
 						JOYSTICK_Move_X(0,(float)(jaxis->value/32768.0));
-					else if(jaxis->axis == 1)
+					else if (jaxis->axis == 1)
 						JOYSTICK_Move_Y(0,(float)(jaxis->value/32768.0));
-					else if(jaxis->axis == 2)
+					else if (jaxis->axis == 2)
 						JOYSTICK_Move_X(1,(float)(jaxis->value/32768.0));
 				}
 				break;
 			case SDL_JOYHATMOTION:
 				jhat = &event->jhat;
-				if(jhat->which == stick) DecodeHatPosition(jhat->value);
+				if (jhat->which == stick) DecodeHatPosition(jhat->value);
 				break;
 			case SDL_JOYBUTTONDOWN:
 			case SDL_JOYBUTTONUP:
@@ -1020,25 +1020,25 @@ private:
 				JOYSTICK_Move_Y(1,0.5);
 				break;
 			case SDL_HAT_LEFTUP:
-				if(JOYSTICK_GetMove_Y(1) < 0)
+				if (JOYSTICK_GetMove_Y(1) < 0)
 					JOYSTICK_Move_Y(1,0.5);
 				else
 					JOYSTICK_Move_Y(1,-1.0);
 				break;
 			case SDL_HAT_RIGHTUP:
-				if(JOYSTICK_GetMove_Y(1) < -0.7)
+				if (JOYSTICK_GetMove_Y(1) < -0.7)
 					JOYSTICK_Move_Y(1,-0.5);
 				else
 					JOYSTICK_Move_Y(1,-1.0);
 				break;
 			case SDL_HAT_RIGHTDOWN:
-				if(JOYSTICK_GetMove_Y(1) < -0.2)
+				if (JOYSTICK_GetMove_Y(1) < -0.2)
 					JOYSTICK_Move_Y(1,0.0);
 				else
 					JOYSTICK_Move_Y(1,-0.5);
 				break;
 			case SDL_HAT_LEFTDOWN:
-				if(JOYSTICK_GetMove_Y(1) > 0.2)
+				if (JOYSTICK_GetMove_Y(1) > 0.2)
 					JOYSTICK_Move_Y(1,0.0);
 				else
 					JOYSTICK_Move_Y(1,0.5);
@@ -1076,8 +1076,8 @@ public:
 		switch(event->type) {
 			case SDL_JOYAXISMOTION:
 				jaxis = &event->jaxis;
-				if(jaxis->which == stick && jaxis->axis < 4) {
-					if(jaxis->axis & 1)
+				if (jaxis->which == stick && jaxis->axis < 4) {
+					if (jaxis->axis & 1)
 						JOYSTICK_Move_Y(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
 					else
 						JOYSTICK_Move_X(jaxis->axis>>1 & 1,(float)(jaxis->value/32768.0));
@@ -1085,16 +1085,16 @@ public:
 				break;
 			case SDL_JOYHATMOTION:
 				jhat = &event->jhat;
-				if(jhat->which == stick && jhat->hat < 2) {
-					if(jhat->value == SDL_HAT_CENTERED)
+				if (jhat->which == stick && jhat->hat < 2) {
+					if (jhat->value == SDL_HAT_CENTERED)
 						button_state&=~hat_magic[jhat->hat][0];
-					if(jhat->value & SDL_HAT_UP)
+					if (jhat->value & SDL_HAT_UP)
 						button_state|=hat_magic[jhat->hat][1];
-					if(jhat->value & SDL_HAT_RIGHT)
+					if (jhat->value & SDL_HAT_RIGHT)
 						button_state|=hat_magic[jhat->hat][2];
-					if(jhat->value & SDL_HAT_DOWN)
+					if (jhat->value & SDL_HAT_DOWN)
 						button_state|=hat_magic[jhat->hat][3];
-					if(jhat->value & SDL_HAT_LEFT)
+					if (jhat->value & SDL_HAT_LEFT)
 						button_state|=hat_magic[jhat->hat][4];
 				}
 				break;
@@ -1115,7 +1115,7 @@ public:
 		unsigned i;
 		Bit16u j;
 		j=button_state;
-		for(i=0;i<16;i++) if (j & 1) break; else j>>=1;
+		for (i=0;i<16;i++) if (j & 1) break; else j>>=1;
 		JOYSTICK_Button(0,0,i&1);
 		JOYSTICK_Button(0,1,(i>>1)&1);
 		JOYSTICK_Button(1,0,(i>>2)&1);
@@ -1263,7 +1263,7 @@ public:
 		}
 	}
 	virtual bool OnTop(Bitu _x,Bitu _y) {
-		return ( enabled && (_x>=x) && (_x<x+dx) && (_y>=y) && (_y<y+dy));
+		return (enabled && (_x>=x) && (_x<x+dx) && (_y>=y) && (_y<y+dy));
 	}
 	virtual void BindColor(void) {}
 	virtual void Click(void) {}
@@ -1340,7 +1340,7 @@ protected:
 
 class CCaptionButton : public CButton {
 public:
-	CCaptionButton(Bitu _x,Bitu _y,Bitu _dx,Bitu _dy) : CButton(_x,_y,_dx,_dy){
+	CCaptionButton(Bitu _x,Bitu _y,Bitu _dx,Bitu _dy) : CButton(_x,_y,_dx,_dy) {
 		caption[0]=0;
 	}
 	void Change(const char * format,...) GCC_ATTRIBUTE(__format__(__printf__,2,3));
@@ -1826,7 +1826,7 @@ static void CreateLayout(void) {
 #define PY(_Y_) (10+(_Y_)*BH)
 	AddKeyButtonEvent(PX(0),PY(0),BW,BH,"ESC","esc",KBD_esc);
 	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(0),BW,BH,combo_f[i].title,combo_f[i].entry,combo_f[i].key);
-	for (i=0;i<14;i++) AddKeyButtonEvent(PX(  i),PY(1),BW,BH,combo_1[i].title,combo_1[i].entry,combo_1[i].key);
+	for (i=0;i<14;i++) AddKeyButtonEvent(PX(i),PY(1),BW,BH,combo_1[i].title,combo_1[i].entry,combo_1[i].key);
 
 	AddKeyButtonEvent(PX(0),PY(2),BW*2,BH,"TAB","tab",KBD_tab);
 	for (i=0;i<12;i++) AddKeyButtonEvent(PX(2+i),PY(2),BW,BH,combo_2[i].title,combo_2[i].entry,combo_2[i].key);
@@ -1961,20 +1961,20 @@ static void CreateLayout(void) {
 		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Joystick 2");
 		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
 		btn->SetColor(CLR_GREY);
-	} else if(joytype ==JOY_4AXIS || joytype == JOY_4AXIS_2) {
+	} else if (joytype ==JOY_4AXIS || joytype == JOY_4AXIS_2) {
 		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
 		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
 		btn=new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
 		btn->SetColor(CLR_GREY);
-	} else if(joytype == JOY_CH) {
+	} else if (joytype == JOY_CH) {
 		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
 		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
 		new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Hat/D-pad");
-	} else if ( joytype==JOY_FCS) {
+	} else if (joytype==JOY_FCS) {
 		new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
 		new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3");
 		new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Hat/D-pad");
-	} else if(joytype == JOY_NONE) {
+	} else if (joytype == JOY_NONE) {
 		btn=new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Disabled");
 		btn->SetColor(CLR_GREY);
 		btn=new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Disabled");
@@ -2199,8 +2199,8 @@ static void CreateDefaultBinds(void) {
 
 void MAPPER_AddHandler(MAPPER_Handler * handler,MapKeys key,Bitu mods,char const * const eventname,char const * const buttonname) {
 	//Check if it already exists=> if so return.
-	for(CHandlerEventVector_it it=handlergroup.begin();it!=handlergroup.end();it++)
-		if(strcmp((*it)->buttonname,buttonname) == 0) return;
+	for (CHandlerEventVector_it it=handlergroup.begin();it!=handlergroup.end();it++)
+		if (strcmp((*it)->buttonname,buttonname) == 0) return;
 
 	char tempname[17];
 	strcpy(tempname,"hand_");
@@ -2439,7 +2439,7 @@ static void CreateBindGroups(void) {
 		case JOY_2AXIS:
 		default:
 			mapper.sticks.stick[mapper.sticks.num_groups++]=new CStickBindGroup(joyno,joyno);
-			if((joyno+1U) < mapper.sticks.num) {
+			if ((joyno+1U) < mapper.sticks.num) {
 				mapper.sticks.stick[mapper.sticks.num_groups++]=new CStickBindGroup(joyno+1U,joyno+1U);
 			} else {
 				new CStickBindGroup(joyno+1U,joyno+1U,true);
@@ -2459,7 +2459,7 @@ void MAPPER_UpdateJoysticks(void) {
 
 void MAPPER_LosingFocus(void) {
 	for (CEventVector_it evit=events.begin();evit!=events.end();evit++) {
-		if(*evit != caps_lock_event && *evit != num_lock_event)
+		if (*evit != caps_lock_event && *evit != num_lock_event)
 			(*evit)->DeActivateAll();
 	}
 }
@@ -2482,13 +2482,13 @@ void MAPPER_RunInternal() {
 	int cursor = SDL_ShowCursor(SDL_QUERY);
 	SDL_ShowCursor(SDL_ENABLE);
 	bool mousetoggle=false;
-	if(mouse_is_captured) {
+	if (mouse_is_captured) {
 		mousetoggle=true;
 		GFX_ToggleMouseCapture();
 	}
 
 	/* Be sure that there is no update in progress */
-	GFX_EndUpdate( 0 );
+	GFX_EndUpdate(0);
 	mapper.window = GFX_SetSDLSurfaceWindow(640, 480);
 	if (mapper.window == nullptr)
 		E_Exit("Could not initialize video mode for mapper: %s", SDL_GetError());
@@ -2534,7 +2534,7 @@ void MAPPER_RunInternal() {
 #if defined (REDUCE_JOYSTICK_POLLING)
 	SDL_JoystickEventState(SDL_DISABLE);
 #endif
-	if(mousetoggle) GFX_ToggleMouseCapture();
+	if (mousetoggle) GFX_ToggleMouseCapture();
 	SDL_ShowCursor(cursor);
 	GFX_ResetScreen();
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -225,7 +225,7 @@ void OPENGL_ERROR(const char* message) {
 	LOG_MSG("errors from %s",message);
 	do {
 		LOG_MSG("%X",r);
-	} while ( (r=glGetError()) != GL_NO_ERROR);
+	} while ((r=glGetError()) != GL_NO_ERROR);
 }
 #else 
 void OPENGL_ERROR(const char*) {
@@ -253,13 +253,13 @@ extern bool CPU_CycleAutoAdjust;
 bool startup_state_numlock=false;
 bool startup_state_capslock=false;
 
-void GFX_SetTitle(Bit32s cycles,int frameskip,bool paused){
+void GFX_SetTitle(Bit32s cycles,int frameskip,bool paused) {
 	char title[200] = { 0 };
 	static Bit32s internal_cycles = 0;
 	static int internal_frameskip = 0;
 	if (cycles != -1) internal_cycles = cycles;
 	if (frameskip != -1) internal_frameskip = frameskip;
-	if(CPU_CycleAutoAdjust) {
+	if (CPU_CycleAutoAdjust) {
 		sprintf(title,"DOSBox %s, CPU speed: max %3d%% cycles, Frameskip %2d, Program: %8s",VERSION,internal_cycles,internal_frameskip,RunningProgram);
 	} else {
 		sprintf(title,"DOSBox %s, CPU speed: %8d cycles, Frameskip %2d, Program: %8s",VERSION,internal_cycles,internal_frameskip,RunningProgram);
@@ -319,7 +319,7 @@ static void PauseDOSBox(bool pressed) {
 				break;
 			case SDL_KEYDOWN:   // Must use Pause/Break Key to resume.
 			case SDL_KEYUP:
-			if(event.key.keysym.sym == SDLK_PAUSE) {
+			if (event.key.keysym.sym == SDLK_PAUSE) {
 
 				paused = false;
 				GFX_SetTitle(-1,-1,false);
@@ -380,7 +380,7 @@ check_surface:
 void GFX_ResetScreen(void) {
 	GFX_Stop();
 	if (sdl.draw.callback)
-		(sdl.draw.callback)( GFX_CallBackReset );
+		(sdl.draw.callback)(GFX_CallBackReset);
 	GFX_Start();
 	CPU_Reset_AutoAdjust();
 }
@@ -533,7 +533,7 @@ static SDL_Window * GFX_SetupWindowScaled(SCREEN_TYPES screenType)
 	if (fixedWidth && fixedHeight) {
 		double ratio_w=(double)fixedWidth/(sdl.draw.width*sdl.draw.scalex);
 		double ratio_h=(double)fixedHeight/(sdl.draw.height*sdl.draw.scaley);
-		if ( ratio_w < ratio_h) {
+		if (ratio_w < ratio_h) {
 			sdl.clip.w=fixedWidth;
 			sdl.clip.h=(Bit16u)(sdl.draw.height*sdl.draw.scaley*ratio_w + 0.1); //possible rounding issues
 		} else {
@@ -580,7 +580,7 @@ static SDL_Window * GFX_SetupWindowScaled(SCREEN_TYPES screenType)
 
 Bitu GFX_SetSize(Bitu width,Bitu height,Bitu flags,double scalex,double scaley,GFX_CallBack_t callback) {
 	if (sdl.updating)
-		GFX_EndUpdate( 0 );
+		GFX_EndUpdate(0);
 
 	sdl.draw.width=width;
 	sdl.draw.height=height;
@@ -792,7 +792,7 @@ dosurface:
 		// No borders
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
-		if (!sdl.opengl.bilinear || ( (sdl.clip.h % height) == 0 && (sdl.clip.w % width) == 0) ) {
+		if (!sdl.opengl.bilinear || ((sdl.clip.h % height) == 0 && (sdl.clip.w % width) == 0)) {
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		} else {
@@ -868,9 +868,9 @@ static void ToggleMouseCapture(bool pressed) {
 
 #if defined (WIN32)
 STICKYKEYS stick_keys = {sizeof(STICKYKEYS), 0};
-void sticky_keys(bool restore){
+void sticky_keys(bool restore) {
 	static bool inited = false;
-	if (!inited){
+	if (!inited) {
 		inited = true;
 		SystemParametersInfo(SPI_GETSTICKYKEYS, sizeof(STICKYKEYS), &stick_keys, 0);
 	}
@@ -881,7 +881,7 @@ void sticky_keys(bool restore){
 	//Get current sticky keys layout:
 	STICKYKEYS s = {sizeof(STICKYKEYS), 0};
 	SystemParametersInfo(SPI_GETSTICKYKEYS, sizeof(STICKYKEYS), &s, 0);
-	if ( !(s.dwFlags & SKF_STICKYKEYSON)) { //Not on already
+	if (!(s.dwFlags & SKF_STICKYKEYSON)) { //Not on already
 		s.dwFlags &= ~SKF_HOTKEYACTIVE;
 		SystemParametersInfo(SPI_SETSTICKYKEYS, sizeof(STICKYKEYS), &s, 0);
 	}
@@ -961,7 +961,7 @@ bool GFX_StartUpdate(Bit8u * & pixels,Bitu & pitch) {
 	}
 #if C_OPENGL
 	case SCREEN_OPENGL:
-		if(sdl.opengl.pixel_buffer_object) {
+		if (sdl.opengl.pixel_buffer_object) {
 		    glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
 		    pixels=(Bit8u *)glMapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, GL_WRITE_ONLY);
 		} else {
@@ -980,7 +980,7 @@ bool GFX_StartUpdate(Bit8u * & pixels,Bitu & pitch) {
 }
 
 
-void GFX_EndUpdate( const Bit16u *changedLines ) {
+void GFX_EndUpdate(const Bit16u *changedLines) {
 	if (!sdl.update_display_contents)
 		return;
 	if (!sdl.updating)
@@ -1039,7 +1039,7 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
 					Bitu height = changedLines[index];
 					glTexSubImage2D(GL_TEXTURE_2D, 0, 0, y,
 						sdl.draw.width, height, GL_BGRA_EXT,
-						GL_UNSIGNED_INT_8_8_8_8_REV, pixels );
+						GL_UNSIGNED_INT_8_8_8_8_REV, pixels);
 					y += height;
 				}
 				index++;
@@ -1068,7 +1068,7 @@ Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue) {
 
 void GFX_Stop() {
 	if (sdl.updating)
-		GFX_EndUpdate( 0 );
+		GFX_EndUpdate(0);
 	sdl.active=false;
 }
 
@@ -1102,7 +1102,7 @@ void GFX_UpdateDisplayDimensions(int width, int height)
 
 static void GUI_ShutDown(Section * /*sec*/) {
 	GFX_Stop();
-	if (sdl.draw.callback) (sdl.draw.callback)( GFX_CallBackStop );
+	if (sdl.draw.callback) (sdl.draw.callback)(GFX_CallBackStop);
 	if (sdl.desktop.fullscreen) GFX_SwitchFullScreen();
 	if (mouse_is_captured) GFX_ToggleMouseCapture();
 }
@@ -1114,8 +1114,8 @@ static void SetPriority(PRIORITY_LEVELS level) {
 // Do nothing if priorties are not the same and not root, else the highest
 // priority can not be set as users can only lower priority (not restore it)
 
-	if((sdl.priority.focus != sdl.priority.nofocus ) &&
-		(getuid()!=0) ) return;
+	if ((sdl.priority.focus != sdl.priority.nofocus) &&
+		(getuid()!=0)) return;
 
 #endif
 	switch (level) {
@@ -1149,10 +1149,10 @@ static void SetPriority(PRIORITY_LEVELS level) {
 		setpriority (PRIO_PGRP, 0,PRIO_MAX-(PRIO_TOTAL/2));
 		break;
 	case PRIORITY_LEVEL_HIGHER:
-		setpriority (PRIO_PGRP, 0,PRIO_MAX-((3*PRIO_TOTAL)/5) );
+		setpriority (PRIO_PGRP, 0,PRIO_MAX-((3*PRIO_TOTAL)/5));
 		break;
 	case PRIORITY_LEVEL_HIGHEST:
-		setpriority (PRIO_PGRP, 0,PRIO_MAX-((3*PRIO_TOTAL)/4) );
+		setpriority (PRIO_PGRP, 0,PRIO_MAX-((3*PRIO_TOTAL)/4));
 		break;
 #endif
 	default:
@@ -1229,9 +1229,9 @@ static void GUI_StartUp(Section * sec) {
 	const char* fullresolution=section->Get_string("fullresolution");
 	sdl.desktop.full.width  = 0;
 	sdl.desktop.full.height = 0;
-	if(fullresolution && *fullresolution) {
+	if (fullresolution && *fullresolution) {
 		char res[100];
-		safe_strncpy( res, fullresolution, sizeof( res ));
+		safe_strncpy(res, fullresolution, sizeof(res));
 		fullresolution = lowcase (res);//so x and X are allowed
 		if (strcmp(fullresolution,"original")) {
 			sdl.desktop.full.fixed = true;
@@ -1249,19 +1249,19 @@ static void GUI_StartUp(Section * sec) {
 	sdl.desktop.window.width  = 0;
 	sdl.desktop.window.height = 0;
 	const char* windowresolution=section->Get_string("windowresolution");
-	if(windowresolution && *windowresolution) {
+	if (windowresolution && *windowresolution) {
 		char res[100];
-		safe_strncpy( res,windowresolution, sizeof( res ));
+		safe_strncpy(res,windowresolution, sizeof(res));
 		windowresolution = lowcase (res);//so x and X are allowed
-		if(strcmp(windowresolution,"original")) {
+		if (strcmp(windowresolution,"original")) {
 			char* height = const_cast<char*>(strchr(windowresolution,'x'));
-			if(height && *height) {
+			if (height && *height) {
 				*height = 0;
 				sdl.desktop.window.height = (Bit16u)atoi(height+1);
 				sdl.desktop.window.width  = (Bit16u)atoi(res);
 			} else {
 				char* percentage = const_cast<char*>(strchr(windowresolution,'%'));
-				if(percentage && *percentage) {
+				if (percentage && *percentage) {
 					*percentage = 0;
 					windowspercentage = (Bit16u) atoi(res);
 					if (windowspercentage) putenv(const_cast<char*>("SDL_VIDEO_CENTERED=1"));
@@ -1335,10 +1335,10 @@ static void GUI_StartUp(Section * sec) {
 			glMapBufferARB = (PFNGLMAPBUFFERARBPROC)SDL_GL_GetProcAddress("glMapBufferARB");
 			glUnmapBufferARB = (PFNGLUNMAPBUFFERARBPROC)SDL_GL_GetProcAddress("glUnmapBufferARB");
 			const char * gl_ext = (const char *)glGetString (GL_EXTENSIONS);
-			if(gl_ext && *gl_ext){
+			if (gl_ext && *gl_ext) {
 				sdl.opengl.packed_pixel=(strstr(gl_ext,"EXT_packed_pixels") != NULL);
 				sdl.opengl.paletted_texture=(strstr(gl_ext,"EXT_paletted_texture") != NULL);
-				sdl.opengl.pixel_buffer_object=(strstr(gl_ext,"GL_ARB_pixel_buffer_object") != NULL ) &&
+				sdl.opengl.pixel_buffer_object=(strstr(gl_ext,"GL_ARB_pixel_buffer_object") != NULL) &&
 				    glGenBuffersARB && glBindBufferARB && glDeleteBuffersARB && glBufferDataARB &&
 				    glMapBufferARB && glUnmapBufferARB;
     			} else {
@@ -1484,8 +1484,8 @@ static void GUI_StartUp(Section * sec) {
 #endif
 	/* Get Keyboard state of numlock and capslock */
 	SDL_Keymod keystate = SDL_GetModState();
-	if(keystate&KMOD_NUM) startup_state_numlock = true;
-	if(keystate&KMOD_CAPS) startup_state_capslock = true;
+	if (keystate&KMOD_NUM) startup_state_numlock = true;
+	if (keystate&KMOD_CAPS) startup_state_capslock = true;
 }
 
 static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
@@ -1615,7 +1615,7 @@ void GFX_Events() {
 					GFX_HandleVideoResize(event.window.data1, event.window.data2);
 					continue;
 				case SDL_WINDOWEVENT_EXPOSED:
-					if (sdl.draw.callback) sdl.draw.callback( GFX_CallBackRedraw );
+					if (sdl.draw.callback) sdl.draw.callback(GFX_CallBackRedraw);
 					continue;
 				case SDL_WINDOWEVENT_FOCUS_GAINED:
 					SetPriority(sdl.priority.focus);
@@ -1707,7 +1707,7 @@ void GFX_Events() {
 			if (((event.key.keysym.sym==SDLK_TAB)) && ((sdl.laltstate==SDL_KEYDOWN) || (sdl.raltstate==SDL_KEYDOWN)))
 				break;
 			// This can happen as well.
-			if (((event.key.keysym.sym == SDLK_TAB )) && (event.key.keysym.mod & KMOD_ALT)) break;
+			if (((event.key.keysym.sym == SDLK_TAB)) && (event.key.keysym.mod & KMOD_ALT)) break;
 			// ignore tab events that arrive just after regaining focus. (likely the result of alt-tab)
 			if ((event.key.keysym.sym == SDLK_TAB) && (GetTicks() - sdl.focus_ticks < 2)) break;
 #endif
@@ -1872,16 +1872,16 @@ static void show_warning(char const * const message) {
 	bool textonly = true;
 #ifdef WIN32
 	textonly = false;
-	if ( !sdl.inited && SDL_Init(SDL_INIT_VIDEO|SDL_INIT_NOPARACHUTE) < 0 ) textonly = true;
+	if (!sdl.inited && SDL_Init(SDL_INIT_VIDEO|SDL_INIT_NOPARACHUTE) < 0) textonly = true;
 	sdl.inited = true;
 #endif
 	printf("%s",message);
-	if(textonly) return;
+	if (textonly) return;
 	if (!sdl.window)
 		if (!GFX_SetSDLSurfaceWindow(640, 400))
 			return;
 	sdl.surface = SDL_GetWindowSurface(sdl.window);
-	if(!sdl.surface)
+	if (!sdl.surface)
 		return;
 
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
@@ -1900,11 +1900,11 @@ static void show_warning(char const * const message) {
 	std::string m(message),m2;
 	std::string::size_type a,b,c,d;
 
-	while(m.size()) { //Max 50 characters. break on space before or on a newline
+	while (m.size()) { //Max 50 characters. break on space before or on a newline
 		c = m.find('\n');
 		d = m.rfind(' ',50);
-		if(c>d) a=b=d; else a=b=c;
-		if( a != std::string::npos) b++;
+		if (c>d) a=b=d; else a=b=c;
+		if (a != std::string::npos) b++;
 		m2 = m.substr(0,a); m.erase(0,b);
 		OutputString(x,y,m2.c_str(),0xffffffff,0,splash_surf);
 		y += 20;
@@ -1921,17 +1921,17 @@ static void launcheditor() {
 	Cross::GetPlatformConfigName(file);
 	path += file;
 	FILE* f = fopen(path.c_str(),"r");
-	if(!f && !control->PrintConfig(path.c_str())) {
+	if (!f && !control->PrintConfig(path.c_str())) {
 		printf("tried creating %s. but failed.\n",path.c_str());
 		exit(1);
 	}
-	if(f) fclose(f);
-/*	if(edit.empty()) {
+	if (f) fclose(f);
+/*	if (edit.empty()) {
 		printf("no editor specified.\n");
 		exit(1);
 	}*/
 	std::string edit;
-	while(control->cmdline->FindString("-editconf",edit,true)) //Loop until one succeeds
+	while (control->cmdline->FindString("-editconf",edit,true)) //Loop until one succeeds
 		execlp(edit.c_str(),edit.c_str(),path.c_str(),(char*) 0);
 	//if you get here the launching failed!
 	printf("can't find editor(s) specified at the command line.\n");
@@ -1948,7 +1948,7 @@ void restart_program(std::vector<std::string> & parameters) {
 	// parameter 0 is the executable path
 	// contents of the vector follow
 	// last one is NULL
-	for(Bitu i = 0; i < parameters.size(); i++) newargs[i] = (char*)parameters[i].c_str();
+	for (Bitu i = 0; i < parameters.size(); i++) newargs[i] = (char*)parameters[i].c_str();
 	newargs[parameters.size()] = NULL;
 	MIXER_CloseAudioDevice();
 	SDL_Delay(50);
@@ -1958,14 +1958,14 @@ void restart_program(std::vector<std::string> & parameters) {
 	DEBUG_ShutDown(NULL);
 #endif
 
-	if(execvp(newargs[0], newargs) == -1) {
+	if (execvp(newargs[0], newargs) == -1) {
 #ifdef WIN32
-		if(newargs[0][0] == '\"') {
+		if (newargs[0][0] == '\"') {
 			//everything specifies quotes around it if it contains a space, however my system disagrees
 			std::string edit = parameters[0];
 			edit.erase(0,1);edit.erase(edit.length() - 1,1);
 			//However keep the first argument of the passed argv (newargs) with quotes, as else repeated restarts go wrong.
-			if(execvp(edit.c_str(), newargs) == -1) E_Exit("Restarting failed");
+			if (execvp(edit.c_str(), newargs) == -1) E_Exit("Restarting failed");
 		}
 #endif
 		E_Exit("Restarting failed");
@@ -1979,8 +1979,8 @@ void Restart(bool pressed) { // mapper handler
 static void launchcaptures(std::string const& edit) {
 	std::string path,file;
 	Section* t = control->GetSection("dosbox");
-	if(t) file = t->GetPropValue("captures");
-	if(!t || file == NO_SUCH_PROPERTY) {
+	if (t) file = t->GetPropValue("captures");
+	if (!t || file == NO_SUCH_PROPERTY) {
 		printf("Config system messed up.\n");
 		exit(1);
 	}
@@ -1988,11 +1988,11 @@ static void launchcaptures(std::string const& edit) {
 	path += file;
 	Cross::CreateDir(path);
 	struct stat cstat;
-	if(stat(path.c_str(),&cstat) || (cstat.st_mode & S_IFDIR) == 0) {
+	if (stat(path.c_str(),&cstat) || (cstat.st_mode & S_IFDIR) == 0) {
 		printf("%s doesn't exists or isn't a directory.\n",path.c_str());
 		exit(1);
 	}
-/*	if(edit.empty()) {
+/*	if (edit.empty()) {
 		printf("no editor specified.\n");
 		exit(1);
 	}*/
@@ -2010,18 +2010,18 @@ static void printconfiglocation() {
 	path += file;
 
 	FILE* f = fopen(path.c_str(),"r");
-	if(!f && !control->PrintConfig(path.c_str())) {
+	if (!f && !control->PrintConfig(path.c_str())) {
 		printf("tried creating %s. but failed",path.c_str());
 		exit(1);
 	}
-	if(f) fclose(f);
+	if (f) fclose(f);
 	printf("%s\n",path.c_str());
 	exit(0);
 }
 
 static void eraseconfigfile() {
 	FILE* f = fopen("dosbox.conf","r");
-	if(f) {
+	if (f) {
 		fclose(f);
 		show_warning("Warning: dosbox.conf exists in current working directory.\nThis will override the configuration file at runtime.\n");
 	}
@@ -2030,7 +2030,7 @@ static void eraseconfigfile() {
 	Cross::GetPlatformConfigName(file);
 	path += file;
 	f = fopen(path.c_str(),"r");
-	if(!f) exit(0);
+	if (!f) exit(0);
 	fclose(f);
 	unlink(path.c_str());
 	exit(0);
@@ -2038,7 +2038,7 @@ static void eraseconfigfile() {
 
 static void erasemapperfile() {
 	FILE* g = fopen("dosbox.conf","r");
-	if(g) {
+	if (g) {
 		fclose(g);
 		show_warning("Warning: dosbox.conf exists in current working directory.\nKeymapping might not be properly reset.\n"
 		             "Please reset configuration as well and delete the dosbox.conf.\n");
@@ -2048,7 +2048,7 @@ static void erasemapperfile() {
 	Cross::GetPlatformConfigDir(path);
 	path += file;
 	FILE* f = fopen(path.c_str(),"r");
-	if(!f) exit(0);
+	if (!f) exit(0);
 	fclose(f);
 	unlink(path.c_str());
 	exit(0);
@@ -2078,19 +2078,19 @@ int main(int argc, char* argv[]) {
 		DOSBOX_Init();
 
 		std::string editor;
-		if(control->cmdline->FindString("-editconf",editor,false)) launcheditor();
-		if(control->cmdline->FindString("-opencaptures",editor,true)) launchcaptures(editor);
-		if(control->cmdline->FindExist("-eraseconf")) eraseconfigfile();
-		if(control->cmdline->FindExist("-resetconf")) eraseconfigfile();
-		if(control->cmdline->FindExist("-erasemapper")) erasemapperfile();
-		if(control->cmdline->FindExist("-resetmapper")) erasemapperfile();
+		if (control->cmdline->FindString("-editconf",editor,false)) launcheditor();
+		if (control->cmdline->FindString("-opencaptures",editor,true)) launchcaptures(editor);
+		if (control->cmdline->FindExist("-eraseconf")) eraseconfigfile();
+		if (control->cmdline->FindExist("-resetconf")) eraseconfigfile();
+		if (control->cmdline->FindExist("-erasemapper")) erasemapperfile();
+		if (control->cmdline->FindExist("-resetmapper")) erasemapperfile();
 
 		/* Can't disable the console with debugger enabled */
 #if defined(WIN32) && !(C_DEBUG)
 		if (control->cmdline->FindExist("-noconsole")) {
 			FreeConsole();
 			/* Redirect standard input and standard output */
-			if(freopen(STDOUT_FILE, "w", stdout) == NULL)
+			if (freopen(STDOUT_FILE, "w", stdout) == NULL)
 				no_stdout = true; // No stdout so don't write messages
 			freopen(STDERR_FILE, "w", stderr);
 			setvbuf(stdout, NULL, _IOLBF, BUFSIZ);	/* Line buffered */
@@ -2108,7 +2108,7 @@ int main(int argc, char* argv[]) {
 		}
 #endif  //defined(WIN32) && !(C_DEBUG)
 		if (control->cmdline->FindExist("-version") ||
-		    control->cmdline->FindExist("--version") ) {
+		    control->cmdline->FindExist("--version")) {
 			printf("\nDOSBox version %s, copyright 2002-2019 DOSBox Team.\n\n",VERSION);
 			printf("DOSBox is written by the DOSBox Team (See AUTHORS file))\n");
 			printf("DOSBox comes with ABSOLUTELY NO WARRANTY.  This is free software,\n");
@@ -2116,7 +2116,7 @@ int main(int argc, char* argv[]) {
 			printf("please read the COPYING file thoroughly before doing so.\n\n");
 			return 0;
 		}
-		if(control->cmdline->FindExist("-printconf")) printconfiglocation();
+		if (control->cmdline->FindExist("-printconf")) printconfiglocation();
 
 #if C_DEBUG
 		DEBUG_SetupConsole();
@@ -2145,7 +2145,7 @@ int main(int argc, char* argv[]) {
 #ifndef DISABLE_JOYSTICK
 	//Initialise Joystick separately. This way we can warn when it fails instead
 	//of exiting the application
-	if( SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0 ) LOG_MSG("Failed to init joystick support");
+	if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0) LOG_MSG("Failed to init joystick support");
 #endif
 
 	sdl.laltstate = SDL_KEYUP;
@@ -2158,19 +2158,19 @@ int main(int argc, char* argv[]) {
 	Cross::GetPlatformConfigDir(config_path);
 
 	//First parse -userconf
-	if(control->cmdline->FindExist("-userconf",true)){
+	if (control->cmdline->FindExist("-userconf",true)) {
 		config_file.clear();
 		Cross::GetPlatformConfigDir(config_path);
 		Cross::GetPlatformConfigName(config_file);
 		config_combined = config_path + config_file;
 		control->ParseConfigFile(config_combined.c_str());
-		if(!control->configfiles.size()) {
+		if (!control->configfiles.size()) {
 			//Try to create the userlevel configfile.
 			config_file.clear();
 			Cross::CreatePlatformConfigDir(config_path);
 			Cross::GetPlatformConfigName(config_file);
 			config_combined = config_path + config_file;
-			if(control->PrintConfig(config_combined.c_str())) {
+			if (control->PrintConfig(config_combined.c_str())) {
 				LOG_MSG("CONFIG: Generating default configuration.\nWriting it to %s",config_combined.c_str());
 				//Load them as well. Makes relative paths much easier
 				control->ParseConfigFile(config_combined.c_str());
@@ -2179,7 +2179,7 @@ int main(int argc, char* argv[]) {
 	}
 
 	//Second parse -conf switches
-	while(control->cmdline->FindString("-conf",config_file,true)) {
+	while (control->cmdline->FindString("-conf",config_file,true)) {
 		if (!control->ParseConfigFile(config_file.c_str())) {
 			// try to load it from the user directory
 			if (!control->ParseConfigFile((config_path + config_file).c_str())) {
@@ -2188,22 +2188,22 @@ int main(int argc, char* argv[]) {
 		}
 	}
 	// if none found => parse localdir conf
-	if(!control->configfiles.size()) control->ParseConfigFile("dosbox.conf");
+	if (!control->configfiles.size()) control->ParseConfigFile("dosbox.conf");
 
 	// if none found => parse userlevel conf
-	if(!control->configfiles.size()) {
+	if (!control->configfiles.size()) {
 		config_file.clear();
 		Cross::GetPlatformConfigName(config_file);
 		control->ParseConfigFile((config_path + config_file).c_str());
 	}
 
-	if(!control->configfiles.size()) {
+	if (!control->configfiles.size()) {
 		//Try to create the userlevel configfile.
 		config_file.clear();
 		Cross::CreatePlatformConfigDir(config_path);
 		Cross::GetPlatformConfigName(config_file);
 		config_combined = config_path + config_file;
-		if(control->PrintConfig(config_combined.c_str())) {
+		if (control->PrintConfig(config_combined.c_str())) {
 			LOG_MSG("CONFIG: Generating default configuration.\nWriting it to %s",config_combined.c_str());
 			//Load them as well. Makes relative paths much easier
 			control->ParseConfigFile(config_combined.c_str());
@@ -2224,7 +2224,7 @@ int main(int argc, char* argv[]) {
 		Section_prop * sdl_sec=static_cast<Section_prop *>(control->GetSection("sdl"));
 
 		if (control->cmdline->FindExist("-fullscreen") || sdl_sec->Get_bool("fullscreen")) {
-			if(!sdl.desktop.fullscreen) { //only switch if not already in fullscreen
+			if (!sdl.desktop.fullscreen) { //only switch if not already in fullscreen
 				GFX_SwitchFullScreen();
 			}
 		}
@@ -2241,7 +2241,7 @@ int main(int argc, char* argv[]) {
 #endif
 		GFX_ShowMsg("Exit to error: %s",error);
 		fflush(NULL);
-		if(sdl.wait_on_error) {
+		if (sdl.wait_on_error) {
 			//TODO Maybe look for some way to show message in linux?
 #if (C_DEBUG)
 			GFX_ShowMsg("Press enter to continue");
@@ -2253,10 +2253,10 @@ int main(int argc, char* argv[]) {
 		}
 
 	}
-	catch (int){
+	catch (int) {
 		; //nothing, pressed killswitch
 	}
-	catch(...){
+	catch(...) {
 		; // Unknown error, let's just exit.
 	}
 #if defined (WIN32)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1477,10 +1477,12 @@ static void GUI_StartUp(Section * sec) {
 		// should have automatically set the default to 'onclick'
 		assert(sdl.mouse.capture_choice == MouseCaptureType::OnClick);
 	}
-	// Capture the mouse straight away if fullscreen or configured
+	// Capture the mouse straight-away if fullscreen or configured
 	if (sdl.desktop.fullscreen || sdl.mouse.capture_choice == MouseCaptureType::OnStart) {
+		SDL_RaiseWindow(sdl.window); // ensure DOSBox is in-focus before capturing the mouse
 		GFX_ToggleMouseCapture();
-	// Otherwise simply ensure the cursor is visible
+		/* We don't RaiseWindow for the other capture events because the user needs
+           to click or press Ctrl-F10 to capture, which implicitly focuses the window. */
 	} else {
 		SDL_ShowCursor(SDL_ENABLE);
 	}

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -214,7 +214,7 @@ INLINE void Mouse_AddEvent(Bit8u type) {
 			/* Always put the newest element in the front as that the events are
 			 * handled backwards (prevents doubleclicks while moving)
 			 */
-			for(Bitu i = mouse.events ; i ; i--)
+			for (Bitu i = mouse.events ; i ; i--)
 				mouse.event_queue[i] = mouse.event_queue[i-1];
 		}
 		mouse.event_queue[0].type=type;
@@ -464,8 +464,8 @@ void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate) {
 	float dx = xrel * mouse.pixelPerMickey_x;
 	float dy = yrel * mouse.pixelPerMickey_y;
 
-	if((fabs(xrel) > 1.0f) || (mouse.senv_x < 1.0f)) dx *= mouse.senv_x;
-	if((fabs(yrel) > 1.0f) || (mouse.senv_y < 1.0f)) dy *= mouse.senv_y;
+	if ((fabs(xrel) > 1.0f) || (mouse.senv_x < 1.0f)) dx *= mouse.senv_x;
+	if ((fabs(yrel) > 1.0f) || (mouse.senv_y < 1.0f)) dy *= mouse.senv_y;
 	if (useps2callback) dy *= 2;
 
 	mouse.mickey_x += (dx * mouse.mickeysPerPixel_x);
@@ -580,7 +580,7 @@ void Mouse_ButtonReleased(Bit8u button) {
 	mouse.last_released_y[button]=POS_Y;
 }
 
-static void Mouse_SetMickeyPixelRate(Bit16s px, Bit16s py){
+static void Mouse_SetMickeyPixelRate(Bit16s px, Bit16s py) {
 	if ((px!=0) && (py!=0)) {
 		mouse.mickeysPerPixel_x	 = (float)px/X_MICKEY;
 		mouse.mickeysPerPixel_y  = (float)py/Y_MICKEY;
@@ -589,10 +589,10 @@ static void Mouse_SetMickeyPixelRate(Bit16s px, Bit16s py){
 	}
 }
 
-static void Mouse_SetSensitivity(Bit16u px, Bit16u py, Bit16u dspeed){
-	if(px>100) px=100;
-	if(py>100) py=100;
-	if(dspeed>100) dspeed=100;
+static void Mouse_SetSensitivity(Bit16u px, Bit16u py, Bit16u dspeed) {
+	if (px>100) px=100;
+	if (py>100) py=100;
+	if (dspeed>100) dspeed=100;
 	// save values
 	mouse.senv_x_val=px;
 	mouse.senv_y_val=py;
@@ -606,7 +606,7 @@ static void Mouse_SetSensitivity(Bit16u px, Bit16u py, Bit16u dspeed){
 }
 
 
-static void Mouse_ResetHardware(void){
+static void Mouse_ResetHardware(void) {
 	PIC_SetIRQMask(MOUSE_IRQ,false);
 }
 
@@ -731,7 +731,7 @@ static Bitu INT33_Handler(void) {
 		Mouse_Reset();
 		break;
 	case 0x01:	/* Show Mouse */
-		if(mouse.hidden) mouse.hidden--;
+		if (mouse.hidden) mouse.hidden--;
 		mouse.updateRegion_y[1] = -1; //offscreen
 		DrawCursor();
 		break;
@@ -792,8 +792,8 @@ static Bitu INT33_Handler(void) {
 			mouse.min_x=min;
 			mouse.max_x=max;
 			/* Battlechess wants this */
-			if(mouse.x > mouse.max_x) mouse.x = mouse.max_x;
-			if(mouse.x < mouse.min_x) mouse.x = mouse.min_x;
+			if (mouse.x > mouse.max_x) mouse.x = mouse.max_x;
+			if (mouse.x < mouse.min_x) mouse.x = mouse.min_x;
 			/* Or alternatively this:
 			mouse.x = (mouse.max_x - mouse.min_x + 1)/2;*/
 			LOG(LOG_MOUSE,LOG_NORMAL)("Define Hortizontal range min:%d max:%d",min,max);
@@ -809,8 +809,8 @@ static Bitu INT33_Handler(void) {
 			mouse.min_y=min;
 			mouse.max_y=max;
 			/* Battlechess wants this */
-			if(mouse.y > mouse.max_y) mouse.y = mouse.max_y;
-			if(mouse.y < mouse.min_y) mouse.y = mouse.min_y;
+			if (mouse.y > mouse.max_y) mouse.y = mouse.max_y;
+			if (mouse.y < mouse.min_y) mouse.y = mouse.min_y;
 			/* Or alternatively this:
 			mouse.y = (mouse.max_y - mouse.min_y + 1)/2;*/
 			LOG(LOG_MOUSE,LOG_NORMAL)("Define Vertical range min:%d max:%d",min,max);
@@ -1059,7 +1059,7 @@ static Bitu INT74_Handler(void) {
 			CPU_Push16(mouse.sub_seg);
 			CPU_Push16(mouse.sub_ofs);
 			mouse.in_UIR = true;
-			//LOG(LOG_MOUSE,LOG_ERROR)("INT 74 %X",mouse.event_queue[mouse.events].type );
+			//LOG(LOG_MOUSE,LOG_ERROR)("INT 74 %X",mouse.event_queue[mouse.events].type);
 		} else if (useps2callback) {
 			CPU_Push16(RealSeg(CALLBACK_RealPointer(int74_ret_callback)));
 			CPU_Push16(RealOff(CALLBACK_RealPointer(int74_ret_callback)));


### PR DESCRIPTION
This commit:
- replaces the existing `true` and `false` mouse capture configuration with three choices:
  - **onstart**, which captures the mouse immediately on starting DOSBox. You now don't need to mouse-around and click once just to get started: you're mouse is active from the get-go, which matches original DOS behavior.
  - **onclick**, which captures the mouse after manually clicking into the DOSBox window. This is equivalent to the existing DOSBox behavior, and is the default. 
  - **never**, which disables capturing the mouse in windowed-mode. The mouse cannot be accidentally captured and is always useable for other tasks.  This is perhaps useful for non-mouse games.
  - In all three modes the mouse is captured in fullscreen because at that point DOSBox has exclusive focus so you might as well have control of the mouse.
- The capture-state is retained when exiting fullscreen (for `onclick` and `onstart`) so you don't have to _"click again"_ to regain mouse control to continue playing.  Where as `never` always releases the mouse as promised in window-mode. 
- Renames the conf file setting to `capturemouse` to better describe _when the mouse will be captured_: For example, it now says what it does: `capturemouse = onstart`, or `capturemouse = onclick`.
- Previously the code used four separate state-tracking 'bool's to control the mouse capture behavior; this commit boils them down to one.
- Add a boolean config option `middlerelease`, (true/false), allowing the middle-mouse button to release the captured mouse, in window-mode.
- A one-line message is now printed to the console indicating when the mouse is captured and released.
- All of the above behavior is commented into the conf file when it's written (6 lines of text). 
