### PR TITLE
Modem improvements

### DIFF
--- a/README
+++ b/README
@@ -1368,6 +1368,21 @@ To host a DOS-based BBS:
     fowarding entry to listen on TCP port 23 and pass it through to
     port 2323 to your DOSBox machine's IP address.  This allows Internet
     users to "dial" your BBS using the default Telnet port.
+	
+Phone book
+----------
+You can map fake phone numbers to Internet addresses which is useful for programs
+where limitations on phone number input field are too strict.
+Create a text file with the name specified in "phonebookfile" entry in [serial]
+section in the DOSBox configuration file and add phone-address pairs per line,
+for example:
+
+5551234 towel.blinkenlights.nl:23
+
+Now you can dial the specified phone number and the emulated modem will connect
+to the address it's mapped to. Note that phone book does not allow any
+characters in the phone number that are ignored or denied by a real Hayes
+compatible modem.
 
 =====================================
 10. How to speed up/slow down DOSBox:

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -768,6 +768,9 @@ void DOSBOX_Init(void) {
 	Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
 	Pmulti_remain->Set_help("see serial1");
 
+	Pstring = secprop->Add_path("phonebookfile", Property::Changeable::OnlyAtStart, "phonebook-" VERSION ".txt");
+	Pstring->Set_help("File used to map fake phone numbers to addresses.");
+
 
 	/* All the DOS Related stuff, which will eventually start up in the shell */
 	secprop=control->AddSection_prop("dos",&DOS_Init,false);//done

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1214,8 +1214,7 @@ bool CSerial::Putchar(Bit8u data, bool wait_dsr, bool wait_cts, Bitu timeout) {
 
 #if SERIAL_DEBUG
 	log_ser(dbg_aux,"Putchar 0x%x",data);
-#endif
-
+#endif 
 	return true;
 }
 
@@ -1226,8 +1225,8 @@ public:
 		Section_prop *section = static_cast <Section_prop*>(configuration);
 
 #if C_MODEM
-		Prop_path *pbFilename = section->Get_path("phonebookfile");
-		MODEM_ReadPhonebook(pbFilename->realpath.c_str());
+		const Prop_path *pbFilename = section->Get_path("phonebookfile");
+		MODEM_ReadPhonebook(pbFilename->realpath);
 #endif
 
 		char s_property[] = "serialx"; 

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1225,6 +1225,11 @@ public:
 		Bit16u biosParameter[4] = { 0, 0, 0, 0 };
 		Section_prop *section = static_cast <Section_prop*>(configuration);
 
+#if C_MODEM
+		Prop_path *pbFilename = section->Get_path("phonebookfile");
+		MODEM_ReadPhonebook(pbFilename->realpath.c_str());
+#endif
+
 		char s_property[] = "serialx"; 
 		for(Bitu i = 0; i < 4; i++) {
 			// get the configuration property

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -65,11 +65,11 @@ static bool MODEM_IsPhoneValid(const std::string &input) {
 }
 
 bool MODEM_ReadPhonebook(const std::string &filename) {
-	LOG_MSG("SERIAL: Loading phonebook from %s", filename.c_str());
-
 	std::ifstream loadfile(filename);
 	if (!loadfile)
 		return false;
+
+	LOG_MSG("SERIAL: Loading phonebook from %s", filename.c_str());
 
 	std::string linein;
 	while (std::getline(loadfile, linein)) {

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -246,9 +246,10 @@ void CSerialModem::Reset(){
 	EnterIdleState();
 	cmdpos = 0;
 	cmdbuf[0] = 0;
-	oldDTRstate = getDTR();
 	flowcontrol = 0;
 	plusinc = 0;
+	oldDTRstate = getDTR();
+	dtrmode = 2;
 	clientsocket.reset(nullptr);
 
 	memset(&reg,0,sizeof(reg));
@@ -259,6 +260,7 @@ void CSerialModem::Reset(){
 	reg[MREG_LF_CHAR]          = '\n';
 	reg[MREG_BACKSPACE_CHAR]   = '\b';
 	reg[MREG_GUARD_TIME]       = 50;
+	reg[MREG_DTR_DELAY]        = 5;
 
 	cmdpause = 0;
 	echo = true;
@@ -272,6 +274,7 @@ void CSerialModem::Reset(){
 void CSerialModem::EnterIdleState(void){
 	connected = false;
 	ringing = false;
+	dtrofftimer = -1;
 	clientsocket.reset(nullptr);
 	waitingclientsocket.reset(nullptr);
 
@@ -313,6 +316,7 @@ void CSerialModem::EnterConnectedState(void) {
 	memset(&telClient, 0, sizeof(telClient));
 	connected = true;
 	ringing = false;
+	dtrofftimer = -1;
 	CSerial::setCD(true);
 	CSerial::setRI(false);
 }
@@ -535,6 +539,15 @@ void CSerialModem::DoCommand() {
 					Bitu val = ScanNumber(scanbuf);
 					if(val < 5)
 						flowcontrol = val;
+					else {
+						SendRes(ResERROR);
+						return;
+					}
+					break;
+				}
+				case 'D': {
+					Bitu val = ScanNumber(scanbuf);
+					if (val<4) dtrmode=val;
 					else {
 						SendRes(ResERROR);
 						return;
@@ -769,7 +782,7 @@ void CSerialModem::Timer2(void) {
 	if (!connected && !waitingclientsocket && serversocket) {
 		waitingclientsocket.reset(serversocket->Accept());
 		if (waitingclientsocket) {
-			if (!CSerial::getDTR()) {
+			if (!CSerial::getDTR() && dtrmode != 0) {
 				// accept no calls with DTR off; TODO: AT &Dn
 				EnterIdleState();
 			} else {
@@ -796,6 +809,40 @@ void CSerialModem::Timer2(void) {
 			ringtimer = 3000;
 		}
 		--ringtimer;
+	}
+
+	if (connected && !getDTR()) {
+		if (dtrofftimer == 0) {
+			switch (dtrmode) {
+				case 0:
+					// Do nothing.
+					//LOG_MSG("Modem: Dropped DTR.");
+					break;
+				case 1:
+					// Go back to command mode.
+					LOG_MSG("Modem: Entering command mode due to dropped DTR.");
+					commandmode = true;
+					SendRes(ResOK);
+					break;
+				case 2:
+					// Hang up.
+					LOG_MSG("Modem: Hanging up due to dropped DTR.");
+					SendRes(ResNOCARRIER);
+					EnterIdleState();
+					break;
+				case 3:
+					// Reset.
+					LOG_MSG("Modem: Resetting due to dropped DTR.");
+					SendRes(ResNOCARRIER);
+					Reset();
+					break;
+			}
+		}
+
+		// Set the timer to -1 once it's expired to turn it off.
+		if (dtrofftimer >= 0) {
+			dtrofftimer--;
+		}
 	}
 }
 
@@ -838,12 +885,16 @@ void CSerialModem::setRTS(bool val) {
 	(void) val; // deliberately unused but but needed for API compliance
 }
 void CSerialModem::setDTR(bool val) {
-	if (!val && connected) {
-		// If DTR goes low, hang up.
-		SendRes(ResNOCARRIER);
-		EnterIdleState();
-		LOG_MSG("Modem: Hang up due to dropped DTR.");
+	if (val != oldDTRstate) {
+		if (connected && !val) {
+			// Start the timer upon losing DTR.
+			dtrofftimer = reg[MREG_DTR_DELAY];
+		} else {
+			dtrofftimer = -1;
+		}
 	}
+
+	oldDTRstate = val;
 }
 /*
 void CSerialModem::updateModemControlLines() {

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -718,9 +718,11 @@ void CSerialModem::Timer2(void) {
 				rqueue->addb(txval);
 				//LOG_MSG("Echo back to queue: %x",txval);
 			}
-			if (txval == 0xa) continue; //Real modem doesn't seem to skip this?
-			else if (txval == 0x8 && (cmdpos > 0)) --cmdpos; // backspace
-			else if (txval == 0xd) DoCommand(); // return
+			if (txval == '\n') continue; // Real modem doesn't seem to skip this?
+			else if (txval == '\b') { // backspace
+				if (cmdpos > 0) cmdpos--;
+			}
+			else if (txval == '\r') DoCommand(); // return
 			else if (txval != '+') {
 				if(cmdpos<99) {
 					cmdbuf[cmdpos] = txval;

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -328,7 +328,7 @@ void CSerialModem::DoCommand() {
 	LOG_MSG("Command sent to modem: ->%s<-\n", cmdbuf);
 	/* Check for empty line, stops dialing and autoanswer */
 	if (!cmdbuf[0]) {
-		reg[0] = 0;	// autoanswer off
+		reg[MREG_AUTOANSWER_COUNT] = 0;	// autoanswer off
 		return;
 	}
 	//else {
@@ -791,14 +791,15 @@ void CSerialModem::Timer2(void) {
 				CSerial::setRI(!CSerial::getRI());
 				//MIXER_Enable(mhd.chan,true);
 				ringtimer = 3000;
-				reg[1] = 0; //Reset ring counter reg
+				reg[MREG_RING_COUNT] = 0; //Reset ring counter reg
 			}
 		}
 	}
 	if (ringing) {
 		if (ringtimer <= 0) {
-			reg[1]++;
-			if ((reg[0] > 0) && (reg[0] >= reg[1])) {
+			reg[MREG_RING_COUNT]++;
+			if ((reg[MREG_AUTOANSWER_COUNT] > 0) &&
+				(reg[MREG_RING_COUNT] >= reg[MREG_AUTOANSWER_COUNT])) {
 				AcceptIncomingCall();
 				return;
 			}

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -29,6 +29,75 @@
 #include "softmodem.h"
 #include "misc_util.h"
 
+static const char phoneValidChars[] = "01234567890*=,;#+>";
+
+class CPhonebookEntry {
+public:
+	CPhonebookEntry(const char *_phone, const char *_address) {
+		safe_strncpy(phone, _phone, sizeof(phone));
+		safe_strncpy(address, _address, sizeof(phone));
+	}
+
+	const char *IsMatchingPhone(const char *input) {
+		if (strcmp(input, phone) != 0)
+			return NULL;
+
+		return address;
+	}
+
+	static char IsValidPhone(const char *input) {
+		for (const char *ch = input; *ch; ch++) {
+			if (!strchr(phoneValidChars, *ch)) {
+				LOG_MSG("SERIAL: Phone %s contains invalid character %c", input, *ch);
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+private:
+	char phone[64];
+	char address[64];
+};
+
+static std::vector<CPhonebookEntry *> phones;
+
+bool MODEM_ReadPhonebook(const char *filename) {
+	LOG_MSG("SERIAL: Loading phonebook from %s", filename);
+
+	FILE *loadfile = fopen(filename, "rt");
+	if (!loadfile) return false;
+	char linein[512];
+	while (fgets(linein, 512, loadfile)) {
+		char *line = trim(linein);
+		char *phone = StripWord(line);
+		char *address = StripWord(line);
+
+		if (*phone && *address) {
+			// Check phone number for characters ignored by Hayes modems.
+			if (!CPhonebookEntry::IsValidPhone(phone))
+				continue;
+
+			LOG_MSG("SERIAL: Mapped phone %s to address %s", phone, address);
+			CPhonebookEntry *pbEntry = new CPhonebookEntry(phone, address);
+			phones.push_back(pbEntry);
+		}
+	}
+	fclose(loadfile);
+	return true;
+}
+
+static const char *MODEM_CheckPhonebook(const char *input) {
+	for (std::vector<CPhonebookEntry *>::iterator it = phones.begin(); it != phones.end(); it++) {
+		CPhonebookEntry *pbEntry = *it;
+		const char *address = pbEntry->IsMatchingPhone(input);
+		if (address) return address;
+	}
+
+	return NULL;
+}
+
 CSerialModem::CSerialModem(Bitu id, CommandLine* cmd)
 	: CSerial(id, cmd),
 	  rqueue(new CFifo(MODEM_BUFFER_QUEUE_SIZE)),
@@ -187,11 +256,13 @@ void CSerialModem::SendRes(const ResTypes response) {
 	}
 }
 
-bool CSerialModem::Dial(char * host) {
+bool CSerialModem::Dial(const char * host) {
+	char buf[128];
+	strcpy(buf, host);
 
 	// Scan host for port
 	Bit16u port;
-	char * hasport = strrchr(host,':');
+	char * hasport = strrchr(buf,':');
 	if (hasport) {
 		*hasport++ = 0;
 		port = (Bit16u)atoi(hasport);
@@ -200,8 +271,8 @@ bool CSerialModem::Dial(char * host) {
 		port = MODEM_DEFAULT_PORT;
 
 	// Resolve host we're gonna dial
-	LOG_MSG("Connecting to host %s port %u", host, port);
-	clientsocket.reset(new TCPClientSocket(host, port));
+	LOG_MSG("Connecting to host %s port %u", buf, port);
+	clientsocket.reset(new TCPClientSocket(buf, port));
 	if (!clientsocket->isopen) {
 		clientsocket.reset(nullptr);
 		LOG_MSG("Failed to connect.");
@@ -379,6 +450,12 @@ void CSerialModem::DoCommand() {
 			while(helper[0] == ' ') {
 				helper[0] = 0;
 				helper--;
+			}
+
+			const char *mappedaddr = MODEM_CheckPhonebook(foundstr);
+			if (mappedaddr) {
+				Dial(mappedaddr);
+				return;
 			}
 
 			//Large enough scope, so the buffers are still valid when reaching Dail.

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -166,6 +166,7 @@ private:
 #define MREG_LF_CHAR 4
 #define MREG_BACKSPACE_CHAR 5
 #define MREG_GUARD_TIME 12
+#define MREG_DTR_DELAY 25
 
 
 class CSerialModem : public CSerial {
@@ -230,6 +231,8 @@ protected:
 	Bitu plusinc;
 	Bitu cmdpos;
 	Bitu flowcontrol;
+	Bitu dtrmode;
+	Bits dtrofftimer;
 	Bit8u tmpbuf[MODEM_BUFFER_QUEUE_SIZE];
 	Bitu listenport;
 	Bit8u reg[SREGS];

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -57,7 +57,7 @@ enum ResTypes {
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
 
-bool MODEM_ReadPhonebook(const char *filename);
+bool MODEM_ReadPhonebook(const std::string &filename);
 
 class CFifo {
 public:

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -57,6 +57,8 @@ enum ResTypes {
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
 
+bool MODEM_ReadPhonebook(const char *filename);
+
 class CFifo {
 public:
 	CFifo(Bitu _size)
@@ -181,9 +183,7 @@ public:
 
 	void EnterIdleState();
 	void EnterConnectedState();
-
-	void openConnection(void);
-	bool Dial(char * host);
+	bool Dial(const char *host);
 	void AcceptIncomingCall(void);
 	Bitu ScanNumber(char * & scan) const;
 	char GetChar(char * & scan) const;


### PR DESCRIPTION
* Fixed a bug where entering backspace while command buffer was already empty added backspace char to the buffer thus screwing it up.
* Fixed a bug where auto-answer (S0) was not working properly (was always answering on the first ring).
* Implemented DTR drop actions (&Dn). May be needed for old apps which don't set DTR or set it to garbage.
* Implemented DTR drop action delay (S25). Required for Quake otherwise it doesn't disconnect properly.
* Implemented modem phone book to remap phone numbers to network addresses. Helps games where limitations on phone number input field are too strict. Create a text file with the name specified in the config file and add phone-address pair per line. Like this:
`
5551234 towel.blinkenlights.nl
`
Phone book does not allow any characters in the phone number that are ignored or denied by a real Hayes compatible modem.