### PR TITLE
Refresh copyrights and headers

### DIFF
--- a/src/libs/decoders/SDL_sound.c
+++ b/src/libs/decoders/SDL_sound.c
@@ -1,31 +1,31 @@
 /*
- * SDL_sound -- An abstract sound format decoding API.
- * Copyright (C) 2001  Ryan C. Gordon.
+ *  Modified SDL Sound API implementation
+ *  -------------------------------------
+ *  This file implements the API, the documentation for which can
+ *  be found in SDL_sound.h.  This API has been changed from its
+ *  original implementation as follows:
+ *    - Cut down in size; most notably exclusion of the conversion routines
+ *    - Small bug fixes and warnings cleaned up
+ *    - Elimination of intermediate buffers, allowing direct decoding
+ *    - Moved from sample-based logic to frame-based (channel-agnostic)
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
-/**
- * This file implements the core API, which is relatively simple.
- *   The real meat of SDL_sound is in the decoders directory.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * Documentation is in SDL_sound.h ... It's verbose, honest.  :)
- *
- * Please see the file src/libs/decoders/docs/LICENSE.txt.
- *
- *  This file written by Ryan C. Gordon. (icculus@icculus.org)
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include <stdio.h>

--- a/src/libs/decoders/SDL_sound.h
+++ b/src/libs/decoders/SDL_sound.h
@@ -1,31 +1,7 @@
-/** \file SDL_sound.h */
-
 /*
- * SDL_sound -- An abstract sound format decoding API.
- * Copyright (C) 2001  Ryan C. Gordon.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
-/**
- * \mainpage SDL_sound
- *
- * The latest version of SDL_sound can be found at:
- *     http://icculus.org/SDL_sound/
- *
- * The basic gist of SDL_sound is that you use an SDL_RWops to get sound data
+ *  Modified SDL Sound API
+ *  ----------------------
+ *  The basic gist of SDL_sound is that you use an SDL_RWops to get sound data
  *  into this library, and SDL_sound will take that data, in one of several
  *  popular formats, and decode it into raw waveform data in the format of
  *  your choice. This gives you a nice abstraction for getting sound into your
@@ -35,7 +11,7 @@
  *  the initial sound data from any number of sources: file, memory buffer,
  *  network connection, etc.
  *
- * As the name implies, this library depends on SDL: Simple Directmedia Layer,
+ *  As the name implies, this library depends on SDL2: Simple Directmedia Layer,
  *  which is a powerful, free, and cross-platform multimedia library. It can
  *  be found at http://www.libsdl.org/
  *
@@ -46,10 +22,23 @@
  *   - .OPUS (Ogg Opus support via the Opusfile and SpeexDSP libraries)
  *   - .FLAC (Free Lossless Audio Codec support via the dr_flac single-header decoder)
  *
- * Please see the file src/libs/decoders/docs/LICENSE.txt.
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
- * \author Ryan C. Gordon (icculus@icculus.org)
- * \author many others, please see CREDITS in the source's root directory.
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef _INCLUDE_SDL_SOUND_H_

--- a/src/libs/decoders/SDL_sound_internal.h
+++ b/src/libs/decoders/SDL_sound_internal.h
@@ -1,29 +1,26 @@
 /*
- * SDL_sound -- An abstract sound format decoding API.
- * Copyright (C) 2001  Ryan C. Gordon.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- */
-
-/*
- * Internal function/structure declaration. Do NOT include in your
+ *  Modified SDL Sound API implementation
+ *  -------------------------------------
+ *  Internal function/structure declaration. Do NOT include in your
  *  application.
  *
- * Please see the file src/libs/decoders/docs/LICENSE.txt.
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
- *  This file written by Ryan C. Gordon. (icculus@icculus.org)
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef _INCLUDE_SDL_SOUND_INTERNAL_H_

--- a/src/libs/decoders/flac.c
+++ b/src/libs/decoders/flac.c
@@ -1,30 +1,26 @@
 /*
- * DOSBox FLAC decoder is maintained by Kevin R. Croft (krcroft@gmail.com)
- * This decoder makes use of the excellent dr_flac library by David Reid (mackron@gmail.com)
+ *  DOSBox FLAC decoder API implementation
+ *  --------------------------------------
+ *  This decoder makes use of the dr_flac library by David Reid (mackron@gmail.com)
+ *    - dr_libs: https://github.com/mackron/dr_libs (source)
+ *    - dr_flac: http://mackron.github.io/dr_flac.html (website)
  *
- * Source links
- *   - dr_libs: https://github.com/mackron/dr_libs (source)
- *   - dr_flac: http://mackron.github.io/dr_flac.html (website)
+ *  Copyright (C) 2018-2020  The DOSBox Team
+ *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
- * The upstream SDL2 Sound 1.9.x FLAC decoder is written and copyright by Ryan C. Gordon. (icculus@icculus.org)
- *
- * Please see the file src/libs/decoders/docs/LICENSE.txt.
- *
- *  This file is part of the SDL Sound Library.
- *
- *  This SDL_sound FLAC decoder backend is free software: you can redistribute
- *  it and/or modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation, either version 3 of the License, or
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
  *
- *  This SDL_sound FLAC decoder backend is distributed in the hope that it
- *  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with the SDL Sound Library.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #if HAVE_CONFIG_H
@@ -165,9 +161,8 @@ const Sound_DecoderFunctions __Sound_DecoderFunctions_FLAC =
 {
     {
         extensions_flac,
-        "Free Lossless Audio Codec",
-        "Ryan C. Gordon <icculus@icculus.org>",
-        "https://icculus.org/SDL_sound/"
+        "Free Lossless Audio Codec (FLAC)",
+        "The DOSBox Team"
     },
 
     FLAC_init,       /*   init() method */

