### PR TITLE
fixup! Warning iterator-past-end-of-container

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -502,6 +502,7 @@ bool CDROM_Interface_Image::PlayAudioSector(uint64_t start, uint64_t len)
 
 	// Guard: sanity check the request beyond what GetTrack already checks
 	if (len == 0
+	   || track == tracks.end()
 	   || !track_file
 	   || track->attr == 0x40
 	   || !player.channel


### PR DESCRIPTION
Fix this issue caught by Coverity:

```
*** CID 288531:  API usage errors  (INVALIDATE_ITERATOR)
/src/dos/cdrom_image.cpp: 504 in CDROM_Interface_Image::PlayAudioSector(unsigned long, unsigned long)()
498             track_const_iter track = GetTrack(start);
499             std::shared_ptr<TrackFile> track_file;
500             if (track != tracks.end())
501                     track_file = track->file;
502     
503             // Guard: sanity check the request beyond what GetTrack already checks
>>>     CID 288531:  API usage errors  (INVALIDATE_ITERATOR)
>>>     Dereferencing iterator "track" though it is already past the end of its container.
504             if (len == 0
505                || !track_file
506                || track->attr == 0x40
507                || !player.channel
508                || !player.mutex) {
509                     StopAudio();
```
