### PR TITLE
Fix filename shortening on AmigaOS

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -196,7 +196,7 @@ public:
 		bool        isDir;
 		Bit16u      id;
 		Bitu        nextEntry;
-		Bitu        shortNr;
+		unsigned    shortNr;
 		// contents
 		std::vector<CFileInfo*> fileList;
 		std::vector<CFileInfo*> longNameList;
@@ -209,7 +209,7 @@ private:
 	bool		RemoveTrailingDot	(char* shortname);
 	Bits		GetLongName		(CFileInfo* info, char* shortname, const size_t shortname_len);
 	void		CreateShortName		(CFileInfo* dir, CFileInfo* info);
-	Bitu		CreateShortNameID	(CFileInfo* dir, const char* name);
+	unsigned        CreateShortNameID       (CFileInfo* dir, const char* name);
 	int		CompareShortname	(const char* compareName, const char* shortName);
 	bool		SetResult		(CFileInfo* dir, char * &result, Bitu entryNr);
 	bool		IsCachedIn		(CFileInfo* dir);

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -16,23 +16,16 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 #ifndef DOSBOX_DOS_SYSTEM_H
 #define DOSBOX_DOS_SYSTEM_H
 
-#include <vector>
-#ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
-#endif
-#ifndef DOSBOX_CROSS_H
+
+#include <vector>
+
 #include "cross.h"
-#endif
-#ifndef DOSBOX_SUPPORT_H
-#include "support.h"
-#endif
-#ifndef DOSBOX_MEM_H
 #include "mem.h"
-#endif
+#include "support.h"
 
 #define DOS_NAMELENGTH 12
 #define DOS_NAMELENGTH_ASCII (DOS_NAMELENGTH+1)
@@ -301,4 +294,5 @@ void DOS_AddDevice(DOS_Device * adddev);
 void DOS_DelDevice(DOS_Device * dev);
 
 void VFILE_Register(const char * name,Bit8u * data,Bit32u size);
+
 #endif

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -16,23 +16,17 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "dos_system.h"
 
-#include "drives.h"
-#include "dos_inc.h"
-#include "support.h"
-#include "cross.h"
-
-// System includes
-#include <assert.h>
-#include <vector>
-#include <iterator>
 #include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <vector>
 
-#if defined (WIN32)   /* Win 32 */
-#define WIN32_LEAN_AND_MEAN        // Exclude rarely-used stuff from 
-#include <windows.h>
-#endif
-
+#include "cross.h"
+#include "dos_inc.h"
+#include "drives.h"
+#include "support.h"
 
 int fileInfoCounter = 0;
 

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -418,8 +418,10 @@ int DOS_Drive_Cache::CompareShortname(const char* compareName, const char* short
 }
 
 Bitu DOS_Drive_Cache::CreateShortNameID(CFileInfo* curDir, const char* name) {
-	std::vector<CFileInfo*>::size_type filelist_size = curDir->longNameList.size();
-	if (GCC_UNLIKELY(filelist_size<=0)) return 1;	// shortener IDs start with 1
+	assert(curDir);
+	const auto filelist_size = curDir->longNameList.size();
+	if (filelist_size == 0)
+		return 1; // short name IDs start with 1
 
 	Bitu foundNr	= 0;	
 	Bits low		= 0;

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -623,8 +623,8 @@ void DOS_Drive_Cache::CreateShortName(CFileInfo* curDir, CFileInfo* info) {
 		safe_strncpy(info->shortname, tmpName,
 		             tocopy < DOS_NAMELENGTH_ASCII ? tocopy + 1 : DOS_NAMELENGTH_ASCII);
 		// Copy number
-		strncat(info->shortname, "~", DOS_NAMELENGTH_ASCII - strlen(info->shortname) - 1);
-		strncat(info->shortname, short_nr, DOS_NAMELENGTH_ASCII - strlen(info->shortname) - 1);
+		safe_strcat(info->shortname, "~");
+		safe_strcat(info->shortname, short_nr);
 
 		// Add (and cut) Extension, if available
 		if (pos) {


### PR DESCRIPTION
Includes fix developed in #162 and small cleanup in the code around.