--- a/src/libs/decoders/mp3.cpp
+++ b/src/libs/decoders/mp3.cpp
@@ -1,24 +1,29 @@
-/**
- * This DOSBox mp3 decooder backend is maintained by Kevin R. Croft (krcroft@gmail.com)
- * This decoder makes use of the following single-header public libraries:
- *   - dr_mp3: http://mackron.github.io/dr_mp3.html, by David Reid
+/*
+ *  DOSBox MP3 decoder API implementation
+ *  -------------------------------------
+ *  This decoder makes use of the dr_mp3 library by David Reid (mackron@gmail.com)
+ *    - dr_libs: https://github.com/mackron/dr_libs (source)
+ *    - dr_mp3:  http://mackron.github.io/dr_mp3.html (website)
  *
- * The upstream SDL2 Sound 1.9.x mp3 decoder is written and copyright by Ryan C. Gordon. (icculus@icculus.org)
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
- *  This SDL_sound MP3 decoder backend is free software: you can redistribute
- *  it and/or modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation, either version 3 of the License, or
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
  *
- *  This MP3 decoder backend is distributed in the hope that it
- *  will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
- *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with the SDL Sound Library.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+
 #if HAVE_CONFIG_H
 #  include <config.h>
 #endif
@@ -173,8 +178,7 @@ extern const Sound_DecoderFunctions __Sound_DecoderFunctions_MP3 = {
     {
         extensions_mp3,
         "MPEG-1 Audio Layer I-III",
-        "Ryan C. Gordon <icculus@icculus.org>",
-        "https://icculus.org/SDL_sound/"
+        "The DOSBox Team"
     },
 
     MP3_init,       /*   init() method */

--- a/src/libs/decoders/mp3_seek_table.cpp
+++ b/src/libs/decoders/mp3_seek_table.cpp
@@ -1,5 +1,6 @@
-/**
- * DOSBox MP3 Seek Table handler, Copyright 2018-2020 Kevin R. Croft (krcroft@gmail.com)
+/*
+ *  DOSBox MP3 Seek Table Handler
+ *  -----------------------------
  *
  * Problem:
  *          Seeking within an MP3 file to an exact time-offset, such as is expected
@@ -54,19 +55,22 @@
  *   - archive:  https://github.com/voidah/archive, by Arthur Ouellet
  *   - xxHash:   http://cyan4973.github.io/xxHash, by Yann Collet
  *
- *  This seek table handler is free software: you can redistribute
- *  it and/or modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation, either version 3 of the License, or
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
  *
- *  This software is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty
- *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with DOSBox.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #if HAVE_CONFIG_H

--- a/src/libs/decoders/mp3_seek_table.h
+++ b/src/libs/decoders/mp3_seek_table.h
@@ -1,25 +1,30 @@
-/**
- * DOSBox MP3 Seek Table handler, Copyright 2018-2020 Kevin R. Croft (krcroft@gmail.com)
+/*
+ * DOSBox MP3 Seek Table Handler
+ * -----------------------------
  * See mp3_seek_table.cpp for more documentation.
  *
- * The seek table handler makes use of the following single-header public libraries:
+ * The seek table handler makes use of the following single-header
+ * public libraries:
  *   - dr_mp3: http://mackron.github.io/dr_mp3.html, by David Reid
  *   - archive: https://github.com/voidah/archive, by Arthur Ouellet
  *   - xxHash: http://cyan4973.github.io/xxHash, by Yann Collet
  *
- *  This seek table handler is free software: you can redistribute
- *  it and/or modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation, either version 3 of the License, or
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
  *
- *  This software is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty
- *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with DOSBox.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #include <vector>    // provides: vector

--- a/src/libs/decoders/opus.cpp
+++ b/src/libs/decoders/opus.cpp
@@ -1,19 +1,33 @@
 /*
- * This DOSBox Ogg Opus decoder backend is written and
- * copyright 2019-2020 Kevin R Croft (krcroft@gmail.com)
- * SPDX-License-Identifier: GPL-2.0-or-later
+ *  DOSBox Opus decoder API implementation
+ *  --------------------------------------
+ *  This decoders makes use of:
+ *    - libopusfile, for .opus file handing and frame decoding
  *
- * This decoders makes use of:
- *   - libopusfile, for .opus file handing and frame decoding
+ *  Source links
+ *    - opusfile:   https://github.com/xiph/opusfile
+ *    - opus-tools: https://github.com/xiph/opus-tools
  *
- * Source links
- *   - opusfile:   https://github.com/xiph/opusfile
- *   - opus-tools: https://github.com/xiph/opus-tools
-
  * Documentation references
- *   - Ogg Opus:  https://www.opus-codec.org/docs
- *   - OpusFile:  https://mf4.xiph.org/jenkins/view/opus/job/opusfile-unix/ws/doc/html/index.html
+ *    - Ogg Opus:  https://www.opus-codec.org/docs
+ *    - OpusFile:  https://mf4.xiph.org/jenkins/view/opus/job/opusfile-unix/ws/doc/html/index.html
  *
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 // #define DEBUG_CHATTER 1
@@ -383,8 +397,7 @@ extern const Sound_DecoderFunctions __Sound_DecoderFunctions_OPUS =
     {
         extensions_opus,
         "Ogg Opus audio using libopusfile",
-        "Kevin R Croft <krcroft@gmail.com>",
-        "https://www.opus-codec.org/"
+        "The DOSBox Team"
     },
 
     opus_init,   /*   init() method */

