### PR TITLE
Avoid initializing the joysticks too early

### DIFF
--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -5,7 +5,7 @@ cxx="clang++${postfix}"
 # Flag additions
 TYPES+=(debug warnmore profile)
 cflags_release=("${cflags[@]}" -Os)
-cflags_debug=("${cflags[@]}" -g -Og -fno-omit-frame-pointer)
+cflags_debug=("${cflags[@]}" -g -fno-omit-frame-pointer)
 cflags_profile=("${cflags_debug[@]}" -fprofile-instr-generate -fcoverage-mapping)
 cflags_warnmore=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused
                  -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -9,7 +9,7 @@ ranlib="gcc-ranlib${postfix}"
 TYPES+=(debug warnmore profile)
 
 cflags+=(-fstack-protector -fdiagnostics-color=auto)
-cflags_debug=("${cflags[@]}" -g -Og	-fno-omit-frame-pointer)
+cflags_debug=("${cflags[@]}" -g -fno-omit-frame-pointer)
 cflags_release=("${cflags[@]}" -Ofast -ffunction-sections -fdata-sections)
 cflags_profile=("${cflags_debug[@]}" -pg)
 cflags_warnmore=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2438,6 +2438,12 @@ static void CreateBindGroups(void) {
 		if (mapper.sticks.num) SDL_JoystickEventState(SDL_ENABLE);
 		else return;
 #endif
+		// Free up our previously assigned joystick slot before assinging below
+		if (joytype != JOY_NONE && mapper.sticks.stick[mapper.sticks.num_groups]) {
+			delete mapper.sticks.stick[mapper.sticks.num_groups];
+			mapper.sticks.stick[mapper.sticks.num_groups] = nullptr;
+		}
+
 		Bit8u joyno=0;
 		switch (joytype) {
 		case JOY_NONE:
@@ -2474,6 +2480,7 @@ static void CreateBindGroups(void) {
 #if defined (REDUCE_JOYSTICK_POLLING)
 void MAPPER_UpdateJoysticks(void) {
 	for (Bitu i=0; i<mapper.sticks.num_groups; i++) {
+		assert(mapper.sticks.stick[i]);
 		mapper.sticks.stick[i]->UpdateJoystick();
 	}
 }

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -405,9 +405,9 @@ protected:
 #define MAX_VJOY_HAT 16
 #define MAX_VJOY_AXIS 8
 static struct {
-	bool button_pressed[MAX_VJOY_BUTTONS];
-	Bit16s axis_pos[MAX_VJOY_AXIS];
-	bool hat_pressed[MAX_VJOY_HAT];
+	int16_t axis_pos[MAX_VJOY_AXIS] = {0};
+	bool hat_pressed[MAX_VJOY_HAT] = {false};
+	bool button_pressed[MAX_VJOY_BUTTONS] = {false};
 } virtual_joysticks[2];
 
 
@@ -1197,8 +1197,9 @@ static struct CMapper {
 	bool addbind = false;
 	Bitu mods = 0;
 	struct {
-		Bitu num_groups,num;
-		CStickBindGroup * stick[MAXSTICKS];
+		CStickBindGroup * stick[MAXSTICKS] = {nullptr};
+		unsigned int num = 0;
+		unsigned int num_groups = 0;
 	} sticks;
 	std::string filename = "";
 } mapper;
@@ -2577,19 +2578,10 @@ void MAPPER_Init(void) {
 	}
 }
 
-static void ReloadMapper(Section *sec) {
+void MAPPER_StartUp(Section * sec) {
+	// Set the user-defined mapper file, or the default (if not specified)
 	Section_prop const *const section=static_cast<Section_prop *>(sec);
 	Prop_path const *const pp = section->Get_path("mapperfile");
 	mapper.filename = pp->realpath;
-	GFX_LosingFocus(); //Release any keys pressed, or else they'll get stuck.
-	MAPPER_Init();
-}
-
-void MAPPER_StartUp(Section * sec) {
-	Section_prop * section=static_cast<Section_prop *>(sec);
-	section->AddInitFunction(&ReloadMapper, true); //runs immediately after this function ends
-	mapper.sticks.num=0;
-	mapper.sticks.num_groups=0;
-	memset(&virtual_joysticks,0,sizeof(virtual_joysticks));
 	MAPPER_AddHandler(&MAPPER_Run,MK_f1,MMOD1,"mapper","Mapper");
 }


### PR DESCRIPTION
The prior code initialized the joysticks during the config-file parsing phase, which is simply too - the functions return empty results because SDL hasn't come to life yet in sdlmain yet. 

Likewise, the prior code runs a second round of joystick initialization (via mapper_init) in sdlmain, after SDL has been initialized. 

 This second call should in theory work, but the joystick initialization function has a bug that purges the prior joystick tally while at the same time blocking the re-assessment of the joystick state.  So as written, this second call cannot fix what the prior call populated with empty (unuseable) values.

This PR drops the early initialization call.  It fix the `InitializeJoystick` function to tolerate subsequent calls without leaving the previously tallied joysticks in an inaccessible state. 

Thanks to @mdmallardi for catching and reporting this big functional hole, and to @bitstrom for pinpointing the flawed early initialization.

Todo: add subsystem initialization and check via 
https://wiki.libsdl.org/SDL_WasInit


Fixes #219