### PR TITLE
Refactor and make the joystick querier re-runnable

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -57,7 +57,7 @@ jobs:
           path: report
       - name: Summarize report
         env:
-          MAX_BUGS: 216
+          MAX_BUGS: 215
         run: |
           # summary
           echo "Full report is included in build Artifacts"
@@ -127,7 +127,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 524
+          MAX_BUGS: 496
         run: |
           echo "Full report is included in build Artifacts"
           echo
@@ -149,7 +149,7 @@ jobs:
             sanitizers: TSAN UASAN
             usan:  -1
             tsan:  0  # our test does not trigger multiple threads yet
-            uasan: 177
+            uasan: 80
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,15 +12,15 @@ jobs:
           - name: GCC-5 (Ubuntu 16.04)
             os: ubuntu-16.04
             flags: -c gcc
-            max_warnings: 86
+            max_warnings: 60
           - name: GCC-7 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc
-            max_warnings: 88
+            max_warnings: 62
           - name: GCC-9 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c gcc -v 9
-            max_warnings: 107
+            max_warnings: 81
           - name: Clang-8 (Ubuntu 18.04)
             os: ubuntu-18.04
             flags: -c clang -v 8

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
             max_warnings: 62
           - name: GCC-9
             flags: -c gcc -v 9
-            max_warnings: 99
+            max_warnings: 82
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,11 +24,11 @@ jobs:
           - compiler: GCC
             bits: 32
             arch: i686
-            max_warnings: 66
+            max_warnings: 49
           - compiler: GCC
             bits: 64
             arch: x86_64
-            max_warnings: 99
+            max_warnings: 82
     env:
       CHERE_INVOKING: yes
     steps:

--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -5,7 +5,7 @@ cxx="clang++${postfix}"
 # Flag additions
 TYPES+=(debug warnmore profile)
 cflags_release=("${cflags[@]}" -Os)
