### PR TITLE
Fix a number of warnings and static analysis issues in vga_xga

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -57,7 +57,7 @@ jobs:
           path: report
       - name: Summarize report
         env:
-          MAX_BUGS: 221
+          MAX_BUGS: 216
         run: |
           # summary
           echo "Full report is included in build Artifacts"
@@ -127,7 +127,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 525
+          MAX_BUGS: 524
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,19 +12,19 @@ jobs:
           - name: GCC-5 (Ubuntu 16.04)
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 96
+            max_warnings: 86
           - name: GCC-7 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 98
+            max_warnings: 88
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 117
+            max_warnings: 107
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8
-            max_warnings: 63
+            max_warnings: 58
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,10 +11,10 @@ jobs:
         conf:
           - name: Clang
             flags: -c clang
-            max_warnings: 67
+            max_warnings: 62
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 109
+            max_warnings: 99
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,15 +20,15 @@ jobs:
           - compiler: Clang
             bits: 64
             arch: x86_64
-            max_warnings: 64
+            max_warnings: 59
           - compiler: GCC
             bits: 32
             arch: i686
-            max_warnings: 71
+            max_warnings: 66
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 109
+            max_warnings: 99
     env:
       CHERE_INVOKING: yes
     steps:

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -183,10 +183,10 @@ Bitu XGA_GetPoint(Bitu x, Bitu y) {
 	return 0;
 }
 
