### PR TITLE
Use sh-compatible syntax in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -476,7 +476,7 @@ AC_ARG_ENABLE(opus-cdda,
 AS_IF([test "x${enable_opus_cdda}" != "xno"],
       [PKG_CHECK_MODULES([OPUSFILE],
                          [opusfile],
-                         [LIBS+=" $OPUSFILE_LIBS"])])
+                         [LIBS="$LIBS $OPUSFILE_LIBS"])])
 AM_CONDITIONAL([USE_OPUS],
                [test "x${OPUSFILE_LIBS}" != "x"])
 


### PR DESCRIPTION
One-line fixup to replaces the bash-syntax: `a+="b"` with sh-compatible `a="a b"`, as `configure` only uses `/bin/sh`. Fixes https://github.com/dreamer/dosbox-staging/issues/190.
Thanks for the report @numberZero! 
 