### PR TITLE
Migrate some members of the Player class to smart pointers

### DIFF
--- a/include/mixer.h
+++ b/include/mixer.h
@@ -106,6 +106,18 @@ MixerChannel * MIXER_FindChannel(const char * name);
 /* Find the device you want to delete with findchannel "delchan gets deleted" */
 void MIXER_DelChannel(MixerChannel* delchan); 
 
+// A smart pointer deleter for MixerChannel objects
+// Use-case:
+// std::unique_ptr<MixerChannel, MixerChannelDeleter> myChannel;
+// myChannel.reset(MIXER_AddChannel(...));
+//
+struct MixerChannelDeleter {
+	void operator()(MixerChannel *channel) {
+		if (channel)
+			MIXER_DelChannel(channel);
+	}
+};
+
 /* Object to maintain a mixerchannel; As all objects it registers itself with create
  * and removes itself when destroyed. */
 class MixerObject{

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -106,18 +106,6 @@ MixerChannel * MIXER_FindChannel(const char * name);
 /* Find the device you want to delete with findchannel "delchan gets deleted" */
 void MIXER_DelChannel(MixerChannel* delchan); 
 
-// A smart pointer deleter for MixerChannel objects
-// Use-case:
-// std::unique_ptr<MixerChannel, MixerChannelDeleter> myChannel;
-// myChannel.reset(MIXER_AddChannel(...));
-//
-struct MixerChannelDeleter {
-	void operator()(MixerChannel *channel) {
-		if (channel)
-			MIXER_DelChannel(channel);
-	}
-};
-
 /* Object to maintain a mixerchannel; As all objects it registers itself with create
  * and removes itself when destroyed. */
 class MixerObject{

--- a/include/support.h
+++ b/include/support.h
@@ -34,18 +34,6 @@
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
 #endif
 
-// A smart-pointer deleter for SDL-Mutex objects.
-// Use-case example:
-// std::unique_ptr<SDL_mutex, SdlMutexDeleter> myMutex;
-// myMutex.reset(SDL_CreateMutex());
-//
-struct SdlMutexDeleter {
-	void operator()(SDL_mutex* mutex) {
-		if (mutex)
-			SDL_DestroyMutex(mutex);
-	}
-};
-
 // Returns the filename with the prior path stripped.
 // Works with both \ and / directory delimeters.
 std::string get_basename(const std::string& filename);

--- a/include/support.h
+++ b/include/support.h
@@ -27,11 +27,27 @@
 #include <string.h>
 #include <string>
 
+#include <SDL.h>
+
 #ifdef _MSC_VER
 #define strcasecmp(a, b) _stricmp(a, b)
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
 #endif
 
+// A smart-pointer deleter for SDL-Mutex objects.
+// Use-case example:
+// std::unique_ptr<SDL_mutex, SdlMutexDeleter> myMutex;
+// myMutex.reset(SDL_CreateMutex());
+//
+struct SdlMutexDeleter {
+	void operator()(SDL_mutex* mutex) {
+		if (mutex)
+			SDL_DestroyMutex(mutex);
+	}
+};
+
+// Returns the filename with the prior path stripped.
+// Works with both \ and / directory delimeters.
 std::string get_basename(const std::string& filename);
 
 // Include a message in assert, similar to static_assert:

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -221,16 +221,17 @@ public:
 
 private:
 	static struct imagePlayer {
-		Bit16s                                             buffer[MIXER_BUFSIZE * 2] = {0};
 		std::unique_ptr<SDL_mutex, SdlMutexDeleter>        mutex = nullptr;
-		std::unique_ptr<MixerChannel, MixerChannelDeleter> channel = nullptr;
 		std::weak_ptr<TrackFile>                           trackFile;
+		MixerObject                                        channelManager;
+		MixerChannel                                       *channel = nullptr;
 		CDROM_Interface_Image                              *cd = nullptr;
 		void (MixerChannel::*addFrames) (Bitu, const Bit16s*) = nullptr;
 		uint64_t                                           playedTrackFrames = 0;
 		uint64_t                                           totalTrackFrames = 0;
 		uint32_t                                           startSector = 0;
 		uint32_t                                           totalRedbookFrames = 0;
+		int16_t                                            buffer[MIXER_BUFSIZE * REDBOOK_CHANNELS] = {0};
 		bool                                               isPlaying = false;
 		bool                                               isPaused = false;
 	} player;

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -221,19 +221,20 @@ public:
 
 private:
 	static struct imagePlayer {
-		std::unique_ptr<SDL_mutex, SdlMutexDeleter>        mutex = nullptr;
-		std::weak_ptr<TrackFile>                           trackFile;
-		MixerObject                                        channelManager;
-		MixerChannel                                       *channel = nullptr;
-		CDROM_Interface_Image                              *cd = nullptr;
+		// Objects, pointers, and then scalars; in descending size-order.
+		MixerObject              mixerChannel       = {};
+		std::weak_ptr<TrackFile> trackFile          = {};
+		SDL_mutex                *mutex             = nullptr;
+		MixerChannel             *channel           = nullptr;
+		CDROM_Interface_Image    *cd                = nullptr;
 		void (MixerChannel::*addFrames) (Bitu, const Bit16s*) = nullptr;
-		uint64_t                                           playedTrackFrames = 0;
-		uint64_t                                           totalTrackFrames = 0;
-		uint32_t                                           startSector = 0;
-		uint32_t                                           totalRedbookFrames = 0;
-		int16_t                                            buffer[MIXER_BUFSIZE * REDBOOK_CHANNELS] = {0};
-		bool                                               isPlaying = false;
-		bool                                               isPaused = false;
+		uint64_t                 playedTrackFrames  = 0;
+		uint64_t                 totalTrackFrames   = 0;
+		uint32_t                 startSector        = 0;
+		uint32_t                 totalRedbookFrames = 0;
+		int16_t                  buffer[MIXER_BUFSIZE * REDBOOK_CHANNELS] = {0};
+		bool                     isPlaying          = false;
+		bool                     isPaused           = false;
 	} player;
 
 	// Private utility functions

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -32,6 +32,7 @@
 #include <SDL_thread.h>
 
 #include "dosbox.h"
+#include "support.h"
 #include "mem.h"
 #include "mixer.h"
 #include "../libs/decoders/SDL_sound.h"
@@ -220,18 +221,18 @@ public:
 
 private:
 	static struct imagePlayer {
-		Bit16s                buffer[MIXER_BUFSIZE * 2]; // 2 channels (max)
-		SDL_mutex             *mutex;
-		TrackFile             *trackFile;
-		MixerChannel          *channel;
-		CDROM_Interface_Image *cd;
-		void                  (MixerChannel::*addFrames) (Bitu, const Bit16s*);
-		uint32_t              startSector;
-		uint32_t              totalRedbookFrames;
-		uint64_t              playedTrackFrames;
-		uint64_t              totalTrackFrames;
-		bool                  isPlaying;
-		bool                  isPaused;
+		Bit16s                                             buffer[MIXER_BUFSIZE * 2] = {0};
+		std::unique_ptr<SDL_mutex, SdlMutexDeleter>        mutex = nullptr;
+		std::unique_ptr<MixerChannel, MixerChannelDeleter> channel = nullptr;
+		std::weak_ptr<TrackFile>                           trackFile;
+		CDROM_Interface_Image                              *cd = nullptr;
+		void (MixerChannel::*addFrames) (Bitu, const Bit16s*) = nullptr;
+		uint64_t                                           playedTrackFrames = 0;
+		uint64_t                                           totalTrackFrames = 0;
+		uint32_t                                           startSector = 0;
+		uint32_t                                           totalRedbookFrames = 0;
+		bool                                               isPlaying = false;
+		bool                                               isPaused = false;
 	} player;
 
 	// Private utility functions

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -413,8 +413,9 @@ bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr,
 	if (!tracks.empty()) { 	// We have a useable CD; get a valid play-position
 		track_iter track = tracks.begin();
 		// the CD's current track is valid
-		if (player.trackFile.lock()) {
-			const uint32_t sample_rate = player.trackFile.lock()->getRate();
+		const auto track_file = player.trackFile.lock(); // lock() creates a shared_ptr!
+		if (track_file) {
+			const uint32_t sample_rate = track_file->getRate();
 			const uint32_t played_frames = (player.playedTrackFrames
 			                                * REDBOOK_FRAMES_PER_SECOND
 			                                + sample_rate - 1) / sample_rate;


### PR DESCRIPTION
Coming off feedback from the prior PR, this applies some small C++11 finishing touches. 
1. Moves the `mutex` and mixer `channel` raw.pointer members to unique pointers.
2. Moves the `trackFile` raw pointer to a weak pointer.
3. Moves the Player's member initialization from the constructor definitions to the class prototype, which is more direct.

This class still retains its raw `*cd` member, however fixing this ripples up to the array of [26] CD images, and across more code that generically deals with mount points; so this work remains to do.