### PR TITLE
Test more criteria during PVS analysis

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -103,22 +103,31 @@ jobs:
       - name: Analyze
         run:  |
           set -xeu
-          pvs-studio-analyzer analyze -s .pvs-suppress -o pvs-analysis.log -j "$(nproc)"
-          criteria="GA:1,2;64:1;OP:1,2,3;CS:1;MISRA:1,2"
-          plog-converter -a "${criteria}" -d V1042 -t csv -o pvs-report.csv pvs-analysis.log
-          mkdir -p pvs-analysis-report
+          log="pvs-analysis.log"
+          mirsa_criteria="MISRA:1,2"
+          general_criteria="GA:1,2;64:1;OP:1,2,3;CS:1"
           stamp="$(date +'%Y-%m-%d_T%H%M')-${GITHUB_SHA:0:8}"
-          plog-converter -a "${criteria}" -d V1042 -t fullhtml -p dosbox-staging \
-          -v "${GITHUB_SHA:0:8}" -o "pvs-analysis-report/pvs-analysis-report-${stamp}" \
-          pvs-analysis.log
+          reportdir="pvs-report/pvs-report-${stamp}"
+          mkdir -p "${reportdir}"
+          pvs-studio-analyzer analyze -a 63 -s .pvs-suppress -o "${log}" -j "$(nproc)"
+          plog-converter -a "${general_criteria}" -d V1042 -t fullhtml -p dosbox-staging \
+          -v "${GITHUB_SHA:0:8}" -o "${reportdir}" "${log}"
+          mv "${reportdir}/fullhtml" "${reportdir}/general"
+          plog-converter -a "${mirsa_criteria}" -d V1042 -t fullhtml -p dosbox-staging \
+          -v "${GITHUB_SHA:0:8}" -o "${reportdir}" "${log}"
+          mv "${reportdir}/fullhtml" "${reportdir}/mirsa"
+          plog-converter -a "${general_criteria}" -d V1042 -t csv -o pvs-report.csv "${log}"
+          cp -l pvs-report.csv "${reportdir}/general/"
+          pvs-studio-analyzer suppress -a "${general_criteria}" \
+          -o "${reportdir}/general/supressible-list.json" "${log}"
       - name: Upload report
         uses: actions/upload-artifact@master
         with:
           name: pvs-analysis-report
-          path: pvs-analysis-report
+          path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 304
+          MAX_BUGS: 627
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.pvs-suppress
+++ b/.pvs-suppress
@@ -34,6 +34,14 @@
             "Message": "A call of the 'memcpy' function will lead to underflow of the buffer '& state'."
         },
         {
+            "CodeCurrent": 3039254062,
+            "CodeNext": 3404253786,
+            "CodePrev": 3282303307,
+            "ErrorCode": "V560",
+            "FileName": "dr_flac.h",
+            "Message": "A part of conditional expression is always true: blockSize >= _."
+        },
+        {
             "CodeCurrent": 2009695132,
             "CodeNext": 17733,
             "CodePrev": 3053,


### PR DESCRIPTION
The commit:
- adds a separate analysis run against the MIRSA (Motor Industry Software Reliability Association) criteria, which is extremely thorough.  This tally is not summarized or considered fatal to the workflow.  It runs virtually instantly, and the results are very interesting; however are too numerous to include in our general analysis (ie: over 13,000 issues).
- Changes the PVS summary script output to a tally-per-file instead of trying to summarize the nature of the issue, which was mostly unhelpful without the full text.
- Adds the full list of possible supressible issues inside the report directory, so if further suppressions are needed then these will be easy to find and use.
 - Adds one dr_flac suppression per the resolution here: https://github.com/mackron/dr_libs/issues/117