### PR TITLE
Unifdef unused functions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,19 +12,19 @@ jobs:
           - name: GCC-5 (Ubuntu 16.04)
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 173
+            max_warnings: 140
           - name: GCC-7 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 176
+            max_warnings: 142
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 195
+            max_warnings: 161
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8
-            max_warnings: 95
+            max_warnings: 63
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,10 +11,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 99
+            max_warnings: 67
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 187
+            max_warnings: 153
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,19 +16,19 @@ jobs:
           - compiler: Clang
             bits: 32
             arch: i686
-            max_warnings: 62
+            max_warnings: 30
           - compiler: Clang
             bits: 64
             arch: x86_64
-            max_warnings: 100
+            max_warnings: 68
           - compiler: GCC
             bits: 32
             arch: i686
-            max_warnings: 153
+            max_warnings: 119
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 192
+            max_warnings: 158
     env:
       CHERE_INVOKING: yes
     steps:

--- a/src/gui/render_templates.h
+++ b/src/gui/render_templates.h
@@ -181,6 +181,7 @@
 #define D5 fc[+2 + SCALER_COMPLEXWIDTH]
 #define D6 fc[+2 + 2*SCALER_COMPLEXWIDTH]
 
+#if (SBPP != 9) || (DBPP != 8)
 
 #if RENDER_USE_ADVANCED_SCALERS>1
 static void conc3d(Cache,SBPP,DBPP) (const void * s) {
@@ -240,7 +241,6 @@ static void conc3d(Cache,SBPP,DBPP) (const void * s) {
 	render.scale.complexHandler();
 }
 #endif
-
 
 /* Simple scalers */
 #define SCALERNAME		Normal1x
@@ -310,6 +310,8 @@ static void conc3d(Cache,SBPP,DBPP) (const void * s) {
 #undef SCALERWIDTH
 #undef SCALERHEIGHT
 #undef SCALERFUNC
+
+#endif // (SBPP != 9) || (DBPP != 8)
 
 #if (DBPP > 8)
 
@@ -437,6 +439,8 @@ static void conc3d(Cache,SBPP,DBPP) (const void * s) {
 
 #if (DBPP > 8)
 
+#if (DBPP != 15)
+
 #include "render_templates_hq.h"
 
 #define SCALERNAME		HQ2x
@@ -493,6 +497,8 @@ static void conc3d(Cache,SBPP,DBPP) (const void * s) {
 #undef SCALERHEIGHT
 #undef SCALERFUNC
 
+#endif // (DBPP != 15)
+
 #define SCALERNAME		AdvInterp2x
 #define SCALERWIDTH		2
 #define SCALERHEIGHT	2
@@ -540,6 +546,8 @@ static void conc3d(Cache,SBPP,DBPP) (const void * s) {
 
 #endif // #if (DBPP > 8)
 
+#if (DBPP != 15)
+
 #define SCALERNAME		AdvMame2x
 #define SCALERWIDTH		2
 #define SCALERHEIGHT	2
@@ -585,6 +593,7 @@ static void conc3d(Cache,SBPP,DBPP) (const void * s) {
 #undef SCALERHEIGHT
 #undef SCALERFUNC
 
+#endif // (DBPP != 15)
 
 #endif // (SBPP == DBPP) && !defined (CACHEWITHPAL)
 

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -127,16 +127,11 @@ public:
 	}
 };
 
-
-
-static void auto_free(const device_t::machine_t& machine, void * buffer) {
+static inline void auto_free(const device_t::machine_t& machine, void * buffer) {
 	free(buffer);
 }
 
 #define auto_alloc_array_clear(m, t, c) calloc(c, sizeof(t) )
 #define auto_alloc_clear(m, t) static_cast<t*>( calloc(1, sizeof(t) ) )
-
-
-
 
 #endif

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -1795,7 +1795,7 @@ void FM_OPL::ResetChip()
 #endif
 }
 
-
+#if 0
 void FM_OPL::postload()
 {
 	for(int ch = 0; ch < sizeof(P_CH)/ sizeof(P_CH[0]); ch++)
@@ -1847,6 +1847,7 @@ void FM_OPL::postload()
 	}
 #endif
 }
+#endif
 
 } // anonymous namespace
 

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -680,6 +680,7 @@ static inline void OPL3_STATUS_RESET(OPL3 *chip,int flag)
 	}
 }
 
+#if 0
 /* IRQ mask set */
 static inline void OPL3_STATUSMASK_SET(OPL3 *chip,int flag)
 {
@@ -688,7 +689,7 @@ static inline void OPL3_STATUSMASK_SET(OPL3 *chip,int flag)
 	OPL3_STATUS_SET(chip,0);
 	OPL3_STATUS_RESET(chip,0);
 }
-
+#endif
 
 /* advance LFO to next sample */
 static inline void advance_lfo(OPL3 *chip)


### PR DESCRIPTION
Figured out how to get rid of all those unused functions generated via "macro meta-programming" in scalers code. Also removed few remaining unused-function warnings.