### PR TITLE
Prevent env:OPUSFILE_LIBS from enabling Opus

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -486,9 +486,9 @@ AC_ARG_ENABLE(opus-cdda,
 AS_IF([test "x${enable_opus_cdda}" != "xno"],
       [PKG_CHECK_MODULES([OPUSFILE],
                          [opusfile],
-                         [LIBS="$LIBS $OPUSFILE_LIBS"])])
-AM_CONDITIONAL([USE_OPUS],
-               [test "x${OPUSFILE_LIBS}" != "x"])
+                         [LIBS="$LIBS $OPUSFILE_LIBS" HAVE_OPUS=yes])])
+
+AM_CONDITIONAL(USE_OPUS, test "${HAVE_OPUS}" = "yes")
 
 AH_TEMPLATE(C_OPENGL,[Define to 1 to use opengl display output support])
 AC_CHECK_LIB(GL, main, have_gl_lib=yes, have_gl_lib=no , )


### PR DESCRIPTION
In the current `configure.ac`, we first assess the `--disable-opus-cdda` argument, and if it's not present we run pkg-config to get the Opus CFLAGS and LIBS.  If it finds them, it sets the `OPUSFILE_CFLAGS` and `OPUSFILE_LIBS` variables.  We then use the presence of `OPUSFILE_LIBS` to enable (or disable) the `USE_OPUS` Makefile conditional.

However, if the user directly sets `OPUSFILE_LIBS`, then they inadvertently will always enable the final `USE_OPUS` Makefile conditional check.

Side discussion:

> It would seem intuitive to move the Opus Make conditional check inside the pkg-config check (for example, moving `AM_CONDITIONAL` inside `AS_IF`) however that results in the Make conditional not existing at all if thepkg-config test fails its check, and unfortunately the absence of a Make conditional is not sufficient to assume the false-case.  So this approach doesn't work.

Therefore, we set a new variable `HAVE_OPUS=yes`, if the pkg-config check passes, and look for that to set the `USE_OPUS` Make conditional, instead of `OPUSFILE_LIBS`. Of course, the user could `export HAVE_OPUS=yes` in their environment as well, but at that point they're deliberately circumenting configure, in which case they can have at it!

Thanks to @ant-222 for reporting this.