### PR TITLE
Expand mouse control methods

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -127,7 +127,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 614
+          MAX_BUGS: 613
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/video.h
+++ b/include/video.h
@@ -69,8 +69,4 @@ bool GFX_SDLUsingWinDIB(void);
 void MAPPER_UpdateJoysticks(void);
 #endif
 
-/* Mouse related */
-void GFX_CaptureMouse(void);
-extern bool mouselocked; //true if mouse is confined to window
-
 #endif

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -40,6 +40,10 @@
 #include "support.h"
 #include "video.h"
 
+/* Mouse related */
+void GFX_ToggleMouseCapture(void);
+extern SDL_bool mouse_is_captured; //true if mouse is confined to window
+
 enum {
 	CLR_BLACK=0,
 	CLR_GREY=1,
@@ -2477,10 +2481,10 @@ SDL_Surface* SDL_SetVideoMode_Wrap(int width,int height,int bpp,Bit32u flags);
 void MAPPER_RunInternal() {
 	int cursor = SDL_ShowCursor(SDL_QUERY);
 	SDL_ShowCursor(SDL_ENABLE);
-	bool mousetoggle=false;
-	if(mouselocked) {
-		mousetoggle=true;
-		GFX_CaptureMouse();
+	bool mousetoggle = false;
+	if (mouse_is_captured) {
+		mousetoggle = true;
+		GFX_ToggleMouseCapture();
 	}
 
 	/* Be sure that there is no update in progress */
@@ -2530,7 +2534,8 @@ void MAPPER_RunInternal() {
 #if defined (REDUCE_JOYSTICK_POLLING)
 	SDL_JoystickEventState(SDL_DISABLE);
 #endif
-	if(mousetoggle) GFX_CaptureMouse();
+	if (mousetoggle)
+		GFX_ToggleMouseCapture();
 	SDL_ShowCursor(cursor);
 	GFX_ResetScreen();
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -546,7 +546,7 @@ static SDL_Window * GFX_SetupWindowScaled(SCREEN_TYPES screenType)
 			 * (partly caused by the rounding issues fix in RENDER_SetSize)
 			 */
 			sdl.clip.w=(Bit16u)(sdl.draw.width*sdl.draw.scalex*ratio_h + 0.4);
-			sdl.clip.h=(Bit16u)fixedHeight;
+			sdl.clip.h = fixedHeight;
 		}
 
 		if (sdl.desktop.fullscreen) {
@@ -728,7 +728,7 @@ dosurface:
 		if (sdl.opengl.pixel_buffer_object) {
 			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
 			if (sdl.opengl.buffer) glDeleteBuffersARB(1, &sdl.opengl.buffer);
-		} else if (sdl.opengl.framebuf) {
+		} else {
 			free(sdl.opengl.framebuf);
 		}
 		sdl.opengl.framebuf=0;
@@ -1205,7 +1205,7 @@ static void OutputString(Bitu x,Bitu y,const char * text,Bit32u color,Bit32u col
 		for (i=0;i<14;i++) {
 			Bit8u map=*font++;
 			for (j=0;j<8;j++) {
-				if (map & 0x80) *((Bit32u*)(draw_line+j))=color; else *((Bit32u*)(draw_line+j))=color2;
+				*(draw_line + j) = map & 0x80 ? color : color2;
 				map<<=1;
 			}
 			draw_line+=output_surface->pitch/4;
@@ -1897,7 +1897,7 @@ void Config_Add_SDL() {
 	std::string mouse_control_defaults(mouse_controls[0]);
 	mouse_control_defaults += " ";
 	mouse_control_defaults += middle_controls[0];
-	Pmulti->SetValue(mouse_control_defaults.c_str());
+	Pmulti->SetValue(mouse_control_defaults);
 
 	// Add the mouse and middle control as sub-sections
 	Psection = Pmulti->GetSection();
@@ -1918,7 +1918,7 @@ void Config_Add_SDL() {
 		"                   or when seamless control is set. Ctrl-F10 will also uncapture the mouse.\n"
 		"Defaults (if not present or incorrect): ");
 	mouse_control_help += mouse_control_defaults;
-	Pmulti->Set_help(mouse_control_help.c_str());
+	Pmulti->Set_help(mouse_control_help);
 
 	Pmulti = sdl_sec->Add_multi("sensitivity",Property::Changeable::Always, ",");
 	Pmulti->Set_help("Mouse sensitivity. The optional second parameter specifies vertical sensitivity (e.g. 100,-50).");
@@ -2053,6 +2053,7 @@ void restart_program(std::vector<std::string> & parameters) {
 	delete [] newargs;
 }
 void Restart(bool pressed) { // mapper handler
+	(void) pressed; // deliberately unused but required for API compliance
 	restart_program(control->startup_params);
 }
 

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -135,7 +135,6 @@ bool Mouse_SetPS2State(bool use) {
 		return false;
 	}
 	useps2callback = use;
-	Mouse_AutoLock(useps2callback);
 	PIC_SetIRQMask(MOUSE_IRQ,!useps2callback);
 	return true;
 }
@@ -143,13 +142,11 @@ bool Mouse_SetPS2State(bool use) {
 void Mouse_ChangePS2Callback(Bit16u pseg, Bit16u pofs) {
 	if ((pseg==0) && (pofs==0)) {
 		ps2callbackinit = false;
-		Mouse_AutoLock(false);
 	} else {
 		ps2callbackinit = true;
 		ps2cbseg = pseg;
 		ps2cbofs = pofs;
 	}
-	Mouse_AutoLock(ps2callbackinit);
 }
 
 void DoPS2Callback(Bit16u data, Bit16s mouseX, Bit16s mouseY) {
@@ -731,12 +728,10 @@ static Bitu INT33_Handler(void) {
 		reg_ax=0xffff;
 		reg_bx=MOUSE_BUTTONS;
 		Mouse_Reset();
-		Mouse_AutoLock(true);
 		break;
 	case 0x01:	/* Show Mouse */
 		if(mouse.hidden) mouse.hidden--;
 		mouse.updateRegion_y[1] = -1; //offscreen
-		Mouse_AutoLock(true);
 		DrawCursor();
 		break;
 	case 0x02:	/* Hide Mouse */
@@ -853,7 +848,6 @@ static Bitu INT33_Handler(void) {
 		mouse.sub_mask=reg_cx;
 		mouse.sub_seg=SegValue(es);
 		mouse.sub_ofs=reg_dx;
-		Mouse_AutoLock(true); //Some games don't seem to reset the mouse before using
 		break;
 	case 0x0f:	/* Define mickey/pixel rate */
 		Mouse_SetMickeyPixelRate(reg_cx,reg_dx);


### PR DESCRIPTION
Replaces the `autolock = true/false` configuration setting with `mouse_control = ...` having a two-value setting.

The first value defines how the mouse is controlled:

- **onclick**:   The mouse will be captured after the first click inside the window.
- **onstart**:   The mouse is captured immediately on start (similar to real DOS).
- **seamless**:           The mouse can move seamlessly in and out of DOSBox _and cannot be captured_.
- **nomouse**:            The mouse is disabled and hidden without any input sent to the game.

The second value defines how middle-clicks are handled:

- **middlegame**:    Middle-clicks are sent to the game (not used to uncapture the mouse).
- **middlerelease**:  Middle-click will uncapture the mouse when windowed (not sent to the game).  However, middle-clicks are always sent to the game when `fullscreen` or when `seamless` control is set.

The default setting of `onclick middlegame` reproduces DOSBox's existing behavior.

State is retained across full-screen and windowed transitions. The minimum number of capture/visibility toggles are made (typically one or none) during the various window events resulting a consistent and solid feel to mouse behavior.