### PR TITLE
Fix softmodem handling of the escape character and cmd transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ make.log
 *~
 *.swp
 *.tmp
+*.orig
+*.rej
 
 # PVS static analysis outputs or ephemerals
 pvs-*

--- a/README
+++ b/README
@@ -26,7 +26,7 @@ INDEX:
 6. Joystick/Gamepad
 7. KeyMapper
 8. Keyboard Layout
-9. Serial Multiplayer feature
+9. Serial Modem: Multiplayer and BBS Gaming
 10. How to speed up/slow down DOSBox
 11. Troubleshooting
 12. DOSBox Status Window
@@ -1271,9 +1271,9 @@ by DOSBox.
 
 
 
-==============================
-9. Serial Multiplayer feature:
-==============================
+===========================================
+9. Serial Modem: Multiplayer and BBS Gaming
+===========================================
 
 DOSBox can emulate a serial nullmodem cable over network and internet.
 It can be configured through the [serialports] section in the DOSBox
@@ -1316,7 +1316,59 @@ of the nullmodem connection. These are all parameters:
 Example: Be a server listening on TCP port 5000.
    serial1=nullmodem server:<IP or name of the server> port:5000 rxdelay:1000
 
+BBS Gaming
+----------
+DOSBox's serial interface can emulate a telephone modem, which allows original
+DOS terminal applications to either dial or host a BBS on the Internet 
+via the Telnet protocol.
 
+First, configure DOSBox with a serial port emulating a modem:
+
+   [serial]
+   serial1 = modem listenport:2323
+
+Next, launch your favorite DOS terminal or BBS hosting software and configure
+its corresponding serial port with default settings, as follows:
+
+  COM1:
+    - COM port 1
+    - 8N1 data-bits, stop-bits, and parity
+    - 57600 baud
+    - 03F8 address
+    - IRQ4 interrupt
+    - 16550 fifo enabled
+    - Software flow control (Xon/Xoff) enabled
+    - Hardware flow control (CTS/RTS) enabled
+    - Hardware flow control (DSR/DTR) disabled
+
+To dial BBSes on the Internet:
+
+  1) Set your dialing prefix to: ATNET1^MATDT to ensure file-transfers
+     and command mode transitions and handled properly.
+
+  2) Set the phone number of the BBS to its hostname or IP, optionally
+     followed by the Telnet port number, for example:
+
+      - Phone number on non-standard port: remote.bbs.com:2323
+      - Phone number on standard port 23: remote.bbs.com
+
+To host a DOS-based BBS:
+
+ 1) Configure your DOSBox serial port to listen on a Telnet port greater
+    than 1024. This allows you to run DOSbox with normal user privileges
+    as opposed to granting it root or administrator privileges, for example:
+ 
+    [serial]
+    serial1 = modem listenport:2323
+
+ 2) Configure your DOSBox machine to have a static IP address or always
+    receive the sample IP via DHCP.  Typically this is done via your
+    LAN router.
+
+ 3) If your DOSBox machine is behind a router/firewall, add a port-
+    fowarding entry to listen on TCP port 23 and pass it through to
+    port 2323 on DOSBox machine's LAN IP address.  This allows Internet
+    users to dial your BBS using Telnet's default port.
 
 =====================================
 10. How to speed up/slow down DOSBox:

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -165,6 +165,7 @@ private:
 #define MREG_CR_CHAR 3
 #define MREG_LF_CHAR 4
 #define MREG_BACKSPACE_CHAR 5
+#define MREG_GUARD_TIME 12
 
 
 class CSerialModem : public CSerial {


### PR DESCRIPTION
From Marco Maccafferri here: https://sourceforge.net/p/dosbox/patches/287/

> I tried to run a BBS software using dosbox and discovered some issues with how softmodem implemented the escape characters handling to switch to command mode:
> 
> Characters are swallowed instead of passed-through, this causes issue when transmitting strings with the plus character.
> Additional characters before and after the escape sequence don't reset the counters causing switch to command mode even if not intended. For example, connect to a remote and type a+++ it switches to command mode, it should not.
> The attached proposed patch fixes the escape handling:
> 
> Transmission pause is checked before and after the escape sequence, so <pause>+++<pause> is the correct sequence.</pause></pause>
> Extra characters cause the counters to be reset so no unwanted switch is triggered.
> Use register S12 to set the pause timer in 1/50th of seconds, default is 50 = 1 sec.
> Plus characters are passed to the remote.
> With this fix I'm able to run a BBS software and do file transfers with XModem and ZModem without problems.