### PR TITLE
Fix six Coverity and PVS analysis bugs

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1716,8 +1716,8 @@ static void DrawButtons(void) {
 
 static CKeyEvent * AddKeyButtonEvent(Bitu x,Bitu y,Bitu dx,Bitu dy,char const * const title,char const * const entry,KBD_KEYS key) {
 	char buf[64];
-	strcpy(buf,"key_");
-	strcat(buf,entry);
+	safe_strcpy(buf, "key_");
+	safe_strcat(buf, entry);
 	CKeyEvent * event=new CKeyEvent(buf,key);
 	new CEventButton(x,y,dx,dy,title,event);
 	return event;
@@ -2217,8 +2217,8 @@ void MAPPER_AddHandler(MAPPER_Handler * handler,MapKeys key,Bitu mods,char const
 		if(strcmp((*it)->buttonname,buttonname) == 0) return;
 
 	char tempname[17];
-	strcpy(tempname,"hand_");
-	strcat(tempname,eventname);
+	safe_strcpy(tempname, "hand_");
+	safe_strcat(tempname, eventname);
 	new CHandlerEvent(tempname,handler,key,mods,buttonname);
 	return ;
 }


### PR DESCRIPTION
Fix the following SDL main & mapper Coverity and PVS analysis issues (click the images to see clean 1:1 resolution):

---
**Expression 'textonly' is always true.**

![2020-02-01_23-14_1](https://user-images.githubusercontent.com/1557255/73604655-386fc680-4549-11ea-972a-54a5f2afb7ae.png)

---
**Handling of two different exception types is identical.**

![2020-02-01_23-14](https://user-images.githubusercontent.com/1557255/73604656-386fc680-4549-11ea-8fd5-fd00ce633b6e.png)

---
**Uncaught exception.**

![2020-02-01_23-05_1](https://user-images.githubusercontent.com/1557255/73604657-386fc680-4549-11ea-865c-435c0c123054.png)

---
**Variable guard is dead.** (also flagged above by PVS)

![2020-02-01_23-05](https://user-images.githubusercontent.com/1557255/73604658-386fc680-4549-11ea-9681-d3ad1bebac40.png)

---
**Copy into fixed-sized buffer can overrun target.**

![2020-02-01_23-04_1](https://user-images.githubusercontent.com/1557255/73604659-386fc680-4549-11ea-811f-866dbf1ff7b7.png)

---
**Copy into fixed-sized buffer can overrun target.**

![2020-02-01_23-04](https://user-images.githubusercontent.com/1557255/73604660-386fc680-4549-11ea-9d39-575e48e0f8cd.png)

---