-cflags_debug=("${cflags[@]}" -g -Og -fno-omit-frame-pointer)
+cflags_debug=("${cflags[@]}" -g -fno-omit-frame-pointer)
 cflags_profile=("${cflags_debug[@]}" -fprofile-instr-generate -fcoverage-mapping)
 cflags_warnmore=("${cflags_debug[@]}" -Wextra -Wshadow -Wcast-align -Wunused
                  -Woverloaded-virtual -Wpedantic -Wconversion -Wsign-conversion

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -9,7 +9,7 @@ ranlib="gcc-ranlib${postfix}"
 TYPES+=(debug warnmore profile)
 
 cflags+=(-fstack-protector -fdiagnostics-color=auto)
-cflags_debug=("${cflags[@]}" -g -Og	-fno-omit-frame-pointer)
+cflags_debug=("${cflags[@]}" -g -fno-omit-frame-pointer)
 cflags_release=("${cflags[@]}" -Ofast -ffunction-sections -fdata-sections)
 cflags_profile=("${cflags_debug[@]}" -pg)
 cflags_warnmore=("${cflags_debug[@]}" -pedantic -Wcast-align -Wdouble-promotion

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -412,9 +412,9 @@ static std::list<CKeyBindGroup *> keybindgroups;
 #define MAX_VJOY_HAT 16
 #define MAX_VJOY_AXIS 8
 static struct {
-	bool button_pressed[MAX_VJOY_BUTTONS];
-	Bit16s axis_pos[MAX_VJOY_AXIS];
-	bool hat_pressed[MAX_VJOY_HAT];
+	int16_t axis_pos[MAX_VJOY_AXIS] = {0};
+	bool hat_pressed[MAX_VJOY_HAT] = {false};
+	bool button_pressed[MAX_VJOY_BUTTONS] = {false};
 } virtual_joysticks[2];
 
 
@@ -1213,8 +1213,9 @@ static struct CMapper {
 	bool addbind = false;
 	Bitu mods = 0;
 	struct {
-		Bitu num_groups,num;
-		CStickBindGroup * stick[MAXSTICKS];
+		CStickBindGroup * stick[MAXSTICKS] = {nullptr};
+		unsigned int num = 0;
+		unsigned int num_groups = 0;
 	} sticks;
 	std::string filename = "";
 } mapper;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -299,7 +299,7 @@ void CEvent::ClearBinds() {
 	bindlist.clear();
 }
 void CEvent::DeActivateAll(void) {
-	for (CBindList_it bit=bindlist.begin();bit!=bindlist.end();bit++) {
+	for (CBindList_it bit = bindlist.begin() ; bit != bindlist.end(); ++bit) {
 		(*bit)->DeActivateBind(true);
 	}
 }
@@ -1223,19 +1223,19 @@ static struct CMapper {
 void CBindGroup::ActivateBindList(CBindList * list,Bits value,bool ev_trigger) {
 	Bitu validmod=0;
 	CBindList_it it;
-	for (it=list->begin();it!=list->end();it++) {
+	for (it = list->begin(); it != list->end(); ++it) {
 		if (((*it)->mods & mapper.mods) == (*it)->mods) {
 			if (validmod<(*it)->mods) validmod=(*it)->mods;
 		}
 	}
-	for (it=list->begin();it!=list->end();it++) {
+	for (it = list->begin(); it != list->end(); ++it) {
 		if (validmod==(*it)->mods) (*it)->ActivateBind(value,ev_trigger);
 	}
 }
 
 void CBindGroup::DeactivateBindList(CBindList * list,bool ev_trigger) {
 	CBindList_it it;
-	for (it=list->begin();it!=list->end();it++) {
+	for (it = list->begin(); it != list->end(); ++it) {
 		(*it)->DeActivateBind(ev_trigger);
 	}
 }
@@ -1302,6 +1302,8 @@ protected:
 	bool enabled;
 };
 
+// Inform PVS-Studio that new CTextButtons won't be leaked when they go out of scope
+//+V773:SUPPRESS, class:CTextButton
 class CTextButton : public CButton {
 public:
 	CTextButton(Bitu  x, Bitu y, Bitu dx, Bitu dy, const char *txt)
@@ -1415,7 +1417,7 @@ public:
 			break;
 		case BB_Next:
 			if (mapper.abindit!=mapper.aevent->bindlist.end()) 
-				mapper.abindit++;
+				++mapper.abindit;
 			if (mapper.abindit==mapper.aevent->bindlist.end()) 
 				mapper.abindit=mapper.aevent->bindlist.begin();
 			SetActiveBind(*(mapper.abindit));
@@ -1721,7 +1723,7 @@ extern void GFX_UpdateDisplayDimensions(int width, int height);
 
 static void DrawButtons(void) {
 	SDL_FillRect(mapper.draw_surface,0,CLR_BLACK);
-	for (CButton_it but_it = buttons.begin();but_it!=buttons.end();but_it++) {
+	for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
 		(*but_it)->Draw();
 	}
 	// We can't just use SDL_BlitScaled (say for Android) in one step
@@ -2024,7 +2026,7 @@ static void CreateLayout(void) {
 	AddModButton(PX(4),PY(14),50,20,"Mod3",3);
 	/* Create Handler buttons */
 	Bitu xpos=3;Bitu ypos=11;
-	for (CHandlerEventVector_it hit=handlergroup.begin();hit!=handlergroup.end();hit++) {
+	for (CHandlerEventVector_it hit = handlergroup.begin(); hit != handlergroup.end(); ++hit) {
 		new CEventButton(PX(xpos*3),PY(ypos),BW*3,BH,(*hit)->ButtonName(),(*hit));
 		xpos++;
 		if (xpos>6) {
@@ -2071,7 +2073,7 @@ static void CreateStringBind(char * line) {
 	line=trim(line);
 	char * eventname=StripWord(line);
 	CEvent * event;
-	for (CEventVector_it ev_it=events.begin();ev_it!=events.end();ev_it++) {
+	for (CEventVector_it ev_it = events.begin(); ev_it != events.end(); ++ev_it) {
 		if (!strcasecmp((*ev_it)->GetName(),eventname)) {
 			event=*ev_it;
 			goto foundevent;
@@ -2082,7 +2084,7 @@ static void CreateStringBind(char * line) {
 foundevent:
 	CBind * bind;
 	for (char * bindline=StripWord(line);*bindline;bindline=StripWord(line)) {
-		for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();it++) {
+		for (CBindGroup_it it = bindgroups.begin(); it != bindgroups.end(); ++it) {
 			bind=(*it)->CreateConfigBind(bindline);
 			if (bind) {
 				event->AddBind(bind);
@@ -2199,7 +2201,7 @@ static void CreateDefaultBinds(void) {
 	CreateStringBind(buffer);
 	sprintf(buffer, "mod_2 \"key %d\"", SDL_SCANCODE_LALT);
 	CreateStringBind(buffer);
-	for (CHandlerEventVector_it hit=handlergroup.begin();hit!=handlergroup.end();hit++) {
+	for (CHandlerEventVector_it hit = handlergroup.begin(); hit != handlergroup.end(); ++hit) {
 		(*hit)->MakeDefaultBind(buffer);
 		CreateStringBind(buffer);
 	}
@@ -2239,7 +2241,7 @@ static void CreateDefaultBinds(void) {
 
 void MAPPER_AddHandler(MAPPER_Handler * handler,MapKeys key, Bitu mods,char const * const eventname,char const * const buttonname) {
 	//Check if it already exists=> if so return.
-	for(CHandlerEventVector_it it=handlergroup.begin();it!=handlergroup.end();it++)
+	for(CHandlerEventVector_it it=handlergroup.begin(); it != handlergroup.end(); ++it)
 		if(strcmp((*it)->buttonname,buttonname) == 0) return;
 
 	char tempname[17];
@@ -2256,10 +2258,10 @@ static void MAPPER_SaveBinds(void) {
 		return;
 	}
 	char buf[128];
-	for (CEventVector_it event_it=events.begin();event_it!=events.end();event_it++) {
+	for (CEventVector_it event_it = events.begin(); event_it != events.end(); ++event_it) {
 		CEvent * event=*(event_it);
 		fprintf(savefile,"%s ",event->GetName());
-		for (CBindList_it bind_it=event->bindlist.begin();bind_it!=event->bindlist.end();bind_it++) {
+		for (CBindList_it bind_it = event->bindlist.begin(); bind_it != event->bindlist.end(); ++bind_it) {
 			CBind * bind=*(bind_it);
 			bind->ConfigName(buf);
 			bind->AddFlags(buf);
@@ -2285,7 +2287,7 @@ static bool MAPPER_LoadBinds(void) {
 }
 
 void MAPPER_CheckEvent(SDL_Event * event) {
-	for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();it++) {
+	for (CBindGroup_it it = bindgroups.begin(); it != bindgroups.end(); ++it) {
 		if ((*it)->CheckEvent(event)) return;
 	}
 }
@@ -2323,7 +2325,7 @@ void BIND_MappingEvents(void) {
 				lastHoveredButton = nullptr;
 			}
 			/* Check which button are we currently pointing at */
-			for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); but_it++) {
+			for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
 				if (dynamic_cast<CClickableTextButton *>(*but_it) && (*but_it)->OnTop(event.button.x,event.button.y)) {
 					(*but_it)->SetColor(CLR_RED);
 					mapper.redraw = true;
@@ -2348,7 +2350,7 @@ void BIND_MappingEvents(void) {
 			if ((event.button.y < 0) || (event.button.y>=mapper.draw_surface->h))
 				break;
 			/* Check the press */
-			for (CButton_it but_it = buttons.begin();but_it!=buttons.end();but_it++) {
+			for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
 				if (dynamic_cast<CClickableTextButton *>(*but_it) && (*but_it)->OnTop(event.button.x,event.button.y)) {
 					(*but_it)->Click();
 					break;
@@ -2376,7 +2378,7 @@ void BIND_MappingEvents(void) {
 			mapper.exit=true;
 			break;
 		default:
-			if (mapper.addbind) for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();it++) {
+			if (mapper.addbind) for (CBindGroup_it it = bindgroups.begin(); it != bindgroups.end(); ++it) {
 				CBind * newbind=(*it)->CreateEventBind(&event);
 				if (!newbind) continue;
 				mapper.aevent->AddBind(newbind);
@@ -2497,7 +2499,7 @@ void MAPPER_UpdateJoysticks(void) {
 #endif
 
 void MAPPER_LosingFocus(void) {
-	for (CEventVector_it evit=events.begin();evit!=events.end();evit++) {
+	for (CEventVector_it evit = events.begin(); evit != events.end(); ++evit) {
 		if(*evit != caps_lock_event && *evit != num_lock_event)
 			(*evit)->DeActivateAll();
 	}
@@ -2584,17 +2586,17 @@ void MAPPER_Init(void) {
 	if (buttons.empty()) CreateLayout();
 	if (bindgroups.empty()) CreateBindGroups();
 	if (!MAPPER_LoadBinds()) CreateDefaultBinds();
-	for (CButton_it but_it = buttons.begin();but_it!=buttons.end();but_it++) {
+	for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
 		(*but_it)->BindColor();
 	}
 	if (SDL_GetModState()&KMOD_CAPS) {
-		for (CBindList_it bit=caps_lock_event->bindlist.begin();bit!=caps_lock_event->bindlist.end();bit++) {
+		for (CBindList_it bit = caps_lock_event->bindlist.begin(); bit != caps_lock_event->bindlist.end(); ++bit) {
 			(*bit)->ActivateBind(32767,true,false);
 			(*bit)->DeActivateBind(false);
 		}
 	}
 	if (SDL_GetModState()&KMOD_NUM) {
-		for (CBindList_it bit=num_lock_event->bindlist.begin();bit!=num_lock_event->bindlist.end();bit++) {
+		for (CBindList_it bit = num_lock_event->bindlist.begin(); bit != num_lock_event->bindlist.end(); ++bit) {
 			(*bit)->ActivateBind(32767,true,false);
 			(*bit)->DeActivateBind(false);
 		}

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -292,8 +292,8 @@ void CEvent::AddBind(CBind * bind) {
 }
 void CEvent::ClearBinds() {
 	for (CBind *bind : bindlist) {
-		delete bind;
 		all_binds.remove(bind);
+		delete bind;
 		bind = nullptr;
 	}
 	bindlist.clear();
@@ -1924,6 +1924,7 @@ static void CreateLayout(void) {
 	cjaxis=AddJAxisButton  (PX(XO),PY(YO+1),BW,BH,"X-",0,0,false,NULL);
 	AddJAxisButton  (PX(XO+2),PY(YO+1),BW,BH,"X+",0,0,true,cjaxis);
 
+	CJAxisEvent * tmp_ptr;
 	if (joytype==JOY_2AXIS) {
 		/* Buttons 1+2 of 2nd Joystick */
 		AddJButtonButton(PX(XO+4),PY(YO),BW,BH,"1" ,1,0);
@@ -1933,15 +1934,19 @@ static void CreateLayout(void) {
 		AddJButtonButton_hidden(0,3);
 
 		/* Axes 1+2 (X+Y) of 2nd Joystick */
-		cjaxis=	AddJAxisButton(PX(XO+4),PY(YO+1),BW,BH,"X-",1,0,false,NULL);
-				AddJAxisButton(PX(XO+4+2),PY(YO+1),BW,BH,"X+",1,0,true,cjaxis);
-		cjaxis=	AddJAxisButton(PX(XO+4+1),PY(YO+0),BW,BH,"Y-",1,1,false,NULL);
-				AddJAxisButton(PX(XO+4+1),PY(YO+1),BW,BH,"Y+",1,1,true,cjaxis);
+		cjaxis  = AddJAxisButton(PX(XO+4),PY(YO+1),BW,BH,"X-",1,0,false,NULL);
+		tmp_ptr = AddJAxisButton(PX(XO+4+2),PY(YO+1),BW,BH,"X+",1,0,true,cjaxis);
+		(void)tmp_ptr;
+		cjaxis  = AddJAxisButton(PX(XO+4+1),PY(YO+0),BW,BH,"Y-",1,1,false,NULL);
+		tmp_ptr = AddJAxisButton(PX(XO+4+1),PY(YO+1),BW,BH,"Y+",1,1,true,cjaxis);
+		(void)tmp_ptr;
 		/* Axes 3+4 (X+Y) of 1st Joystick, not accessible */
-		cjaxis=	AddJAxisButton_hidden(0,2,false,NULL);
-				AddJAxisButton_hidden(0,2,true,cjaxis);
-		cjaxis=	AddJAxisButton_hidden(0,3,false,NULL);
-				AddJAxisButton_hidden(0,3,true,cjaxis);
+		cjaxis  = AddJAxisButton_hidden(0,2,false,NULL);
+		tmp_ptr = AddJAxisButton_hidden(0,2,true,cjaxis);
+		(void)tmp_ptr;
+		cjaxis  = AddJAxisButton_hidden(0,3,false,NULL);
+		tmp_ptr = AddJAxisButton_hidden(0,3,true,cjaxis);
+		(void)tmp_ptr;
 	} else {
 		/* Buttons 3+4 of 1st Joystick */
 		AddJButtonButton(PX(XO+4),PY(YO),BW,BH,"3" ,0,2);
@@ -1951,15 +1956,19 @@ static void CreateLayout(void) {
 		AddJButtonButton_hidden(1,1);
 
 		/* Axes 3+4 (X+Y) of 1st Joystick */
-		cjaxis=	AddJAxisButton(PX(XO+4),PY(YO+1),BW,BH,"X-",0,2,false,NULL);
-				AddJAxisButton(PX(XO+4+2),PY(YO+1),BW,BH,"X+",0,2,true,cjaxis);
-		cjaxis=	AddJAxisButton(PX(XO+4+1),PY(YO+0),BW,BH,"Y-",0,3,false,NULL);
-				AddJAxisButton(PX(XO+4+1),PY(YO+1),BW,BH,"Y+",0,3,true,cjaxis);
+		cjaxis  = AddJAxisButton(PX(XO+4),PY(YO+1),BW,BH,"X-",0,2,false,NULL);
+		tmp_ptr = AddJAxisButton(PX(XO+4+2),PY(YO+1),BW,BH,"X+",0,2,true,cjaxis);
+		(void)tmp_ptr;
+		cjaxis  = AddJAxisButton(PX(XO+4+1),PY(YO+0),BW,BH,"Y-",0,3,false,NULL);
+		tmp_ptr = AddJAxisButton(PX(XO+4+1),PY(YO+1),BW,BH,"Y+",0,3,true,cjaxis);
+		(void)tmp_ptr;
 		/* Axes 1+2 (X+Y) of 2nd Joystick , not accessible*/
-		cjaxis=	AddJAxisButton_hidden(1,0,false,NULL);
-				AddJAxisButton_hidden(1,0,true,cjaxis);
-		cjaxis=	AddJAxisButton_hidden(1,1,false,NULL);
-				AddJAxisButton_hidden(1,1,true,cjaxis);
+		cjaxis  = AddJAxisButton_hidden(1,0,false,NULL);
+		tmp_ptr = AddJAxisButton_hidden(1,0,true,cjaxis);
+		(void)tmp_ptr;
+		cjaxis  = AddJAxisButton_hidden(1,1,false,NULL);
+		tmp_ptr = AddJAxisButton_hidden(1,1,true,cjaxis);
+		(void)tmp_ptr;
 	}
 
 	if (joytype==JOY_CH) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -386,7 +386,7 @@ public:
 	};
 	bool CheckEvent(SDL_Event * event) {
 		if (event->type!=SDL_KEYDOWN && event->type!=SDL_KEYUP) return false;
-		Bitu key = event->key.keysym.scancode;
+		uintptr_t key = static_cast<uintptr_t>(event->key.keysym.scancode);
 		if (event->type==SDL_KEYDOWN) ActivateBindList(&lists[key],0x7fff,true);
 		else DeactivateBindList(&lists[key],true);
 		return 0;
@@ -1580,9 +1580,9 @@ public:
 	void Active(bool yesno)
 	{
 		if (yesno)
-			mapper.mods |= (1 << (wmod-1));
+			mapper.mods |= (static_cast<Bitu>(1) << (wmod-1));
 		else
-			mapper.mods &= ~(1 << (wmod-1));
+			mapper.mods &= ~(static_cast<Bitu>(1) << (wmod-1));
 	}
 
 protected:
@@ -2228,7 +2228,7 @@ static void CreateDefaultBinds(void) {
 	sprintf(buffer,"jhat_0_0_3 \"stick_0 hat 0 8\" ");CreateStringBind(buffer);
 }
 
-void MAPPER_AddHandler(MAPPER_Handler * handler,MapKeys key,Bitu mods,char const * const eventname,char const * const buttonname) {
+void MAPPER_AddHandler(MAPPER_Handler * handler,MapKeys key, Bitu mods,char const * const eventname,char const * const buttonname) {
 	//Check if it already exists=> if so return.
 	for(CHandlerEventVector_it it=handlergroup.begin();it!=handlergroup.end();it++)
 		if(strcmp((*it)->buttonname,buttonname) == 0) return;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2406,14 +2406,12 @@ static void QueryJoysticks() {
 	// Set the type of joystick based which are useable
 	const bool first_usable = useable[0];
 	const bool second_usable = useable[1];	
-	if (first_usable) {
-		if (second_usable) {
-			joytype = JOY_2AXIS;
-			LOG_MSG("SDL: Two or more joysticks found, initializing with 2axis");
-		} else {
-			joytype = JOY_4AXIS;
-			LOG_MSG("SDL: One joystick found, initializing with 4axis");
-		}
+	if (first_usable && second_usable) {
+		joytype = JOY_2AXIS;
+		LOG_MSG("SDL: Two or more joysticks found, initializing with 2axis");
+	} else if (first_usable) {
+		joytype = JOY_4AXIS;
+		LOG_MSG("SDL: One joystick found, initializing with 4axis");
 	} else if (second_usable) {
 		joytype = JOY_4AXIS_2;
 		LOG_MSG("SDL: One joystick found, initializing with 4axis_2");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2824,7 +2824,6 @@ int main(int argc, char* argv[]) {
 		}
 
 		/* Init the keyMapper */
-		MAPPER_Init();
 		if (control->cmdline->FindExist("-startmapper")) MAPPER_RunInternal();
 		/* Start up main machine */
 		control->StartUp();


### PR DESCRIPTION
**Context:** the joystick was reported unuseable, which was due to the mapper's joystick initialization routine having the following issues:
- It can only be effectively run once because it changes the value of the global variable `joytype` to something other than `AUTO`, which is what this function checks prior to quering SDL's joystick subsystem.     
- When this function is run more than once, it clobbers the prior queried number of joysticks back to zero (without re-requerying for the actual quantities due to locking itself out as mentioned above).  These quantities are used by subsequent code, and when set to zero effectively renders the joystick(s) unuseable.
- Finally, this function depends on several SDL calls to the joystick subsystem, but fails to check if it's initialized.  This is relevant because when the reloadable mapper feature was introduced, it moved forward this joystick initialization routine into the config-file parsing phase, which comes before SDL's initialization in `sdlmain.cpp`;  The calls to SDL's uninitialized joystick routines still passed though - however returning empty values. 

**This PR:**
- Checks for and initializes the joystick subsystem before using it, and properly tears it down on mapper destruction (SDL subsystems are reference-counted)
- Always re-queries the current state of the joysticks, which retains the goal of reloading the mapper during runtime
- Simplifies the joystick initialization logic, but retains the original useability criteria
- Conservatively updates the mapper's joystick global variables only afyer completing the joystick assessment, which protects against early-clobbering if any of the joystick checks fail
- Removes the now redundant Init_Mapper() call from sdlmain, and predicted by @dreamer 
- Adds a small amount of object tracking and cleanup code to stop the mapper from leaking like a sieve (97 leaks fixed)

Thanks to @mdmallardi for catching and reporting this big functional hole, and to @bitstrom for pinpointing the flawed early initialization!

Fixes #219.