--- a/src/libs/decoders/vorbis.c
+++ b/src/libs/decoders/vorbis.c
@@ -1,29 +1,26 @@
 /*
- * This DOSBox Vorbis decoder backend maintained by Kevin R. Croft (krcroft@gmail.com)
- * This decoder makes use of the excellent STB Vorbis decoder by Sean Barrett
- *
- * Source links
+ *  DOSBox MP3 decoder API implementation
+ *  -------------------------------------
+ *  It makes use of the stand-alone STB Vorbis library:
  *   - STB: https://github.com/nothings/stb (source)
  *   - STB: https://twitter.com/nothings (website/author info)
  *
- * The upstream SDL2 Sound 1.9.x Vorbis decoder is written and copyright by Ryan C. Gordon. (icculus@icculus.org)
+ *  Copyright (C) 2018-2020  The DOSBox Team
+ *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
- * Please see the file src/libs/decoders/docs/LICENSE.txt.
- *
- *  This file is part of the SDL Sound Library.
- *
- *  This Vorbis decoder backend is free software: you can redistribute
- *  it and/or modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation, either version 3 of the License, or
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
  *
- *  This decoder backend is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with the SDL Sound Library.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #if HAVE_CONFIG_H
@@ -213,8 +210,7 @@ const Sound_DecoderFunctions __Sound_DecoderFunctions_VORBIS =
     {
         extensions_vorbis,
         "Ogg Vorbis audio",
-        "Ryan C. Gordon <icculus@icculus.org>",
-        "https://icculus.org/SDL_sound/"
+        "The DOSBox Team"
     },
 
     VORBIS_init,       /*   init() method */

--- a/src/libs/decoders/wav.c
+++ b/src/libs/decoders/wav.c
@@ -1,16 +1,28 @@
 /*
- * DOSBox WAV decoder is maintained by Kevin R. Croft (krcroft@gmail.com)
- * This decoder makes use of the excellent dr_wav library by David Reid (mackron@gmail.com)
- *
- * Source links
+ *  DOSBox MP3 decoder API implementation
+ *  -------------------------------------
+ *  It makes use of the dr_wav library by David Reid (mackron@gmail.com)
+ *  Source links:
  *   - dr_libs: https://github.com/mackron/dr_libs (source)
  *   - dr_wav: http://mackron.github.io/dr_wav.html (website)
  *
- * Please see the file src/libs/decoders/docs/LICENSE.txt.
+ *  Copyright (C) 2020       The DOSBox Team
+ *  Copyright (C) 2018-2019  Kevin R. Croft <krcroft@gmail.com>
+ *  Copyright (C) 2001-2017  Ryan C. Gordon <icculus@icculus.org>
  *
- *  You should have received a copy of the GNU General Public License
- *  along with the SDL Sound Library.  If not, see <http://www.gnu.org/licenses/>.
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
  *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #if HAVE_CONFIG_H
@@ -155,8 +167,7 @@ const Sound_DecoderFunctions __Sound_DecoderFunctions_WAV =
     {
         extensions_wav,
         "WAV Audio Codec",
-        "Kevin R. Croft <krcroft@gmail.com>",
-        "github.com/mackron/dr_libs/blob/master/dr_wav.h"
+        "The DOSBox Team"
     },
 
     WAV_init,       /*   init() method */


### PR DESCRIPTION
Ties in with the overall header update effort.
Attempts to simplify the headers using references to the license and SDL credits files.
Also moves maintainership to the DOSBox team from myself (for most files).
