### PR TITLE
Add a script to fetch and diff GitHub workflow logs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -57,7 +57,7 @@ jobs:
           path: report
       - name: Summarize report
         env:
-          MAX_BUGS: 76
+          MAX_BUGS: 221
         run: |
           # summary
           echo "Full report is included in build Artifacts"


### PR DESCRIPTION
Adds a stand-alone script `./scripts/diff-workflow-against-master.sh` that does a couple things:
1. Pulls the artifacts and logs for the local branch's latest CI run
2. Diffs any failed jobs with the most recent successful equivalent master branch job

The script is fire-and-forget; it takes no argument and just grinds away for a couple seconds until done.  Even if you're not interested in diffing, it's a convenient way to slurp down our current zip files, reports, and logs. 

It currently constructs a directory in `/tmp` to hold content, and the script will clean away older files too so it doesn't get overrun.

The log diff needs improving though.  @dreamer , if you have something smarter than can take in two "raw logs" and diff-out the meaningful gcc differences (and drop everthing elsee), then we can drop that function (or python) in to improve it.  Right now I'm just stripping the prefix time-stamp and then diffing the raw logs; so the resulting diff file is still pretty cluttered.

None the less, it's a first cut that's working - and we can refine it as we go.  Let me know what you think!

Here's output from the start of the run:

![2020-02-11_23-57](https://user-images.githubusercontent.com/1557255/74322456-cfeacb80-4d38-11ea-8c32-3b71a3b318d7.png)
