### PR TITLE
Add scripts to check if <ctype.h> is included before <algorithm>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ clean.log
 make.log
 .previous_build
 .current_build
+*.defines
 
 # Visual Studio
 .vs

--- a/scripts/dump-preprocessor-defines.sh
+++ b/scripts/dump-preprocessor-defines.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (C) 2020  Kevin Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This script captures pre-processor #define statements
+# matching the as-compiled state of the source file.
+# The script runs recursively for all source files, and
+# saves the results in corresponding <source>.defines file.
+#
+set -euo pipefail
+
+# Ensure the project has been configured
+if [[ ! -f config.h ]]; then
+	echo "config.h not found. Please ./configure the project first"
+	exit 1
+fi
+
+# Gather include paths
+root_dir="$(pwd)"
+root_include="$root_dir/include"
+gcc_includes="$(gcc -xc++ -E -v - < /dev/null 2>&1 | grep '^ ' | tail -n +2 | sed 's/^ /-I/' | xargs)"
+sdl_includes="$(sdl2-config --cflags)"
+
+# Round up our source files
+sources=( "$(find . -name '*.cpp' -o -name '*.c')" )
+
+# Run it
+parallel \
+	"g++ -std=gnu++11 \
+	    $gcc_includes \
+	    $sdl_includes \
+	    -I$root_dir \
+	    -I$root_include \
+	    -I{//} \
+	    -DHAVE_CONFIG_H \
+	    -E -dM -include '{}' - < /dev/null 2> /dev/null \
+	    | grep '^#define' > '{.}.defines' \
+	    ; echo '{} to {.}.defines'" ::: "${sources[@]}"

--- a/scripts/verify-ctype-algorithm-include-order.sh
+++ b/scripts/verify-ctype-algorithm-include-order.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (C) 2020  Kevin Croft <krcroft@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This script checks if <ctype> is included before <algorithm> by
+# querying records written by the dump-preprocessor-defines.sh
+# script.  It prints details and returns a non-zero exit code to
+# the shell if it detects one or more incorrect include orders.
+#
+# See the following discussions for why this script exists:
+# - https://travisdowns.github.io/blog/2019/11/19/toupper.html
+# - https://news.ycombinator.com/item?id=21579333
+#
+set -euo pipefail
+
+# Colors
+declare -gr bold="\\e[1m"
+declare -gr red="\\e[31m"
+declare -gr green="\\e[32m"
+declare -gr cyan="\\e[36m"
+declare -gr reset="\\e[0m"
+
+# Round up defines files
+# shellcheck disable=SC2207
+defines=( $(find . -name '*.defines') )
+
+# Ensure we have the expected quantity
+actual="${#defines[@]}"
+expected="$(find . -name '*.cpp' -o -name '*.c' | wc -l)"
+if (( "$actual" != "$expected" )); then
+    echo "We should have $expected .defines files but $actual were found"
+	exit 1
+fi
+
+# The header strings that we're looking for
+ctype="#define _CTYPE_H 1"
+algorithm="#define __NO_CTYPE 1"
+failures=0
+
+# Check each for the correct order
+for def in "${defines[@]}"; do
+	result="$(grep -n "${ctype}\\|${algorithm}" "$def" || true)"
+	ctype_line="$(echo "$result" | grep "$ctype"     | cut -f1 -d: || echo)"
+	algor_line="$(echo "$result" | grep "$algorithm" | cut -f1 -d: || echo)"
+	source="${def%.*}"
+	if [[ -n "$ctype_line" && -n "$algor_line" ]]; then
+		if [[ "$ctype_line" -lt "$algor_line" ]]; then
+			echo -e "${bold}${green}[PASS]${reset} $source properly includes <ctype> before <algorithm>"
+		else
+			echo -e "${bold}${red}[FAIL]${reset} $source should include <ctype> before <algorithm>"
+			(( failures++ )) || true
+		fi
+		echo "${result//^/       }"
+		echo ""
+	else
+		echo -e "${bold}${cyan}[PASS]${reset} $source only includes one or neither"
+	fi
+done
+
+if [[ "$failures" -gt "0" ]]; then
+	exit 1
+fi


### PR DESCRIPTION
This PR adds two scripts:
- `scripts/dump-preprocessor-defines.sh`
- `scripts/verify-ctype-algorithm-include-order.sh`

The first preprocesses all the sources and captures their `#define`s in the same order as when they're compiled.  The second queries the resulting records for the specific directives we care about (in issue https://github.com/dreamer/dosbox-staging/issues/196).  

I decided to split these two roles given the first one, dumping #defines, is useful outside of the specific ctype/algorithm include-order issue. 

![2020-03-13_20-54](https://user-images.githubusercontent.com/1557255/76674457-f33dac00-656c-11ea-8d66-ae9902b21ae7.png)

Even with these to help us, I haven't spent enough time to figuring out exactly how to fix our files  because the layers of includes goes quite deep.