### PR TITLE
Fix CDDA playback regression in MK3 and DOS Navigator 

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -127,7 +127,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 611
+          MAX_BUGS: 610
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -18,14 +18,14 @@
 
 #include "cdrom.h"
 
-bool CDROM_Interface_Fake :: GetAudioTracks(int& stTrack, int& end, TMSF& leadOut) {
+bool CDROM_Interface_Fake::GetAudioTracks(uint8_t& stTrack, uint8_t& end, TMSF& leadOut) {
 	stTrack = end = 1;
 	leadOut.min	= 60;
 	leadOut.sec = leadOut.fr = 0;
 	return true;
 }
 
-bool CDROM_Interface_Fake :: GetAudioTrackInfo(int track, TMSF& start, unsigned char& attr) {
+bool CDROM_Interface_Fake::GetAudioTrackInfo(uint8_t track, TMSF& start, unsigned char& attr) {
 	if (track>1) return false;
 	start.min = start.fr = 0;
 	start.sec = 2;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -85,12 +85,12 @@ public:
 	virtual ~CDROM_Interface        (void) {}
 	virtual bool SetDevice          (char *path) = 0;
 	virtual bool GetUPC             (unsigned char& attr, char* upc) = 0;
-	virtual bool GetAudioTracks     (int& stTrack, int& end, TMSF& leadOut) = 0;
-	virtual bool GetAudioTrackInfo  (int track, TMSF& start, unsigned char& attr) = 0;
+	virtual bool GetAudioTracks     (uint8_t& stTrack, uint8_t& end, TMSF& leadOut) = 0;
+	virtual bool GetAudioTrackInfo  (uint8_t track, TMSF& start, unsigned char& attr) = 0;
 	virtual bool GetAudioSub        (unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos) = 0;
 	virtual bool GetAudioStatus     (bool& playing, bool& pause) = 0;
 	virtual bool GetMediaTrayStatus (bool& mediaPresent, bool& mediaChanged, bool& trayOpen) = 0;
-	virtual bool PlayAudioSector    (unsigned long start,unsigned long len) = 0;
+	virtual bool PlayAudioSector    (uint64_t start, uint64_t len) = 0;
 	virtual bool PauseAudio         (bool resume) = 0;
 	virtual bool StopAudio          (void) = 0;
 	virtual void ChannelControl     (TCtrl ctrl) = 0;
@@ -104,12 +104,12 @@ class CDROM_Interface_Fake : public CDROM_Interface
 public:
 	bool SetDevice          (char *) { return true; }
 	bool GetUPC             (unsigned char& attr, char* upc) { attr = 0; strcpy(upc,"UPC"); return true; };
-	bool GetAudioTracks     (int& stTrack, int& end, TMSF& leadOut);
-	bool GetAudioTrackInfo  (int track, TMSF& start, unsigned char& attr);
+	bool GetAudioTracks     (uint8_t& stTrack, uint8_t& end, TMSF& leadOut);
+	bool GetAudioTrackInfo  (uint8_t track, TMSF& start, unsigned char& attr);
 	bool GetAudioSub        (unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos);
 	bool GetAudioStatus     (bool& playing, bool& pause);
 	bool GetMediaTrayStatus (bool& mediaPresent, bool& mediaChanged, bool& trayOpen);
-	bool PlayAudioSector    (unsigned long /*start*/,unsigned long /*len*/) { return true; };
+	bool PlayAudioSector    (uint64_t start, uint64_t len) { (void)start; (void)len; return true; };
 	bool PauseAudio         (bool /*resume*/) { return true; };
 	bool StopAudio          (void) { return true; };
 	void ChannelControl     (TCtrl ctrl) { (void)ctrl; // unused by part of the API
@@ -126,15 +126,15 @@ private:
 	protected:
 		TrackFile(Bit16u _chunkSize) : chunkSize(_chunkSize) {}
 	public:
-		virtual         ~TrackFile() = default;
-		virtual bool    read(Bit8u *buffer, int seek, int count) = 0;
-		virtual bool    seek(Bit32u offset) = 0;
-		virtual Bit32u  decode(Bit16s *buffer, Bit32u desired_track_frames) = 0;
-		virtual Bit16u  getEndian() = 0;
-		virtual Bit32u  getRate() = 0;
-		virtual Bit8u   getChannels() = 0;
-		virtual int     getLength() = 0;
-		const Bit16u    chunkSize;
+		virtual          ~TrackFile() = default;
+		virtual bool     read(Bit8u *buffer, int seek, int count) = 0;
+		virtual bool     seek(Bit32u offset) = 0;
+		virtual uint64_t decode(Bit16s *buffer, uint32_t desired_track_frames) = 0;
+		virtual Bit16u   getEndian() = 0;
+		virtual Bit32u   getRate() = 0;
+		virtual Bit8u    getChannels() = 0;
+		virtual int      getLength() = 0;
+		const Bit16u     chunkSize;
 	};
 
 	class BinaryFile : public TrackFile {
@@ -148,7 +148,7 @@ private:
 
 		bool            read(Bit8u *buffer, int seek, int count);
 		bool            seek(Bit32u offset);
-		Bit32u          decode(Bit16s *buffer, Bit32u desired_track_frames);
+		uint64_t        decode(Bit16s *buffer, Bit32u desired_track_frames);
 		Bit16u          getEndian();
 		Bit32u          getRate() { return 44100; }
 		Bit8u           getChannels() { return 2; }
@@ -172,7 +172,7 @@ private:
 		                    (void)count;  // ...
 		                    return false; }
 		bool            seek(Bit32u offset);
-		Bit32u          decode(Bit16s *buffer, Bit32u desired_track_frames);
+		uint64_t        decode(Bit16s *buffer, Bit32u desired_track_frames);
 		Bit16u          getEndian();
 		Bit32u          getRate();
 		Bit8u           getChannels();
@@ -185,12 +185,12 @@ public:
 	// Nested struct definition
 	struct Track {
 		std::shared_ptr<TrackFile> file       = nullptr;
-		int                        number     = 0;
-		int                        attr       = 0;
-		int                        start      = 0;
-		int                        length     = 0;
-		int                        skip       = 0;
-		int                        sectorSize = 0;
+		uint32_t                   start      = 0;
+		uint32_t                   length     = 0;
+		uint32_t                   skip       = 0;
+		uint16_t                   number     = 0;
+		uint16_t                   sectorSize = 0;
+		uint8_t                    attr       = 0;
 		bool                       mode2      = false;
 	};
 	CDROM_Interface_Image           (Bit8u _subUnit);
@@ -198,12 +198,12 @@ public:
 	void	InitNewMedia            (void);
 	bool	SetDevice               (char *path);
 	bool	GetUPC                  (unsigned char& attr, char* upc);
-	bool	GetAudioTracks          (int& stTrack, int& end, TMSF& leadOut);
-	bool	GetAudioTrackInfo       (int track, TMSF& start, unsigned char& attr);
+	bool	GetAudioTracks          (uint8_t& stTrack, uint8_t& end, TMSF& leadOut);
+	bool	GetAudioTrackInfo       (uint8_t track, TMSF& start, unsigned char& attr);
 	bool	GetAudioSub             (unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos);
 	bool	GetAudioStatus          (bool& playing, bool& pause);
 	bool	GetMediaTrayStatus      (bool& mediaPresent, bool& mediaChanged, bool& trayOpen);
-	bool	PlayAudioSector         (unsigned long start,unsigned long len);
+	bool	PlayAudioSector         (uint64_t start, uint64_t len);
 	bool	PauseAudio              (bool resume);
 	bool	StopAudio               (void);
 	void	ChannelControl          (TCtrl ctrl);
@@ -221,10 +221,10 @@ private:
 		MixerChannel          *channel;
 		CDROM_Interface_Image *cd;
 		void                  (MixerChannel::*addFrames) (Bitu, const Bit16s*);
-		Bit32u                startSector;
-		Bit32u                totalRedbookFrames;
-		Bit32u                playedTrackFrames;
-		Bit32u                totalTrackFrames;
+		uint32_t              startSector;
+		uint32_t              totalRedbookFrames;
+		uint64_t              playedTrackFrames;
+		uint64_t              totalTrackFrames;
 		bool                  isPlaying;
 		bool                  isPaused;
 	} player;
@@ -232,7 +232,7 @@ private:
 	// Private utility functions
 	bool  LoadIsoFile(char *filename);
 	bool  CanReadPVD(TrackFile *file, int sectorSize, bool mode2);
-	std::vector<Track>::iterator GetTrack(int sector);
+	std::vector<Track>::iterator GetTrack(const uint32_t sector);
 	static void CDAudioCallBack (Bitu desired_frames);
 
 	// Private functions for cue sheet processing

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -188,8 +188,8 @@ public:
 		uint32_t                   start      = 0;
 		uint32_t                   length     = 0;
 		uint32_t                   skip       = 0;
-		uint16_t                   number     = 0;
 		uint16_t                   sectorSize = 0;
+		uint8_t                    number     = 0;
 		uint8_t                    attr       = 0;
 		bool                       mode2      = false;
 	};

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -884,6 +884,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 	int currPregap = 0;
 	int totalPregap = 0;
 	int prestart = -1;
+	int track_number;
 	bool success;
 	bool canAddTrack = false;
 	char tmp[MAX_FILENAME_LENGTH];  // dirname can change its argument
@@ -916,8 +917,9 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 			currPregap = 0;
 			prestart = -1;
 
-			line >> track.number;
-			string type;
+			line >> track_number; // (cin) read into a true int first
+			track.number = track_number; // then assign to the uint8_t
+			string type;   
 			GetCueKeyword(type, line);
 
 			if (type == "AUDIO") {

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -83,13 +83,19 @@ bool CDROM_Interface_Image::BinaryFile::read(Bit8u *buffer, int seek, int count)
 int CDROM_Interface_Image::BinaryFile::getLength()
 {
 	// Guard: only proceed with a valid file
-	if (file == nullptr) return -1;
+	if (file == nullptr)
+		return -1;
 
-	std::streampos original_pos = file->tellg();
+	// All read operations involve an absolute position and
+	// this function isn't called in other threads, therefore
+	// we don't need to retain the original read position.
 	file->seekg(0, ios::end);
 	const int length = static_cast<int>(file->tellg());
-	file->seekg(original_pos, ios::end);
+#ifdef DEBUG
+	LOG_MSG("CDROM: BinaryLength (in milliseconds) = %d", length);
+#endif
 	return length;
+
 }
 
 Bit16u CDROM_Interface_Image::BinaryFile::getEndian()

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -573,45 +573,25 @@ bool CDROM_Interface_Image::PlayAudioSector(uint64_t start, uint64_t len)
 
 bool CDROM_Interface_Image::PauseAudio(bool resume)
 {
-	// Guard: Bail if our mixer channel hasn't been allocated
-	if (player.channel == nullptr) {
-#ifdef DEBUG
-		LOG_MSG("CDROM: PauseAudio => game toggled before playing audio");
-#endif
-		return false;
-	}
-
-	// Only switch states if needed
-	if (player.isPaused == resume) {
+	player.isPaused = !resume;
+	if (player.channel)
 		player.channel->Enable(resume);
-		player.isPaused = !resume;
 #ifdef DEBUG
-		LOG_MSG("CDROM: PauseAudio => audio is now %s",
-		        resume ? "unpaused" : "paused");
+	LOG_MSG("CDROM: PauseAudio => audio is now %s",
+	        resume ? "unpaused" : "paused");
 #endif
-	}
 	return true;
 }
 
 bool CDROM_Interface_Image::StopAudio(void)
 {
-	// Guard: Bail if our mixer channel hasn't been allocated
-	if (player.channel == nullptr) {
-#ifdef DEBUG
-		LOG_MSG("CDROM: StopAudio => game tried stopping the CD before playing audio");
-#endif
-		return false;
-	}
-
-	// Only switch states if needed
-	if (player.isPlaying) {
+	player.isPlaying = false;
+	player.isPaused = false;
+	if (player.channel)
 		player.channel->Enable(false);
-		player.isPlaying = false;
-		player.isPaused = false;
 #ifdef DEBUG
 	LOG_MSG("CDROM: StopAudio => stopped playback and halted the mixer");
 #endif
-	}
 	return true;
 }
 

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -406,7 +406,8 @@ void CMscdex::GetDriverInfo	(PhysPt data) {
 
 bool CMscdex::GetCDInfo(Bit8u subUnit, Bit8u& tr1, Bit8u& tr2, TMSF& leadOut) {
 	if (subUnit>=numDrives) return false;
-	int tr1i,tr2i;
+	uint8_t tr1i;
+	uint8_t tr2i;
 	// Assume Media change
 	cdrom[subUnit]->InitNewMedia();
 	dinfo[subUnit].lastResult = cdrom[subUnit]->GetAudioTracks(tr1i,tr2i,leadOut);
@@ -414,8 +415,8 @@ bool CMscdex::GetCDInfo(Bit8u subUnit, Bit8u& tr1, Bit8u& tr2, TMSF& leadOut) {
 		tr1 = tr2 = 0;
 		memset(&leadOut,0,sizeof(leadOut));
 	} else {
-		tr1 = (Bit8u) tr1i;
-		tr2 = (Bit8u) tr2i;
+		tr1 = tr1i;
+		tr2 = tr2i;
 	}
 	return dinfo[subUnit].lastResult;
 }

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -406,18 +406,9 @@ void CMscdex::GetDriverInfo	(PhysPt data) {
 
 bool CMscdex::GetCDInfo(Bit8u subUnit, Bit8u& tr1, Bit8u& tr2, TMSF& leadOut) {
 	if (subUnit>=numDrives) return false;
-	uint8_t tr1i;
-	uint8_t tr2i;
 	// Assume Media change
 	cdrom[subUnit]->InitNewMedia();
-	dinfo[subUnit].lastResult = cdrom[subUnit]->GetAudioTracks(tr1i,tr2i,leadOut);
-	if (!dinfo[subUnit].lastResult) {
-		tr1 = tr2 = 0;
-		memset(&leadOut,0,sizeof(leadOut));
-	} else {
-		tr1 = tr1i;
-		tr2 = tr2i;
-	}
+	dinfo[subUnit].lastResult = cdrom[subUnit]->GetAudioTracks(tr1, tr2, leadOut);
 	return dinfo[subUnit].lastResult;
 }
 

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1300,26 +1300,27 @@ bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name)
 
 bool MSCDEX_HasMediaChanged(Bit8u subUnit)
 {
+	bool has_changed = true;
 	static TMSF leadOut[MSCDEX_MAX_DRIVES];
-
 	TMSF leadnew;
 	Bit8u tr1,tr2; // <== place-holders (use lead-out for change status)
 	if (mscdex->GetCDInfo(subUnit,tr1,tr2,leadnew)) {
-		bool changed = (leadOut[subUnit].min!=leadnew.min) || (leadOut[subUnit].sec!=leadnew.sec) || (leadOut[subUnit].fr!=leadnew.fr);
-		if (changed) {
+		has_changed = (leadOut[subUnit].min != leadnew.min
+		               || leadOut[subUnit].sec != leadnew.sec
+		               || leadOut[subUnit].fr != leadnew.fr);
+		if (has_changed) {
 			leadOut[subUnit].min = leadnew.min;
 			leadOut[subUnit].sec = leadnew.sec;
 			leadOut[subUnit].fr	 = leadnew.fr;
 			mscdex->InitNewMedia(subUnit);
 		}
-		return changed;
-	};
-	if (subUnit<MSCDEX_MAX_DRIVES) {
+	// fail-safe assumes the media has changed (if a valid drive is selected)
+	} else if (subUnit<MSCDEX_MAX_DRIVES) {
 		leadOut[subUnit].min = 0;
 		leadOut[subUnit].sec = 0;
 		leadOut[subUnit].fr	 = 0;
 	}
-	return true;
+	return has_changed;
 }
 
 void MSCDEX_ShutDown(Section* /*sec*/) {

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -920,7 +920,16 @@ static Bit16u MSCDEX_IOCTL_Input(PhysPt buffer,Bit8u drive_unit) {
 					break;
 		case 0x0A : /* Get Audio Disk info */	
 					Bit8u tr1,tr2; TMSF leadOut;
-					if (!mscdex->GetCDInfo(drive_unit,tr1,tr2,leadOut)) return 0x05;
+					if (!mscdex->GetCDInfo(drive_unit,tr1,tr2,leadOut)) {
+						// The MSCDEX spec says that tracks return values
+						// must be bounded inclusively between 1 and 99, so
+						// set acceptable defaults if GetCDInfo fails.
+						tr1 = 1;
+						tr2 = 1;
+						leadOut.min = 0;
+						leadOut.sec = 0;
+						leadOut.fr = 0;
+					}
 					mem_writeb(buffer+1,tr1);
 					mem_writeb(buffer+2,tr2);
 					mem_writeb(buffer+3,leadOut.fr);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -537,7 +537,7 @@ bool CMscdex::ResumeAudio(Bit8u subUnit) {
 
 Bit32u CMscdex::GetVolumeSize(Bit8u subUnit) {
 	if (subUnit>=numDrives) return false;
-	Bit8u tr1,tr2;
+	Bit8u tr1,tr2; // <== place-holders (use lead-out for size calculation)
 	TMSF leadOut;
 	dinfo[subUnit].lastResult = GetCDInfo(subUnit,tr1,tr2,leadOut);
 	if (dinfo[subUnit].lastResult) return (leadOut.min*60*75)+(leadOut.sec*75)+leadOut.fr;
@@ -1294,7 +1294,7 @@ bool MSCDEX_HasMediaChanged(Bit8u subUnit)
 	static TMSF leadOut[MSCDEX_MAX_DRIVES];
 
 	TMSF leadnew;
-	Bit8u tr1,tr2;
+	Bit8u tr1,tr2; // <== place-holders (use lead-out for change status)
 	if (mscdex->GetCDInfo(subUnit,tr1,tr2,leadnew)) {
 		bool changed = (leadOut[subUnit].min!=leadnew.min) || (leadOut[subUnit].sec!=leadnew.sec) || (leadOut[subUnit].fr!=leadnew.fr);
 		if (changed) {


### PR DESCRIPTION
Fixes the MK3 and DN playback regressions reported in https://github.com/dreamer/dosbox-staging/issues/158; big thanks to @kas1e for bringing these to light, testing, and discussing ideas. 

Commits are broken up by theme; focus is on overall correctness and simplification.

Tested on PPC, Linux, and Windows.  Also confirmed that the existing set of CDDA-challenging games are regression-free (Rayman, Destruction Derby, Crown of Swords, and Betrayal at Krondor).  