-static Bitu GetMixResult(Bitu mixmode, Bitu srcval, Bitu dstdata)
+static Bitu GetMixResult(uint32_t mixmode, Bitu srcval, Bitu dstdata)
 {
 	Bitu destval = 0;
-	switch(mixmode &  0xf) {
+	switch (mixmode & 0xf) {
 		case 0x00: /* not DST */
 			destval = ~dstdata;
 			break;
@@ -245,8 +245,6 @@ static Bitu GetMixResult(Bitu mixmode, Bitu srcval, Bitu dstdata)
 void XGA_DrawLineVector(Bitu val) {
 	Bits xat, yat;
 	Bitu srcval;
-	Bitu destval;
-	Bitu dstdata;
 	Bits i;
 
 	Bits dx, sx, sy;
@@ -294,12 +292,14 @@ void XGA_DrawLineVector(Bitu val) {
 			break;
 	}
 
-	for (i=0;i<=dx;i++) {
-		Bitu mixmode = (xga.pix_cntl >> 6) & 0x3;
+	for (i = 0; i <= dx; ++i) {
+		uint32_t mixmode = (xga.pix_cntl >> 6) & 0x3;
+		Bitu dstdata;
+		Bitu destval;
 		switch (mixmode) {
 			case 0x00: /* FOREMIX always used */
 				mixmode = xga.foremix;
-				switch((mixmode >> 5) & 0x03) {
+				switch ((mixmode >> 5) & 0x03) {
 					case 0x00: /* Src is background color */
 						srcval = xga.backcolor;
 						break;
@@ -318,11 +318,9 @@ void XGA_DrawLineVector(Bitu val) {
 						LOG_MSG("XGA: DrawRect: Shouldn't be able to get here!");
 						break;
 				}
-				dstdata = XGA_GetPoint(xat,yat);
-
+				dstdata = XGA_GetPoint(xat, yat);
 				destval = GetMixResult(mixmode, srcval, dstdata);
-
-                XGA_DrawPoint(xat,yat, destval);
+				XGA_DrawPoint(xat, yat, destval);
 				break;
 			default: 
 				LOG_MSG("XGA: DrawLine: Needs mixmode %x", mixmode);
@@ -339,8 +337,6 @@ void XGA_DrawLineVector(Bitu val) {
 void XGA_DrawLineBresenham(Bitu val) {
 	Bits xat, yat;
 	Bitu srcval;
-	Bitu destval;
-	Bitu dstdata;
 	Bits i;
 	Bits tmpswap;
 	bool steep;
@@ -388,12 +384,14 @@ void XGA_DrawLineBresenham(Bitu val) {
     
 	//LOG_MSG("XGA: Bresenham: ASC %d, LPDSC %d, sx %d, sy %d, err %d, steep %d, length %d, dmajor %d, dminor %d, xstart %d, ystart %d", dx, dy, sx, sy, e, steep, xga.MAPcount, dmajor, dminor,xat,yat);
 
-	for (i=0;i<=xga.MAPcount;i++) { 
-			Bitu mixmode = (xga.pix_cntl >> 6) & 0x3;
+	for (i = 0; i <= xga.MAPcount; ++i) {
+			uint32_t mixmode = (xga.pix_cntl >> 6) & 0x3;
+			Bitu dstdata;
+			Bitu destval;
 			switch (mixmode) {
 				case 0x00: /* FOREMIX always used */
 					mixmode = xga.foremix;
-					switch((mixmode >> 5) & 0x03) {
+					switch ((mixmode >> 5) & 0x03) {
 						case 0x00: /* Src is background color */
 							srcval = xga.backcolor;
 							break;
@@ -413,11 +411,10 @@ void XGA_DrawLineBresenham(Bitu val) {
 							break;
 					}
 
-					if(steep) {
-						dstdata = XGA_GetPoint(xat,yat);
-					} else {
-						dstdata = XGA_GetPoint(yat,xat);
-					}
+					if (steep)
+						dstdata = XGA_GetPoint(xat, yat);
+					else
+						dstdata = XGA_GetPoint(yat, xat);
 
 					destval = GetMixResult(mixmode, srcval, dstdata);
 
@@ -455,8 +452,6 @@ void XGA_DrawLineBresenham(Bitu val) {
 void XGA_DrawRectangle(Bitu val) {
 	Bit32u xat, yat;
 	Bitu srcval;
-	Bitu destval;
-	Bitu dstdata;
 
 	Bits srcx, srcy, dx, dy;
 
@@ -470,12 +465,14 @@ void XGA_DrawRectangle(Bitu val) {
 
 	for(yat=0;yat<=xga.MIPcount;yat++) {
 		srcx = xga.curx;
-		for(xat=0;xat<=xga.MAPcount;xat++) {
-			Bitu mixmode = (xga.pix_cntl >> 6) & 0x3;
+		for (xat = 0; xat <= xga.MAPcount; ++xat) {
+			uint32_t mixmode = (xga.pix_cntl >> 6) & 0x3;
+			Bitu dstdata;
+			Bitu destval;
 			switch (mixmode) {
 				case 0x00: /* FOREMIX always used */
 					mixmode = xga.foremix;
-					switch((mixmode >> 5) & 0x03) {
+					switch ((mixmode >> 5) & 0x03) {
 						case 0x00: /* Src is background color */
 							srcval = xga.backcolor;
 							break;
@@ -494,11 +491,9 @@ void XGA_DrawRectangle(Bitu val) {
 							LOG_MSG("XGA: DrawRect: Shouldn't be able to get here!");
 							break;
 					}
-					dstdata = XGA_GetPoint(srcx,srcy);
-
+					dstdata = XGA_GetPoint(srcx, srcy);
 					destval = GetMixResult(mixmode, srcval, dstdata);
-
-                    XGA_DrawPoint(srcx,srcy, destval);
+					XGA_DrawPoint(srcx, srcy, destval);
 					break;
 				default: 
 					LOG_MSG("XGA: DrawRect: Needs mixmode %x", mixmode);
@@ -559,10 +554,8 @@ bool XGA_CheckX(void) {
 
 static void DrawWaitSub(uint32_t mixmode, Bitu srcval)
 {
-	Bitu destval;
-	Bitu dstdata;
-	dstdata = XGA_GetPoint(xga.waitcmd.curx, xga.waitcmd.cury);
-	destval = GetMixResult(mixmode, srcval, dstdata);
+	const Bitu dstdata = XGA_GetPoint(xga.waitcmd.curx, xga.waitcmd.cury);
+	const Bitu destval = GetMixResult(mixmode, srcval, dstdata);
 	//LOG_MSG("XGA: DrawPattern: Mixmode: %x srcval: %x", mixmode, srcval);
 
 	XGA_DrawPoint(xga.waitcmd.curx, xga.waitcmd.cury, destval);
@@ -724,7 +717,6 @@ void XGA_BlitRect(Bitu val) {
 	Bitu dstdata;
 
 	Bitu srcval;
-	Bitu destval;
 
 	Bits srcx, srcy, tarx, tary, dx, dy;
 
@@ -740,7 +732,7 @@ void XGA_BlitRect(Bitu val) {
 	tary = xga.desty;
 
 	Bitu mixselect = (xga.pix_cntl >> 6) & 0x3;
-	Bitu mixmode = 0x67; /* Source is bitmap data, mix mode is src */
+	uint32_t mixmode = 0x67; /* Source is bitmap data, mix mode is src */
 	switch(mixselect) {
 		case 0x00: /* Foreground mix is always used */
 			mixmode = xga.foremix;
@@ -766,11 +758,11 @@ void XGA_BlitRect(Bitu val) {
 			srcdata = XGA_GetPoint(srcx, srcy);
 			dstdata = XGA_GetPoint(tarx, tary);
 
-			if(mixselect == 0x3) {
-				if(srcdata == xga.forecolor) {
+			if (mixselect == 0x3) {
+				if (srcdata == xga.forecolor) {
 					mixmode = xga.foremix;
 				} else {
-					if(srcdata == xga.backcolor) {
+					if (srcdata == xga.backcolor) {
 						mixmode = xga.backmix;
 					} else {
 						/* Best guess otherwise */
@@ -779,7 +771,7 @@ void XGA_BlitRect(Bitu val) {
 				}
 			}
 
-			switch((mixmode >> 5) & 0x03) {
+			switch ((mixmode >> 5) & 0x03) {
 				case 0x00: /* Src is background color */
 					srcval = xga.backcolor;
 					break;
@@ -798,7 +790,7 @@ void XGA_BlitRect(Bitu val) {
 					break;
 			}
 
-			destval = GetMixResult(mixmode, srcval, dstdata);
+			const Bitu destval = GetMixResult(mixmode, srcval, dstdata);
 			//LOG_MSG("XGA: DrawPattern: Mixmode: %x Mixselect: %x", mixmode, mixselect);
 
 			XGA_DrawPoint(tarx, tary, destval);
@@ -816,7 +808,6 @@ void XGA_DrawPattern(Bitu val) {
 	Bitu dstdata;
 
 	Bitu srcval;
-	Bitu destval;
 
 	Bits xat, yat, srcx, srcy, tarx, tary, dx, dy;
 
@@ -832,8 +823,8 @@ void XGA_DrawPattern(Bitu val) {
 	tary = xga.desty;
 
 	Bitu mixselect = (xga.pix_cntl >> 6) & 0x3;
-	Bitu mixmode = 0x67; /* Source is bitmap data, mix mode is src */
-	switch(mixselect) {
+	uint32_t mixmode = 0x67; /* Source is bitmap data, mix mode is src */
+	switch (mixselect) {
 		case 0x00: /* Foreground mix is always used */
 			mixmode = xga.foremix;
 			break;
@@ -865,7 +856,7 @@ void XGA_DrawPattern(Bitu val) {
 					mixmode = xga.backmix;
 			}
 
-			switch((mixmode >> 5) & 0x03) {
+			switch ((mixmode >> 5) & 0x03) {
 				case 0x00: /* Src is background color */
 					srcval = xga.backcolor;
 					break;
@@ -884,8 +875,7 @@ void XGA_DrawPattern(Bitu val) {
 					break;
 			}
 
-			destval = GetMixResult(mixmode, srcval, dstdata);
-
+			const Bitu destval = GetMixResult(mixmode, srcval, dstdata);
 			XGA_DrawPoint(tarx, tary, destval);
 			
 			tarx += dx;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -183,8 +183,8 @@ Bitu XGA_GetPoint(Bitu x, Bitu y) {
 	return 0;
 }
 
-
-Bitu XGA_GetMixResult(Bitu mixmode, Bitu srcval, Bitu dstdata) {
+static Bitu GetMixResult(Bitu mixmode, Bitu srcval, Bitu dstdata)
+{
 	Bitu destval = 0;
 	switch(mixmode &  0xf) {
 		case 0x00: /* not DST */
@@ -320,7 +320,7 @@ void XGA_DrawLineVector(Bitu val) {
 				}
 				dstdata = XGA_GetPoint(xat,yat);
 
-				destval = XGA_GetMixResult(mixmode, srcval, dstdata);
+				destval = GetMixResult(mixmode, srcval, dstdata);
 
                 XGA_DrawPoint(xat,yat, destval);
 				break;
@@ -419,7 +419,7 @@ void XGA_DrawLineBresenham(Bitu val) {
 						dstdata = XGA_GetPoint(yat,xat);
 					}
 
-					destval = XGA_GetMixResult(mixmode, srcval, dstdata);
+					destval = GetMixResult(mixmode, srcval, dstdata);
 
 					if(steep) {
 						XGA_DrawPoint(xat,yat, destval);
@@ -496,7 +496,7 @@ void XGA_DrawRectangle(Bitu val) {
 					}
 					dstdata = XGA_GetPoint(srcx,srcy);
 
-					destval = XGA_GetMixResult(mixmode, srcval, dstdata);
+					destval = GetMixResult(mixmode, srcval, dstdata);
 
                     XGA_DrawPoint(srcx,srcy, destval);
 					break;
@@ -561,7 +561,7 @@ void XGA_DrawWaitSub(Bitu mixmode, Bitu srcval) {
 	Bitu destval;
 	Bitu dstdata;
 	dstdata = XGA_GetPoint(xga.waitcmd.curx, xga.waitcmd.cury);
-	destval = XGA_GetMixResult(mixmode, srcval, dstdata);
+	destval = GetMixResult(mixmode, srcval, dstdata);
 	//LOG_MSG("XGA: DrawPattern: Mixmode: %x srcval: %x", mixmode, srcval);
 
 	XGA_DrawPoint(xga.waitcmd.curx, xga.waitcmd.cury, destval);
@@ -796,7 +796,7 @@ void XGA_BlitRect(Bitu val) {
 					break;
 			}
 
-			destval = XGA_GetMixResult(mixmode, srcval, dstdata);
+			destval = GetMixResult(mixmode, srcval, dstdata);
 			//LOG_MSG("XGA: DrawPattern: Mixmode: %x Mixselect: %x", mixmode, mixselect);
 
 			XGA_DrawPoint(tarx, tary, destval);
@@ -882,7 +882,7 @@ void XGA_DrawPattern(Bitu val) {
 					break;
 			}
 
-			destval = XGA_GetMixResult(mixmode, srcval, dstdata);
+			destval = GetMixResult(mixmode, srcval, dstdata);
 
 			XGA_DrawPoint(tarx, tary, destval);
 			

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -557,7 +557,8 @@ bool XGA_CheckX(void) {
 	return newline;
 }
 
-void XGA_DrawWaitSub(Bitu mixmode, Bitu srcval) {
+static void DrawWaitSub(Bitu mixmode, Bitu srcval)
+{
 	Bitu destval;
 	Bitu dstdata;
 	dstdata = XGA_GetPoint(xga.waitcmd.curx, xga.waitcmd.cury);
@@ -598,17 +599,18 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 					}
 					switch(xga.waitcmd.buswidth) {
 						case M_LIN8:		//  8 bit
-							XGA_DrawWaitSub(mixmode, val);
+							DrawWaitSub(mixmode, val);
 							break;
 						case 0x20 | M_LIN8: // 16 bit 
-							for(Bitu i = 0; i < len; i++) {
-								XGA_DrawWaitSub(mixmode, (val>>(8*i))&0xff);
-								if(xga.waitcmd.newline) break;
+							for (Bitu i = 0; i < len; ++i) {
+								DrawWaitSub(mixmode, (val >> (8 * i)) & 0xff);
+								if (xga.waitcmd.newline)
+									break;
 							}
 							break;
 						case 0x40 | M_LIN8: // 32 bit
-                            for(int i = 0; i < 4; i++)
-								XGA_DrawWaitSub(mixmode, (val>>(8*i))&0xff);
+							for (int i = 0; i < 4; ++i)
+								DrawWaitSub(mixmode, (val >> (8 * i)) & 0xff);
 							break;
 						case (0x20 | M_LIN32):
 							if(len!=4) { // Win 3.11 864 'hack?'
@@ -621,22 +623,22 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 									srcval = (val<<16)|xga.waitcmd.data;
 									xga.waitcmd.data = 0;
 									xga.waitcmd.datasize = 0;
-									XGA_DrawWaitSub(mixmode, srcval);
+									DrawWaitSub(mixmode, srcval);
 								}
 								break;
 							} // fall-through
 						case 0x40 | M_LIN32: // 32 bit
-							XGA_DrawWaitSub(mixmode, val);
+							DrawWaitSub(mixmode, val);
 							break;
 						case 0x20 | M_LIN15: // 16 bit 
 						case 0x20 | M_LIN16: // 16 bit 
-							XGA_DrawWaitSub(mixmode, val);
+							DrawWaitSub(mixmode, val);
 							break;
 						case 0x40 | M_LIN15: // 32 bit 
 						case 0x40 | M_LIN16: // 32 bit 
-							XGA_DrawWaitSub(mixmode, val&0xffff);
-							if(!xga.waitcmd.newline)
-								XGA_DrawWaitSub(mixmode, val>>16);
+							DrawWaitSub(mixmode, val & 0xffff);
+							if (!xga.waitcmd.newline)
+								DrawWaitSub(mixmode, val >> 16);
 							break;
 						default:
 							// Let's hope they never show up ;)
@@ -691,7 +693,7 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 									srcval=0;
 									break;
 							}
-                            XGA_DrawWaitSub(mixmode, srcval);
+							DrawWaitSub(mixmode, srcval);
 
 							if((xga.waitcmd.cury<2048) &&
 							  (xga.waitcmd.cury >= xga.waitcmd.y2)) {

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -244,7 +244,7 @@ static Bitu GetMixResult(uint32_t mixmode, Bitu srcval, Bitu dstdata)
 
 void XGA_DrawLineVector(Bitu val) {
 	Bits xat, yat;
-	Bitu srcval;
+	Bitu srcval = 0;
 	Bits i;
 
 	Bits dx, sx, sy;
@@ -336,7 +336,7 @@ void XGA_DrawLineVector(Bitu val) {
 
 void XGA_DrawLineBresenham(Bitu val) {
 	Bits xat, yat;
-	Bitu srcval;
+	Bitu srcval = 0;
 	Bits i;
 	Bits tmpswap;
 	bool steep;
@@ -451,7 +451,7 @@ void XGA_DrawLineBresenham(Bitu val) {
 
 void XGA_DrawRectangle(Bitu val) {
 	Bit32u xat, yat;
-	Bitu srcval;
+	Bitu srcval = 0;
 
 	Bits srcx, srcy, dx, dy;
 
@@ -716,8 +716,6 @@ void XGA_BlitRect(Bitu val) {
 	Bitu srcdata;
 	Bitu dstdata;
 
-	Bitu srcval;
-
 	Bits srcx, srcy, tarx, tary, dx, dy;
 
 	dx = -1;
@@ -771,6 +769,7 @@ void XGA_BlitRect(Bitu val) {
 				}
 			}
 
+			Bitu srcval = 0;
 			switch ((mixmode >> 5) & 0x03) {
 				case 0x00: /* Src is background color */
 					srcval = xga.backcolor;
@@ -786,7 +785,6 @@ void XGA_BlitRect(Bitu val) {
 					break;
 				default:
 					LOG_MSG("XGA: DrawPattern: Shouldn't be able to get here!");
-					srcval = 0;
 					break;
 			}
 
@@ -807,7 +805,6 @@ void XGA_DrawPattern(Bitu val) {
 	Bitu srcdata;
 	Bitu dstdata;
 
-	Bitu srcval;
 
 	Bits xat, yat, srcx, srcy, tarx, tary, dx, dy;
 
@@ -856,6 +853,7 @@ void XGA_DrawPattern(Bitu val) {
 					mixmode = xga.backmix;
 			}
 
+			Bitu srcval = 0;
 			switch ((mixmode >> 5) & 0x03) {
 				case 0x00: /* Src is background color */
 					srcval = xga.backcolor;
@@ -871,7 +869,6 @@ void XGA_DrawPattern(Bitu val) {
 					break;
 				default:
 					LOG_MSG("XGA: DrawPattern: Shouldn't be able to get here!");
-					srcval = 0;
 					break;
 			}
 

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -557,7 +557,7 @@ bool XGA_CheckX(void) {
 	return newline;
 }
 
-static void DrawWaitSub(Bitu mixmode, Bitu srcval)
+static void DrawWaitSub(uint32_t mixmode, Bitu srcval)
 {
 	Bitu destval;
 	Bitu dstdata;
@@ -571,19 +571,21 @@ static void DrawWaitSub(Bitu mixmode, Bitu srcval)
 	XGA_CheckX();
 }
 
-void XGA_DrawWait(Bitu val, Bitu len) {
-	if(!xga.waitcmd.wait) return;
-	Bitu mixmode = (xga.pix_cntl >> 6) & 0x3;
+void XGA_DrawWait(Bitu val, Bitu len)
+{
+	if (!xga.waitcmd.wait)
+		return;
+	uint32_t mixmode = (xga.pix_cntl >> 6) & 0x3;
 	Bitu srcval;
 	Bitu chunksize = 0;
 	Bitu chunks = 0;
 	switch(xga.waitcmd.cmd) {
 		case 2: /* Rectangle */
-			switch(mixmode) {
+			switch (mixmode) {
 				case 0x00: /* FOREMIX always used */
 					mixmode = xga.foremix;
 
-/*					switch((mixmode >> 5) & 0x03) {
+/*					switch ((mixmode >> 5) & 0x03)
 						case 0x00: // Src is background color
 							srcval = xga.backcolor;
 							break;
@@ -592,13 +594,13 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 							break;
 						case 0x02: // Src is pixel data from PIX_TRANS register
 */
-					if(((mixmode >> 5) & 0x03) != 0x2) {
+					if (((mixmode >> 5) & 0x03) != 0x2) {
 						// those cases don't seem to occur
 						LOG_MSG("XGA: unsupported drawwait operation");
 						break;
 					}
 					switch(xga.waitcmd.buswidth) {
-						case M_LIN8:		//  8 bit
+						case M_LIN8: // 8 bit
 							DrawWaitSub(mixmode, val);
 							break;
 						case 0x20 | M_LIN8: // 16 bit 
@@ -672,15 +674,13 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 					
 					for(Bitu k = 0; k < chunks; k++) { // chunks counter
 						xga.waitcmd.newline = false;
-						for(Bitu n = 0; n < chunksize; n++) { // pixels
-							Bitu mixmode;
-							
+						for (Bitu n = 0; n < chunksize; ++n) { // pixels
 							// This formula can rule the world ;)
 							Bitu mask = 1 << ((((n&0xF8)+(8-(n&0x7)))-1)+chunksize*k);
-							if(val&mask) mixmode = xga.foremix;
-							else mixmode = xga.backmix;
-							
-							switch((mixmode >> 5) & 0x03) {
+
+							const uint32_t mixmode = (val & mask) ? xga.foremix:
+							                                        xga.backmix;
+							switch ((mixmode >> 5) & 0x03) {
 								case 0x00: // Src is background color
 									srcval = xga.backcolor;
 									break;
@@ -710,7 +710,7 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 				default:
 					LOG_MSG("XGA: DrawBlitWait: Unhandled mixmode: %d", mixmode);
 					break;
-			} // switch mixmode
+			} // mixmode switch
 			break;
 		default:
 			LOG_MSG("XGA: Unhandled draw command %x", xga.waitcmd.cmd);


### PR DESCRIPTION
Addressing few of warnings, that were irritating me for a while  (mostly -Wformat), and going back on track with reducing the number of static analysis issues :)

Also, small cleanup: marking functions static, formatting fixes, whitespace fixes, etc.