### PR TITLE
Various warning fixes (and a fix to warning counter)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,15 +12,15 @@ jobs:
           - name: GCC-5 (Ubuntu 16.04)
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 136
+            max_warnings: 96
           - name: GCC-7 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 138
+            max_warnings: 98
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 157
+            max_warnings: 117
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
             max_warnings: 67
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 149
+            max_warnings: 109
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,19 +16,19 @@ jobs:
           - compiler: Clang
             bits: 32
             arch: i686
-            max_warnings: 30
+            max_warnings: 26
           - compiler: Clang
             bits: 64
             arch: x86_64
-            max_warnings: 68
+            max_warnings: 64
           - compiler: GCC
             bits: 32
             arch: i686
-            max_warnings: 115
+            max_warnings: 71
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 153
+            max_warnings: 109
     env:
       CHERE_INVOKING: yes
     steps:

--- a/scripts/count-warnings.py
+++ b/scripts/count-warnings.py
@@ -47,7 +47,14 @@ def count_warning(line, warning_types, warning_files, warning_lines):
     match = WARNING_PATTERN.match(line)
     if not match:
         return 0
-    warning_lines.append(line.strip())
+
+    # Some warnings (e.g. effc++) are reported multiple times, once
+    # for every usage; ignore duplicates.
+    line = line.strip()
+    if line in warning_lines:
+        return 0
+    warning_lines.add(line)
+
     file = match.group(1)
     # line = match.group(2)
     wtype = match.group(3)
@@ -117,7 +124,7 @@ def main():
     total = 0
     warning_types = {}
     warning_files = {}
