### PR TITLE
Make mappings reloadable

### DIFF
--- a/README
+++ b/README
@@ -712,23 +712,25 @@ CONFIG -get "section property"
         config -set "cpu cycles=10000"
     3. To turn EMS memory emulation off:
         config -set "dos ems=false"
-    4. To check which cpu core is being used.
+    4. To change the key mappings
+        config -set "sdl mapperfile=/path/to/mapper-file.map"
+    5. To check which cpu core is being used.
         config -get "cpu core"
-    5. To view the list of possible cpu cores:
+    6. To view the list of possible cpu cores:
         config -help cpu core
-    6. To change the machine type and restart:
+    7. To change the machine type and restart:
         config -set "machine cga"
         config -wc -r
-    7. To configure the autoexec section to auto-mount a directory at start:
+    8. To configure the autoexec section to auto-mount a directory at start:
         config -axadd "mount c c:\dosgames" "c:"
         config -wc
-    8. To create a specific config file in the config directory:
+    9. To create a specific config file in the config directory:
         config -set "dos ems=false"
         config -set "cpu cycles=10000"
         config -set "core dynamic"
         config -axadd "mount c c:\dosgames" "c:" "cd my_game" "my_game"
         config -wc my_config.conf
-    9. To restart DOSBox from a specific config file in the config directory:
+    10. To restart DOSBox from a specific config file in the config directory:
         config -r -conf my_config.conf
 
 LOADFIX [-size] [program] [program-parameters]
@@ -1206,6 +1208,10 @@ If you change the default mapping, you can save your changes by clicking on
 the configuration file (the mapperfile= entry). At startup, DOSBox will load
 your mapperfile, if it is present in the DOSBox configuration file.
 
+
+Additionally, the mapperfile configuration entry can by changed with the CONFIG
+program, and will take effect immediately.
+    config -set "sdl mapperfile=/path/to/mapper-file.map"
 
 
 ===================


### PR DESCRIPTION
This allows batch scripts to change keybindings, and is useful for my DOS Games menu
How to use:
```
Z:\> config -set sdl mapperfile=path/to/new/mapperfile.map
```
I'm unsure if this interacts well with the CAPS and NUMLOCK code at the bottom of MAPPER_Init,
as those now get run every time the mapper reloads.

A natural extension of this would be to add the ability to load a mapping from within the MAPPER UI.