### PR TITLE
Build release with AutoFDO data and link-time-optimizations

### DIFF
--- a/.github/scripts/build-autofdo.sh
+++ b/.github/scripts/build-autofdo.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# Builds and installs the AutoFDO package from
+# https://github.com/google/autofdo
+#
+# AutoFDO is used to convert sample profiling data (collected using perf
+# or ocperf.py from a Linux kernel built with with last branch
+# record (LBR) tracing support running on an Intel CPU with LBR
+# support) to GCC-specific AutoFDO records or LLVM's raw profile
+# records.
+#
+# Pre-requisites: autoconf automake git libelf-dev libssl-dev pkg-config
+# If building for LLVM, clang and llvm-dev are needed.
+#
+# Usage: build-autofdo.sh [LLVM version]
+# Examples: ./build-autofdo.sh
+#           ./build-autofdo.sh 10
+#
+# Where the optional [LLVM version] allows building with LLVM support
+# for the provided LLVM version.
+
+set -euo pipefail
+
+rootdir="$(pwd)"
+prefix="$rootdir/afdo"
+
+# Clone the repo
+if [[ ! -d autofdo ]]; then
+	git clone --depth 1 --recursive https://github.com/google/autofdo.git
+fi
+
+# Enter and sync the repo (if it already exists)
+pushd autofdo
+git pull
+
+# Initialize auto-tools
+aclocal -I .
+autoheader
+autoconf
+automake --add-missing -c
+
+# Configure with the specified LLVM version if provided
+if [[ -n "${1:-}" ]]; then
+	ver="$1"
+	withllvm="--with-llvm=$(command -v llvm-config-"$ver")"
+fi
+
+# Configure
+flags="-Os -DNDEBUG -pipe"
+./configure CFLAGS="$flags" CXXFLAGS="$flags" --prefix="$prefix" "${withllvm:-}"
+
+# Build and install
+# Note: make cannot be run in parallel because the sub-projects'
+#       need to be configured serially with respect to eachother
+make
+make install
+popd
+
+# Strip the binaries
+cd "$prefix/bin"
+strip ./*

--- a/.github/scripts/fetch-and-merge-afdo.sh
+++ b/.github/scripts/fetch-and-merge-afdo.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright (c) 2019-2020 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# A helper script that fetches, converts, and merges kernel sample
+# (.prof) files (collected during prior DOSBox testing) into a single
+# GCC-compatible AutoFDO record that can be used to optimize builds.
+
+# For simplicity, this script is dosbox-staging-specific and
+# github-workflow-specific.
+
+# Depedencies:
+#   - zstd
+#   - GNU parallel
+#   - https://github.com/google/autofdo, install locally in ./afdo
+#     using the same compiler that will use the AutoFDO records
+
+set -euo pipefail
+
+# The tarball containing one or more profile records
+PROFILES="https://gitlab.com/luxtorpeda/dosbox-tests/-/raw/master/archives/profiles.tar.zst"
+BINARY="tests/dosbox"
+
+# Move to our repo root
+cd "$(git rev-parse --show-toplevel)"
+
+# Fetch and unpack the profiles
+wget "${PROFILES}" -O - | zstd -d | tar -x
+
+# Convert and merge the profiles
+parallel ./afdo/bin/create_gcov --binary="${BINARY}" --profile="{}" -gcov="{.}".afdo -gcov_version=1 ::: tests/*/*.prof
+./afdo/bin/profile_merger -gcov_version=1 -output_file=current.afdo tests/*/*.afdo

--- a/.github/scripts/fetch-and-merge-profraw.sh
+++ b/.github/scripts/fetch-and-merge-profraw.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Kevin R Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+# A helper script that fetches, converts, and merges kernel sample
+# (.prof) files (collected during prior DOSBox testing) into a single
+# LLVM-compatible Raw Profile record that can be used to optimize builds.
+
+# For simplicity, this script is dosbox-staging-specific and
+# github-workflow-specific.
+
+# Depedencies:
+#   - zstd
+#   - GNU parallel
+#   - https://github.com/google/autofdo, installed locally in ./afdo
+#     configured to use same LLVM that will use the AutoFDO records
+
+set -euo pipefail
+
+# The tarball containing one or more profile records
+PROFILES="https://gitlab.com/luxtorpeda/dosbox-tests/-/raw/master/archives/profiles.tar.zst"
+BINARY="tests/dosbox"
+
+# Move to our repo root
+cd "$(git rev-parse --show-toplevel)"
+
+# Fetch and unpack the profiles
+wget "${PROFILES}" -O - | zstd -d | tar -x
+
+# Convert and merge the profiles
+parallel ./afdo/bin/create_llvm_prof --binary="${BINARY}" --profile="{}" --out="{.}".profraw ::: tests/*/*.prof
+llvm-profdata-11 merge -sample -output=current.profraw tests/*/*.profraw

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,8 +55,8 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
           sudo update-alternatives --config gcc
           sudo apt-get install -y libelf-dev libssl-dev parallel
-      - name: Log and setup environment
-        run: ./scripts/log-env.sh
+      - name: Log environment
+        run:  ./scripts/log-env.sh
       - name: Inject version string
         run: |
           set -x
@@ -86,11 +86,11 @@ jobs:
           LD: gcc-9
           RANLIB: gcc-ranlib-9
           FLAGS: -O2 -flto -fauto-profile=${{ github.workspace }}/current.afdo -ffunction-sections -fdata-sections -DNDEBUG -pipe
-          LDFLAGS: -Wl,--as-needed -pipe -flto=4
+          LINKFLAGS: -Wl,--as-needed -pipe -flto=4
         run: |
           set -x
           ./autogen.sh
-          ./configure CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" --disable-screenshots || cat config.log
+          ./configure CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" LDFLAGS="$FLAGS $LINKFLAGS" --disable-screenshots || cat config.log
           make -j "$(nproc)"
           strip src/dosbox
       - name: Package

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,22 +56,25 @@ jobs:
           sudo update-alternatives --config gcc
           sudo apt-get install -y libelf-dev libssl-dev parallel
       - name: Log and setup environment
-        run: |
-          ./scripts/log-env.sh
-          mkdir -p afdo
+        run: ./scripts/log-env.sh
       - name: Inject version string
         run: |
           set -x
           export VERSION=$(git describe --abbrev=4)
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo ::set-env name=VERSION::$VERSION
+      - name: Prepare for AutoFDO installation
+        id: prep-afdo
+        run: |
+          mkdir -p afdo
+          echo ::set-output name=gcc-version::$(gcc --version | grep ^gcc | sed 's/^.* //g')
       - uses: actions/cache@v1
-        id: cache-autofdo
+        id: restore-afdo
         with:
           path: afdo
-          key: autofdo-0.19_gcc-9.2.1-3
+          key: afdo-for-gcc-${{ steps.prep-afdo.outputs.gcc-version }}
       - name: Install AutoFDO package
-        if:   steps.cache-autofdo.outputs.cache-hit != 'true'
+        if:   steps.restore-afdo.outputs.cache-hit != 'true'
         run:  ./.github/scripts/build-autofdo.sh
       - name: Convert AutoFDO profiles
         run: ./.github/scripts/fetch-and-merge-afdo.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,23 +47,47 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run:  sudo apt-get update
-      - name: Install C++ compiler and libraries
-        run:  sudo apt-get install -y tree libpng16-dev $(./scripts/list-build-dependencies.sh -m apt -c gcc)
-      - name: Log environment
-        run:  ./scripts/log-env.sh
+      - name: Install C++ compiler and build dependencies
+        run: |
+          set -x
+          sudo apt-get update -y
+          sudo apt-get install -y tree libpng16-dev $(./scripts/list-build-dependencies.sh -m apt -c gcc -v 9)
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+          sudo update-alternatives --config gcc
+          sudo apt-get install -y libelf-dev libssl-dev parallel
+      - name: Log and setup environment
+        run: |
+          ./scripts/log-env.sh
+          mkdir -p afdo
       - name: Inject version string
         run: |
           set -x
           export VERSION=$(git describe --abbrev=4)
           sed -i "s/AC_INIT(dosbox,git)/AC_INIT(dosbox,$VERSION)/" configure.ac
           echo ::set-env name=VERSION::$VERSION
+      - uses: actions/cache@v1
+        id: cache-autofdo
+        with:
+          path: afdo
+          key: autofdo-0.19_gcc-9.2.1-3
+      - name: Install AutoFDO package
+        if:   steps.cache-autofdo.outputs.cache-hit != 'true'
+        run:  ./.github/scripts/build-autofdo.sh
+      - name: Convert AutoFDO profiles
+        run: ./.github/scripts/fetch-and-merge-afdo.sh
       - name: Build
         env:
-          FLAGS: -O3 -DNDEBUG -pipe
+          AR: gcc-ar-9
+          CC: gcc-9
+          CXX: g++-9
+          LD: gcc-9
+          RANLIB: gcc-ranlib-9
+          FLAGS: -O2 -flto -fauto-profile=${{ github.workspace }}/current.afdo -ffunction-sections -fdata-sections -DNDEBUG -pipe
+          LDFLAGS: -Wl,--as-needed -pipe -flto=4
         run: |
           set -x
           ./autogen.sh
-          ./configure CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" --disable-screenshots
+          ./configure CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" --disable-screenshots || cat config.log
           make -j "$(nproc)"
           strip src/dosbox
       - name: Package

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,10 @@ suppress_base.json
 
 # macOS directory prefs
 .DS_Store
+
+# Profiling data
+afdo
+autofdo
+*.prof
+*.afdo
+*.afdo.imports

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -4,7 +4,7 @@ cxx="clang++${postfix}"
 
 # Flag additions
 TYPES+=(debug warnmore profile)
-cflags_release=("${cflags[@]}" -Os)
+cflags_release=("${cflags[@]}" -O3)
 cflags_debug=("${cflags[@]}" -g -Og -fno-omit-frame-pointer)
 cflags_profile=("${cflags_debug[@]}" -fprofile-instr-generate -fcoverage-mapping)
 cflags_warnmore=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused
@@ -19,5 +19,4 @@ fi
 
 # Modifier additions
 MODIFIERS=(fdo)
-ldflags_fdo=(-fprofile-instr-generate)
 cflags_fdo=("-fprofile-sample-use=${FDO_FILE:-}")

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -17,7 +17,7 @@ cflags_warnmore=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                  -Wlogical-op -Wmisleading-indentation -Wnull-dereference
                  -Wshadow -Wunused)
 cxxonly_warnmore=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual -Wuseless-cast)
-cflags_fdotrain=("${cflags[@]}" -g1 -fno-omit-frame-pointer)
+cflags_fdotrain=("${cflags[@]}" -DNDEBUG -g1 -fno-omit-frame-pointer)
 
 # Modifier additions
 MODIFIERS=(fdo)

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -6,7 +6,7 @@ ld="gcc${postfix}"
 ranlib="gcc-ranlib${postfix}"
 
 # Flag additions
-TYPES+=(debug warnmore profile)
+TYPES+=(debug warnmore profile fdotrain)
 
 cflags+=(-fstack-protector -fdiagnostics-color=auto)
 cflags_debug=("${cflags[@]}" -g -Og	-fno-omit-frame-pointer)
@@ -17,6 +17,7 @@ cflags_warnmore=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                  -Wlogical-op -Wmisleading-indentation -Wnull-dereference
                  -Wshadow -Wunused)
 cxxonly_warnmore=(-Weffc++ -Wnon-virtual-dtor -Woverloaded-virtual -Wuseless-cast)
+cflags_fdotrain=("${cflags[@]}" -g1 -fno-omit-frame-pointer)
 
 # Modifier additions
 MODIFIERS=(fdo)

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -10,7 +10,7 @@ TYPES+=(debug warnmore profile fdotrain)
 
 cflags+=(-fstack-protector -fdiagnostics-color=auto)
 cflags_debug=("${cflags[@]}" -g -Og	-fno-omit-frame-pointer)
-cflags_release=("${cflags[@]}" -Ofast -ffunction-sections -fdata-sections)
+cflags_release=("${cflags[@]}" -DNDEBUG -O2 -ffunction-sections -fdata-sections)
 cflags_profile=("${cflags_debug[@]}" -pg)
 cflags_warnmore=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion
                  -Wduplicated-branches -Wduplicated-cond -Wextra -Wformat=2


### PR DESCRIPTION
This PR adds AutoFDO data and link-time-optimizations to the Linux release build. 

The AutoFDO data is generated from sample-based measurements collected from 144 tests (listed below) that exercise performance-related aspects of DOSBox: all CPU cores; all machine types; various memory sizes; real and protected modes; all scalers and GLShaders; all SDL modes; all Sound Blaster types; speaker types: beeper, tandy, and disney/CMS; Gravis UltraSound rates and MIDI; and CD-DA playback track types: codecs, frequencies, stereo & mono.

The combination of compiler optimization flags was selected from an exhaustive set of benchmarks testing all permutations of O-levels (Os, O2, O3, and Ofast), architecture tuning (with and without), FDO (with and without), and Link-time-optimizations. 

As usual with FDO, thorough measurements proved more informative for the optimizer (ie: produced the fastest binaries) than simply using generalized architecture and performance-level rules (O3/Ofast). The fastest combination was -O2 using feedback data (FDO) and when allowed to optimize the entire code space as a whole (LTO).

The resulting binary produces Quake bench scores roughly 10% faster than a standard O3 build (when cycles are set to a dynamic value, like `max` or `max 97%`).  Not a huge boost, but roughly on par with other sample-based AutoFDO results. This binary is faster than anything I can compile locally (also using gcc 9.x).

List of sample-profiled tests (the results of which were merged into one big AFDO record used the optimize the release):

**cores: running 3 tests**
```
  - profiling dynamic  [passed]
  - profiling normal   [passed]
  - profiling simple   [passed]
```

**machines: running 13 tests**
```
  - profiling cga      [passed]
  - profiling cga_mono [passed]
  - profiling ega      [passed]
  - profiling hercules [passed]
  - profiling pcjr     [passed]
  - profiling svgaet3k [passed]
  - profiling svgaet4k [passed]
  - profiling svgapara [passed]
  - profiling svga_s3  [passed]
  - profiling vgaonly  [passed]
  - profiling tandy    [passed]
  - profiling vesanolf [passed]
  - profiling vesaoldv [passed]
```

**memsize: running 8 tests**
```
  - profiling ldfix-32 [passed]
  - profiling loadfix  [passed]
  - profiling ldfix-96 [passed]
  - profiling mem-1    [passed]
  - profiling mem-3    [passed]
  - profiling mem-16   [passed]
  - profiling mem-8    [passed]
  - profiling mem-63   [passed]
```

**scalers: running 31 tests**
```
  - profiling asp-on   [passed]
  - profiling asp-off  [passed]
  - profiling gl-adm3x [passed]
  - profiling gl-adm2x [passed]
  - profiling gl-adv2x [passed]
  - profiling gl-adv3x [passed]
  - profiling gl-rgb2x [passed]
  - profiling gl-rgb3x [passed]
  - profiling gl-scn2x [passed]
  - profiling gl-scn3x [passed]
  - profiling gl-sharp [passed]
  - profiling gl-tv2x  [passed]
  - profiling gl-tv3x  [passed]
  - profiling noscale  [passed]
  - profiling sc-adm2x [passed]
  - profiling sc-adm3x [passed]
  - profiling sc-adv2x [passed]
  - profiling sc-adv3x [passed]
  - profiling sc-hq2x  [passed]
  - profiling sc-hq3x  [passed]
  - profiling sc-nrm2x [passed]
  - profiling sc-nrm3x [passed]
  - profiling sc-rgb2x [passed]
  - profiling sc-rgb3x [passed]
  - profiling sc-s2sai [passed]
  - profiling sc-scn2x [passed]
  - profiling sc-scn3x [passed]
  - profiling sc-sup2x [passed]
  - profiling sc-supea [passed]
  - profiling sc-tv2x  [passed]
  - profiling sc-tv3x  [passed]
```

**sdl-modes: running 16 tests**
```
  - profiling f-no-o-o [passed]
  - profiling f-no-s-s [passed]
  - profiling f-no-t-o [passed]
  - profiling f-no-t-s [passed]
  - profiling f-vs-o-o [passed]
  - profiling f-vs-s-s [passed]
  - profiling f-vs-t-o [passed]
  - profiling f-vs-t-s [passed]
  - profiling w-no-o-o [passed]
  - profiling w-no-s-s [passed]
  - profiling w-no-t-o [passed]
  - profiling w-no-t-s [passed]
  - profiling w-vs-o-o [passed]
  - profiling w-vs-t-o [passed]
  - profiling w-vs-s-s [passed]
  - profiling w-vs-t-s [passed]
```

**sound-blaster: running 6 tests**
```
  - profiling gb       [passed]
  - profiling sb1      [passed]
  - profiling sb16     [passed]
  - profiling sb2      [passed]
  - profiling sbpro1   [passed]
  - profiling sbpro2   [passed]
```

**speaker: running 3 tests**
```
  - profiling disney   [passed]
  - profiling speaker  [passed]
  - profiling tandy    [passed]
```

**stress-nolfb: running 8 tests**
```
  - profiling doom-max [passed]
  - profiling doom-min [passed]
  - profiling q-norm0  [passed]
  - profiling q-norm10 [passed]
  - profiling q-norm12 [passed]
  - profiling quakem0  [passed]
  - profiling quakem10 [passed]
  - profiling quakem12 [passed]
```

**stress-s3: running 8 tests**
```
  - profiling doom-max [passed]
  - profiling doom-min [passed]
  - profiling q-norm0  [passed]
  - profiling q-norm10 [passed]
  - profiling quakem0  [passed]
  - profiling quakem10 [passed]
  - profiling q-norm12 [passed]
  - profiling quakem12 [passed]
```

**stress-vgaonly: running 8 tests**
```
  - profiling doom-max [passed]
  - profiling doom-min [passed]
  - profiling q-norm0  [passed]
  - profiling q-norm10 [passed]
  - profiling q-norm12 [passed]
  - profiling quakem0  [passed]
  - profiling quakem10 [passed]
  - profiling quakem12 [passed]
```

**ultrasound: running 4 tests**
```
  - profiling gus11    [passed]
  - profiling gus22    [passed]
  - profiling gus44    [passed]
  - profiling gus-midi [passed]
```

**cd-da: running 60 tests**
```
  - profiling fm-16-22 [passed]
  - profiling fm-16-44 [passed]
  - profiling fm-16-48 [passed]
  - profiling fm-16-88 [passed]
  - profiling fm-24-96 [passed]
  - profiling fm-8-11  [passed]
  - profiling fs-16-22 [passed]
  - profiling fs-16-44 [passed]
  - profiling fs-16-48 [passed]
  - profiling fs-16-88 [passed]
  - profiling fs-24-96 [passed]
  - profiling fs-8-11  [passed]
  - profiling mm-16-22 [passed]
  - profiling mm-16-44 [passed]
  - profiling mm-16-48 [passed]
  - profiling mm-16-88 [passed]
  - profiling mm-24-96 [passed]
  - profiling mm-8-11  [passed]
  - profiling ms-16-22 [passed]
  - profiling ms-16-44 [passed]
  - profiling ms-16-48 [passed]
  - profiling ms-16-88 [passed]
  - profiling ms-24-96 [passed]
  - profiling ms-8-11  [passed]
  - profiling om-16-22 [passed]
  - profiling om-16-44 [passed]
  - profiling om-16-48 [passed]
  - profiling om-16-88 [passed]
  - profiling om-24-96 [passed]
  - profiling om-8-11  [passed]
  - profiling os-16-22 [passed]
  - profiling os-16-44 [passed]
  - profiling os-16-88 [passed]
  - profiling os-16-48 [passed]
  - profiling os-24-96 [passed]
  - profiling os-8-11  [passed]
  - profiling vm-16-22 [passed]
  - profiling vm-16-44 [passed]
  - profiling vm-16-48 [passed]
  - profiling vm-16-88 [passed]
  - profiling vm-24-96 [passed]
  - profiling vm-8-11  [passed]
  - profiling vs-16-22 [passed]
  - profiling vs-16-44 [passed]
  - profiling vs-16-48 [passed]
  - profiling vs-16-88 [passed]
  - profiling vs-24-96 [passed]
  - profiling vs-8-11  [passed]
  - profiling wm-16-22 [passed]
  - profiling wm-16-44 [passed]
  - profiling wm-16-48 [passed]
  - profiling wm-16-88 [passed]
  - profiling wm-24-96 [passed]
  - profiling wm-8-11  [passed]
  - profiling ws-16-22 [passed]
  - profiling ws-16-44 [passed]
  - profiling ws-16-48 [passed]
  - profiling ws-16-88 [passed]
  - profiling ws-24-96 [passed]
  - profiling ws-8-11  [passed]
```