-    warning_lines = []
+    warning_lines = set()
     args = parse_args()
     for line in get_input_lines(args.logfile):
         total += count_warning(line,

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -357,16 +357,16 @@ static void dyn_fpu_esc2(){
 }
 
 static void dyn_fpu_esc3(){
-	dyn_get_modrm();  
+	dyn_get_modrm();
+	const unsigned group = (decode.modrm.val >> 3) & 7;
+	const unsigned sub = (decode.modrm.val & 7);
 	if (decode.modrm.val >= 0xc0) { 
-		Bitu group=(decode.modrm.val >> 3) & 7;
-		Bitu sub=(decode.modrm.val & 7);
 		switch (group) {
 		case 0x04:
 			switch (sub) {
 			case 0x00:				//FNENI
 			case 0x01:				//FNDIS
-				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %lu", sub);
+				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %u", sub);
 				break;
 			case 0x02:				//FNCLEX FCLEX
 				gen_call_function((void*)&FPU_FCLEX,"");
@@ -376,21 +376,19 @@ static void dyn_fpu_esc3(){
 				break;
 			case 0x04:				//FNSETPM
 			case 0x05:				//FRSTPM
-//				LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
+				// LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
 				break;
 			default:
-				E_Exit("ESC 3:ILLEGAL OPCODE group %lu subfunction %lu", group, sub);
+				E_Exit("ESC 3:ILLEGAL OPCODE group %u subfunction %u", group, sub);
 			}
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %lu subfunction %lu", group, sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %u subfunction %u", group, sub);
 			break;
 		}
 	} else {
-		Bitu group=(decode.modrm.val >> 3) & 7;
-		Bitu sub=(decode.modrm.val & 7);
 		dyn_fill_ea(); 
-		switch(group){
+		switch (group) {
 		case 0x00:	/* FILD */
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_protectflags(); 
@@ -398,7 +396,7 @@ static void dyn_fpu_esc3(){
 			gen_call_function((void*)&FPU_FLD_I32,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x01:	/* FISTTP */
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %u subfunction %u", group, sub);
 			break;
 		case 0x02:	/* FIST */
 			gen_call_function((void*)&FPU_FST_I32,"%Drd",DREG(EA));
@@ -416,7 +414,7 @@ static void dyn_fpu_esc3(){
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %u subfunction %u", group, sub);
 		}
 	}
 }

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -230,7 +230,7 @@ static void dh_fpu_esc2(){
 }
 
 static void dh_fpu_esc3(){
-	dyn_get_modrm();  
+	dyn_get_modrm();
 	const unsigned group = (decode.modrm.val >> 3) & 7;
 	const unsigned sub = (decode.modrm.val & 7);
 	if (decode.modrm.val >= 0xc0) { 

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -231,15 +231,15 @@ static void dh_fpu_esc2(){
 
 static void dh_fpu_esc3(){
 	dyn_get_modrm();  
+	const unsigned group = (decode.modrm.val >> 3) & 7;
+	const unsigned sub = (decode.modrm.val & 7);
 	if (decode.modrm.val >= 0xc0) { 
-		Bitu group=(decode.modrm.val >> 3) & 7;
-		Bitu sub=(decode.modrm.val & 7);
 		switch (group) {
 		case 0x04:
 			switch (sub) {
 			case 0x00:				//FNENI
 			case 0x01:				//FNDIS
-				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %lu", sub);
+				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfunction: %u", sub);
 				break;
 			case 0x02:				//FNCLEX FCLEX
 				cache_addb(0xdb);
@@ -252,27 +252,25 @@ static void dh_fpu_esc3(){
 				break;
 			case 0x04:				//FNSETPM
 			case 0x05:				//FRSTPM
-//				LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
+				// LOG(LOG_FPU,LOG_ERROR)("80267 protected mode (un)set. Nothing done");
 				break;
 			default:
-				E_Exit("ESC 3:ILLEGAL OPCODE group %lu subfunction %lu", group, sub);
+				E_Exit("ESC 3:ILLEGAL OPCODE group %u subfunction %u", group, sub);
 			}
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %lu subfunction %lu", group, sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3:Unhandled group %u subfunction %u", group, sub);
 			break;
 		}
 	} else {
-		Bitu group=(decode.modrm.val >> 3) & 7;
-		Bitu sub=(decode.modrm.val & 7);
 		dyn_fill_ea(); 
-		switch(group){
+		switch (group) {
 		case 0x00:	/* FILD */
 			gen_call_function((void*)&FPU_FLD_32,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdb);
 			break;
 		case 0x01:	/* FISTTP */
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %u subfunction %u", group, sub);
 			break;
 		case 0x02:	/* FIST */
 			dh_fpu_mem(0xdb);
@@ -291,7 +289,7 @@ static void dh_fpu_esc3(){
 			gen_call_function((void*)&FPU_FST_80,"%Drd",DREG(EA));
 			break;
 		default:
-			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %lu subfunction %lu", group, sub);
+			LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %u subfunction %u", group, sub);
 		}
 	}
 }
@@ -365,7 +363,7 @@ static void dh_fpu_esc6(){
 }
 
 static void dh_fpu_esc7(){
-	dyn_get_modrm();  
+	dyn_get_modrm();
 	Bitu group=(decode.modrm.val >> 3) & 7;
 	Bitu sub=(decode.modrm.val & 7);
 	if (decode.modrm.val >= 0xc0) { 

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -309,7 +309,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,Bit8u flags) {
 			if (imagesize+headersize<512) imagesize = 512-headersize;
 		}
 	}
-	Bit8u * loadbuf=(Bit8u *)new Bit8u[0x10000];
+	uint8_t *loadbuf = new uint8_t[0x10000];
 	if (flags!=OVERLAY) {
 		/* Create an environment block */
 		envseg=block.exec.envseg;
@@ -347,6 +347,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,Bit8u flags) {
 				DOS_CloseFile(fhandle);
 				DOS_SetError(DOSERR_INSUFFICIENT_MEMORY);
 				DOS_FreeMemory(envseg);
+				delete [] loadbuf;
 				return false;
 			}
 		}
@@ -398,7 +399,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,Bit8u flags) {
 			mem_writew(address,mem_readw(address)+relocate);
 		}
 	}
-	delete[] loadbuf;
+	delete [] loadbuf;
 	DOS_CloseFile(fhandle);
 
 	/* Setup a psp */

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -16,14 +16,14 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
  
-
-#include <math.h>
-#include "dosbox.h"
 #include "mixer.h"
+
+#include <algorithm>
+#include <cmath>
+
 #include "timer.h"
 #include "setup.h"
 #include "pic.h"
-
 
 #ifndef PI
 #define PI 3.14159265358979323846
@@ -331,14 +331,14 @@ public:
 		spkr.mode=SPKR_OFF;
 		spkr.last_ticks=0;
 		spkr.last_index=0;
-		spkr.rate=section->Get_int("pcrate");
+		spkr.rate = std::max(section->Get_int("pcrate"), 8000);
 		spkr.pit_mode=3;
 		spkr.pit_max=(1000.0f/PIT_TICK_RATE)*1320;
 		spkr.pit_half=spkr.pit_max/2;
 		spkr.pit_new_max=spkr.pit_max;
 		spkr.pit_new_half=spkr.pit_half;
 		spkr.pit_index=0;
-		spkr.min_tr=(PIT_TICK_RATE+spkr.rate/2-1)/(spkr.rate/2);
+		spkr.min_tr = (PIT_TICK_RATE + spkr.rate/2 - 1) / (spkr.rate / 2);
 		spkr.used=0;
 		/* Register the sound channel */
 		spkr.chan=MixerChan.Install(&PCSPEAKER_CallBack,spkr.rate,"SPKR");

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -519,11 +519,18 @@ static Bitu INT13_DiskHandler(void) {
 				CALLBACK_SCF(true);
 				return CBRET_NONE;
 			}
-			Bit32u tmpheads, tmpcyl, tmpsect, tmpsize;
-			imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
-			Bit64u largesize = tmpheads*tmpcyl*tmpsect*tmpsize;
-			largesize/=512;
-			Bit32u ts = static_cast<Bit32u>(largesize);
+
+			uint32_t tmpheads, tmpcyl, tmpsect, tmpsize;
+			imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl,
+			                                      &tmpsect, &tmpsize);
+			// Store intermediate calculations in 64-bit to avoid
+			// accidental integer overflow on temporary value:
+			uint64_t largesize = tmpheads;
+			largesize *= tmpcyl;
+			largesize *= tmpsect;
+			largesize *= tmpsize;
+			const uint32_t ts = static_cast<uint32_t>(largesize / 512);
+
 			reg_ah = (drivenum <2)?1:3; //With 2 for floppy MSDOS starts calling int 13 ah 16
 			if(reg_ah == 3) {
 				reg_cx = static_cast<Bit16u>(ts >>16);

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -123,11 +123,13 @@ char * lowcase(char * str) {
 	return str;
 }
 
-
-
-bool ScanCMDBool(char * cmd,char const * const check) {
-	char * scan=cmd;size_t c_len=strlen(check);
-	while ((scan=strchr(scan,'/'))) {
+bool ScanCMDBool(char * cmd, char const * const check)
+{
+	if (cmd == nullptr)
+		return false;
+	char *scan = cmd;
+	const size_t c_len = strlen(check);
+	while ((scan = strchr(scan,'/'))) {
 		/* found a / now see behind it */
 		scan++;
 		if (strncasecmp(scan,check,c_len)==0 && (scan[c_len]==' ' || scan[c_len]=='\t' || scan[c_len]=='/' || scan[c_len]==0)) {


### PR DESCRIPTION
Initially, I wanted this branch to be about few Coverity fixes and use it only for piggy-backing a fix to our warning counter script, but it turned out all our GCC builds were inflating the number of warnings - so that's the reason for a massive drop in warning count.

I adjusted the counter to make effc++ warning numbers more realistic. It seems like GCC was reporting maybe-unitialized warnings multiple times (maybe it was caused by some macro usage, I'm not sure - I downloaded logs from one build and confirmed there were duplicated warning lines).

As for others; I hope *finally* we'll have Coverity below 1.00 issues / 1k LOC :)