### PR TITLE
Fix window positioning

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -584,8 +584,8 @@ static SDL_Window * GFX_SetSDLWindowMode(Bit16u width, Bit16u height, bool fulls
 		SDL_SetWindowFullscreen(sdl.window,
 		                        sdl.desktop.full.display_res ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_FULLSCREEN);
 	} else {
-		SDL_SetWindowFullscreen(sdl.window, 0);
 		SDL_SetWindowSize(sdl.window, width, height);
+		SDL_SetWindowFullscreen(sdl.window, 0);
 	}
 	// Maybe some requested fullscreen resolution is unsupported?
 finish:


### PR DESCRIPTION
Corrects two problems with window positioning:
- Window is now always placed back in the original position after moving to fullscreen and back
- Window is not placed in top-left corner any more when starting dosbox-staging in fullscreen mode (only a workaround, but works very well in practice). This is very important fix for Windows 10, where WM uses content-based coordinates, so 0,0 meant the window decorations were not rendered. Now it works OK.

Tested on:
Windows 10, Gnome 3.34 (Wayland and X11), KDE Plasma 5.15, MATE, Cinnamon 4.4.8.

On Windows 10 and all Linux DEs window managers cooperated with SDL2 correctly to select the proper window placement and the correct display to use for fullscreen :)

There are still some unsolved bugs on Wayland when it comes to switching between fullscreen and window, but aside of that it works stellar. Tested with texture and opengl; output surface is sort-of broken in fullscreen for some time, it's unrelated to this PR.