### PR TITLE
Stamp the PVS analysis directory with time-and-commit details

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -106,8 +106,11 @@ jobs:
           pvs-studio-analyzer analyze -s .pvs-suppress -o pvs-analysis.log -j "$(nproc)"
           criteria="GA:1,2;64:1;OP:1,2,3;CS:1;MISRA:1,2"
           plog-converter -a "${criteria}" -d V1042 -t csv -o pvs-report.csv pvs-analysis.log
+          mkdir -p pvs-analysis-report
+          stamp="$(date +'%Y-%m-%d_T%H%M')-${GITHUB_SHA:0:8}"
           plog-converter -a "${criteria}" -d V1042 -t fullhtml -p dosbox-staging \
-          -v "${GITHUB_SHA:0:8}" -o pvs-analysis-report pvs-analysis.log
+          -v "${GITHUB_SHA:0:8}" -o "pvs-analysis-report/pvs-analysis-report-${stamp}" \
+          pvs-analysis.log
       - name: Upload report
         uses: actions/upload-artifact@master
         with:


### PR DESCRIPTION
The PVS report, inside the zip, wasn't contained in a directory. 
This commit puts the report inside a date-and-commit stamped directory, so unzipping produces a directory like this: `pvs-analysis-report-2020-01-27_T0613-f1d61dc3`
