### PR TITLE
Rename snapshot build artifacts

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,10 +80,10 @@ jobs:
           sed -i "s|%GIT_COMMIT%|$GITHUB_SHA|"               dest/README
           sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README
-          mv dest "dosbox-staging-$VERSION"
-          tree --si -p "dosbox-staging-$VERSION"
+          mv dest "dosbox-staging-linux-$VERSION"
+          tree --si -p "dosbox-staging-linux-$VERSION"
           # Create tarball
-          tar -cJf "dosbox-staging-$VERSION.tar.xz" "dosbox-staging-$VERSION"
+          tar -cJf "dosbox-staging-linux-$VERSION.tar.xz" "dosbox-staging-linux-$VERSION"
       - name: Upload tarball
         uses: actions/upload-artifact@master
         # GitHub automatically zips the artifacts (there's no way to create
@@ -91,4 +91,4 @@ jobs:
         # Letting it zip a tarball preserves flags in the compressed files.
         with:
           name: dosbox-staging-linux-x86_64
-          path: dosbox-staging-${{ env.VERSION }}.tar.xz
+          path: dosbox-staging-linux-${{ env.VERSION }}.tar.xz

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -150,10 +150,9 @@ jobs:
           sed -i "s|%GIT_BRANCH%|${GITHUB_REF#refs/heads/}|" dest/README.txt
           sed -i "s|%GITHUB_REPO%|$GITHUB_REPOSITORY|"       dest/README.txt
           # Create dir for zipping
-          mkdir dosbox-staging-windows-x86
-          mv dest dosbox-staging-windows-x86/dosbox-staging-${{ env.VERSION }}
+          mv dest dosbox-staging-windows-${{ env.VERSION }}
       - name: Upload package
         uses: actions/upload-artifact@master
         with:
-          name: dosbox-staging-windows-x86
-          path: dosbox-staging-windows-x86
+          name: dosbox-staging-windows-${{ env.VERSION }}
+          path: dosbox-staging-windows-${{ env.VERSION }}


### PR DESCRIPTION
When uploading builds somewhere (e.g. to Vogons forum), the packages need to be renamed to include the OS name.

Doing this manually got a bit tedious, with this change, I don't need to repackage files any more (only unpack linux zip).