### PR TITLE
Increment Copyright Year 2020

### DIFF
--- a/.github/scripts/build-and-run-sanitizers.sh
+++ b/.github/scripts/build-and-run-sanitizers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This simple script is used to build, test, and archive the log output from

--- a/.github/scripts/download-and-build-macports.sh
+++ b/.github/scripts/download-and-build-macports.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script downloads and builds MacPorts from source.

--- a/.github/scripts/install-and-update-macports.sh
+++ b/.github/scripts/install-and-update-macports.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script installs and updates MacPorts from an already-compiled

--- a/.github/scripts/prepare-for-macports-cachehit.sh
+++ b/.github/scripts/prepare-for-macports-cachehit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script creates a new writable /opt/local directory with

--- a/.github/scripts/reset-brew.sh
+++ b/.github/scripts/reset-brew.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script removes all existing brew packages, and then

--- a/.github/scripts/shrink-brew.sh
+++ b/.github/scripts/shrink-brew.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script reduces the size of a brew-managed installation on macOS.

--- a/.github/scripts/shrink-macports.sh
+++ b/.github/scripts/shrink-macports.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script reduces the size of a MacPorts installation

--- a/.github/scripts/shrink-msys2.sh
+++ b/.github/scripts/shrink-msys2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script reduces the size of an MSYS2 and MingGW installation

--- a/configure.ac
+++ b/configure.ac
@@ -581,7 +581,7 @@ esac
 
 AH_TOP([
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/bios.h
+++ b/include/bios.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/callback.h
+++ b/include/callback.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019  The DOSBox Team
+ *  Copyright (C) 2019-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/control.h
+++ b/include/control.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/cross.h
+++ b/include/cross.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/dma.h
+++ b/include/dma.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/drives.h
+++ b/include/drives.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/inout.h
+++ b/include/inout.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/ipx.h
+++ b/include/ipx.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/ipxserver.h
+++ b/include/ipxserver.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/joystick.h
+++ b/include/joystick.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/logging.h
+++ b/include/logging.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/mem.h
+++ b/include/mem.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/midi.h
+++ b/include/midi.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/paging.h
+++ b/include/paging.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/pci_bus.h
+++ b/include/pci_bus.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/pic.h
+++ b/include/pic.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/programs.h
+++ b/include/programs.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/regs.h
+++ b/include/regs.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/render.h
+++ b/include/render.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/setup.h
+++ b/include/setup.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/shell.h
+++ b/include/shell.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/support.h
+++ b/include/support.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/timer.h
+++ b/include/timer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/types.h
+++ b/include/types.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019  The DOSBox Team
+ *  Copyright (C) 2019-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/vga.h
+++ b/include/vga.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/video.h
+++ b/include/video.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/scripts/automator/main.sh
+++ b/scripts/automator/main.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Automator is a generic automation tool that helps separate data

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script builds the software for the given build-type (release,

--- a/scripts/dosbox-installer.nsi
+++ b/scripts/dosbox-installer.nsi
@@ -2,7 +2,7 @@
 !define VER_MINOR 74
 !define APP_NAME "DOSBox ${VER_MAYOR}.${VER_MINOR} Installer"
 !define COMP_NAME "DOSBox Team"
-!define COPYRIGHT "Copyright © 2002-2019 DOSBox Team"
+!define COPYRIGHT "Copyright  2002-2020 DOSBox Team"
 !define DESCRIPTION "DOSBox Installer"
 
 VIProductVersion "${VER_MAYOR}.${VER_MINOR}.0.0"

--- a/scripts/list-build-dependencies.sh
+++ b/scripts/list-build-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2019 Kevin R Croft <krcroft@gmail.com>
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # This script prints package dependencies for a given package manmager,

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/helpers.h
+++ b/src/cpu/core_dyn_x86/helpers.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_armv4le-common.h
+++ b/src/cpu/core_dynrec/risc_armv4le-common.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_armv4le-o3.h
+++ b/src/cpu/core_dynrec/risc_armv4le-o3.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-iw.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_armv4le-thumb.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_armv4le.h
+++ b/src/cpu/core_dynrec/risc_armv4le.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_mipsel32.h
+++ b/src/cpu/core_dynrec/risc_mipsel32.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_dynrec/risc_x86.h
+++ b/src/cpu/core_dynrec/risc_x86.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full.cpp
+++ b/src/cpu/core_full.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/ea_lookup.h
+++ b/src/cpu/core_full/ea_lookup.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/loadwrite.h
+++ b/src/cpu/core_full/loadwrite.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/optable.h
+++ b/src/cpu/core_full/optable.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/save.h
+++ b/src/cpu/core_full/save.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_full/support.h
+++ b/src/cpu/core_full/support.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/helpers.h
+++ b/src/cpu/core_normal/helpers.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/prefix_66.h
+++ b/src/cpu/core_normal/prefix_66.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/string.h
+++ b/src/cpu/core_normal/string.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/support.h
+++ b/src/cpu/core_normal/support.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_normal/table_ea.h
+++ b/src/cpu/core_normal/table_ea.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/lazyflags.h
+++ b/src/cpu/lazyflags.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/modrm.cpp
+++ b/src/cpu/modrm.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/modrm.h
+++ b/src/cpu/modrm.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/debug/debug_inc.h
+++ b/src/debug/debug_inc.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/debug/debug_win32.cpp
+++ b/src/debug/debug_win32.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/debug/disasm_tables.h
+++ b/src/debug/disasm_tables.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_mscdex.h
+++ b/src/dos/dos_mscdex.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019  The DOSBox Team
+ *  Copyright (C) 2019-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/dosbox_logo.h
+++ b/src/gui/dosbox_logo.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/midi_alsa.h
+++ b/src/gui/midi_alsa.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/midi_coreaudio.h
+++ b/src/gui/midi_coreaudio.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/midi_oss.h
+++ b/src/gui/midi_oss.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/midi_win32.h
+++ b/src/gui/midi_win32.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_glsl.h
+++ b/src/gui/render_glsl.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_loops.h
+++ b/src/gui/render_loops.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_scalers.cpp
+++ b/src/gui/render_scalers.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_scalers.h
+++ b/src/gui/render_scalers.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_simple.h
+++ b/src/gui/render_simple.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_templates.h
+++ b/src/gui/render_templates.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_templates_hq.h
+++ b/src/gui/render_templates_hq.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_templates_hq2x.h
+++ b/src/gui/render_templates_hq2x.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_templates_hq3x.h
+++ b/src/gui/render_templates_hq3x.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/render_templates_sai.h
+++ b/src/gui/render_templates_sai.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -567,7 +567,7 @@ public:
 			Section_prop *section = static_cast<Section_prop *>(sec);
 			new SectionEditor(getScreen(), 50, 30, section);
 		} else if (arg == "About") {
-			new GUI::MessageBox(getScreen(), 200, 150, 280, "About DOSBox", "\nDOSBox 0.74\nAn emulator for old DOS Games\n\nCopyright 2002-2019\nThe DOSBox Team");
+			new GUI::MessageBox(getScreen(), 200, 150, 280, "About DOSBox", "\nDOSBox 0.74\nAn emulator for old DOS Games\n\nCopyright 2002-2020\nThe DOSBox Team");
 		} else if (arg == "Introduction") {
 			new GUI::MessageBox(getScreen(), 20, 50, 600, "Introduction", MSG_Get("PROGRAM_INTRO"));
 		} else if (arg == "Getting Started") {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -2555,7 +2555,7 @@ int main(int argc, char* argv[]) {
 #endif  //defined(WIN32) && !(C_DEBUG)
 		if (control->cmdline->FindExist("-version") ||
 		    control->cmdline->FindExist("--version") ) {
-			printf("\nDOSBox version %s, copyright 2002-2019 DOSBox Team.\n\n",VERSION);
+			printf("\nDOSBox version %s, copyright 2002-2020 DOSBox Team.\n\n",VERSION);
 			printf("DOSBox is written by the DOSBox Team (See AUTHORS file))\n");
 			printf("DOSBox comes with ABSOLUTELY NO WARRANTY.  This is free software,\n");
 			printf("and you are welcome to redistribute it under certain conditions;\n");
@@ -2575,7 +2575,7 @@ int main(int argc, char* argv[]) {
 
 	/* Display Welcometext in the console */
 	LOG_MSG("DOSBox version %s",VERSION);
-	LOG_MSG("Copyright 2002-2019 DOSBox Team, published under GNU GPL.");
+	LOG_MSG("Copyright 2002-2020 DOSBox Team, published under GNU GPL.");
 	LOG_MSG("---");
 
 	/* Init SDL */

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/ipxserver.cpp
+++ b/src/hardware/ipxserver.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *  OPL2/OPL3 emulation library
  *
  *  This library is free software; you can redistribute it and/or

--- a/src/hardware/opl.h
+++ b/src/hardware/opl.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *  OPL2/OPL3 emulation library
  *
  *  This library is free software; you can redistribute it and/or

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/pci_devices.h
+++ b/src/hardware/pci_devices.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/directserial.h
+++ b/src/hardware/serialport/directserial.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/libserial.cpp
+++ b/src/hardware/serialport/libserial.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/libserial.h
+++ b/src/hardware/serialport/libserial.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/nullmodem.h
+++ b/src/hardware/serialport/nullmodem.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/serialdummy.cpp
+++ b/src/hardware/serialport/serialdummy.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/serialdummy.h
+++ b/src/hardware/serialport/serialdummy.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_misc.cpp
+++ b/src/hardware/vga_misc.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_misc.cpp
+++ b/src/ints/int10_misc.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_video_state.cpp
+++ b/src/ints/int10_video_state.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/int10_vptable.cpp
+++ b/src/ints/int10_vptable.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ints/xms.h
+++ b/src/ints/xms.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/libs/decoders/mp3_seek_table.cpp
+++ b/src/libs/decoders/mp3_seek_table.cpp
@@ -1,5 +1,5 @@
 /**
- * DOSBox MP3 Seek Table handler, Copyright 2018 Kevin R. Croft (krcroft@gmail.com)
+ * DOSBox MP3 Seek Table handler, Copyright 2018-2020 Kevin R. Croft (krcroft@gmail.com)
  *
  * Problem:
  *          Seeking within an MP3 file to an exact time-offset, such as is expected

--- a/src/libs/decoders/mp3_seek_table.h
+++ b/src/libs/decoders/mp3_seek_table.h
@@ -1,5 +1,5 @@
 /**
- * DOSBox MP3 Seek Table handler, Copyright 2018-2019 Kevin R. Croft (krcroft@gmail.com)
+ * DOSBox MP3 Seek Table handler, Copyright 2018-2020 Kevin R. Croft (krcroft@gmail.com)
  * See mp3_seek_table.cpp for more documentation.
  *
  * The seek table handler makes use of the following single-header public libraries:

--- a/src/libs/decoders/opus.c
+++ b/src/libs/decoders/opus.c
@@ -1,5 +1,5 @@
 /*
- * This DOSBox Ogg Opus decoder backend is written and copyright 2019 Kevin R Croft (krcroft@gmail.com)
+ * This DOSBox Ogg Opus decoder backend is written and copyright 2019-2020 Kevin R Croft (krcroft@gmail.com)
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
  * This decoders makes use of:

--- a/src/libs/zmbv/drvproc.cpp
+++ b/src/libs/zmbv/drvproc.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/libs/zmbv/resource.rc
+++ b/src/libs/zmbv/resource.rc
@@ -17,7 +17,7 @@ CAPTION "DOSBox Video Codec v0.1a"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,131,34,29,14
-    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2009-2019 DOSBox Team",
+    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2019-2020 DOSBox Team",
                     IDC_STATIC,7,7,153,25,SS_NOPREFIX
     PUSHBUTTON      "Email author",IDC_EMAIL,7,34,50,14
     PUSHBUTTON      "Visit home page",IDC_HOMEPAGE,59,34,58,14

--- a/src/libs/zmbv/resource.rc
+++ b/src/libs/zmbv/resource.rc
@@ -17,7 +17,7 @@ CAPTION "DOSBox Video Codec v0.1a"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,131,34,29,14
-    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2019-2020 DOSBox Team",
+    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2009-2020 DOSBox Team",
                     IDC_STATIC,7,7,153,25,SS_NOPREFIX
     PUSHBUTTON      "Email author",IDC_EMAIL,7,34,50,14
     PUSHBUTTON      "Visit home page",IDC_HOMEPAGE,59,34,58,14

--- a/src/libs/zmbv/zmbv.cpp
+++ b/src/libs/zmbv/zmbv.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/libs/zmbv/zmbv.h
+++ b/src/libs/zmbv/zmbv.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/libs/zmbv/zmbv_vfw.cpp
+++ b/src/libs/zmbv/zmbv_vfw.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/libs/zmbv/zmbv_vfw.rc
+++ b/src/libs/zmbv/zmbv_vfw.rc
@@ -59,7 +59,7 @@ CAPTION "DOSBox Video Codec v0.1"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,131,34,29,14
-    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2019-2020 DOSBox Team",
+    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2009-2020 DOSBox Team",
                     IDC_STATIC,7,7,153,25,SS_NOPREFIX
     PUSHBUTTON      "Email author",IDC_EMAIL,7,34,50,14
     PUSHBUTTON      "Visit home page",IDC_HOMEPAGE,59,34,58,14

--- a/src/libs/zmbv/zmbv_vfw.rc
+++ b/src/libs/zmbv/zmbv_vfw.rc
@@ -59,7 +59,7 @@ CAPTION "DOSBox Video Codec v0.1"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,131,34,29,14
-    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2009-2019 DOSBox Team",
+    CTEXT           "Zipped Motion Block Video v 0.1\nCopyright 2019-2020 DOSBox Team",
                     IDC_STATIC,7,7,153,25,SS_NOPREFIX
     PUSHBUTTON      "Email author",IDC_EMAIL,7,34,50,14
     PUSHBUTTON      "Visit home page",IDC_HOMEPAGE,59,34,58,14

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/winres.rc
+++ b/src/winres.rc
@@ -19,12 +19,12 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", " 2002-2020 DOSBox Team, published under GNU GPL"
+            VALUE "Comments", "� 2002-2020 DOSBox Team, published under GNU GPL"
             VALUE "CompanyName", "DOSBox Team"
             VALUE "FileDescription", "DOSBox DOS Emulator"
             VALUE "FileVersion", "0, 75, 0, 0"
             VALUE "InternalName", "dosbox-staging"
-            VALUE "LegalCopyright", "Copyright  2002-2020 DOSBox Team"
+            VALUE "LegalCopyright", "Copyright � 2002-2020 DOSBox Team"
             VALUE "OriginalFilename", "dosbox.exe"
             VALUE "ProductName", "dosbox-staging"
             VALUE "ProductVersion", "0, 75, 0, 0"

--- a/src/winres.rc
+++ b/src/winres.rc
@@ -19,12 +19,12 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "Comments", "© 2002-2019 DOSBox Team, published under GNU GPL"
+            VALUE "Comments", " 2002-2020 DOSBox Team, published under GNU GPL"
             VALUE "CompanyName", "DOSBox Team"
             VALUE "FileDescription", "DOSBox DOS Emulator"
             VALUE "FileVersion", "0, 75, 0, 0"
             VALUE "InternalName", "dosbox-staging"
-            VALUE "LegalCopyright", "Copyright © 2002-2019 DOSBox Team"
+            VALUE "LegalCopyright", "Copyright  2002-2020 DOSBox Team"
             VALUE "OriginalFilename", "dosbox.exe"
             VALUE "ProductName", "dosbox-staging"
             VALUE "ProductVersion", "0, 75, 0, 0"


### PR DESCRIPTION
**Motivation for change:**
In the roadmap to first release, there's a [card](https://github.com/dreamer/dosbox-staging/projects/2#card-33478874) for "Update copyright dates throughout the project.", is this what you had in mind? We're not lawyers, but do you have any clue if we're allowed to increment copyright dates in this fashion?

**Details**
* First I ran: `rpl -Rvw 2002-2019 2002-2020 ./*`
* After reviewing the changes I noticed `src/winres.rc` was now missing the "�" symbols, I'm guessing this is a copyright symbol but my browser does not render it correctly. I manually re-added them to the file. Also found and corrected similar problem in `dosbox-installer.nsi`. Using `rpl` has proven unreliable, removing symbols that shouldn't be stripped, or maybe I'm just not using it correctly.

Excited for the first release of dosbox-staging, hope this helps. Let me know if you had something else in mind.