### PR TITLE
Only initialize the mapper once during startup

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -127,7 +127,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 496
+          MAX_BUGS: 492
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -27,10 +27,10 @@ enum MapKeys {
 
 typedef void (MAPPER_Handler)(bool pressed);
 void MAPPER_AddHandler(MAPPER_Handler * handler,MapKeys key,Bitu mods,char const * const eventname,char const * const buttonname);
-void MAPPER_Init(void);
+void MAPPER_BindKeys();
 void MAPPER_StartUp(Section * sec);
 void MAPPER_Run(bool pressed);
-void MAPPER_RunInternal();
+void MAPPER_DisplayUI();
 void MAPPER_LosingFocus(void);
 
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -864,6 +864,7 @@ protected:
 	Uint8 old_hat_state[16];
 	bool is_dummy;
 };
+std::list<CStickBindGroup *> stickbindgroups;
 
 class C4AxisBindGroup : public  CStickBindGroup {
 public:
@@ -2469,27 +2470,28 @@ static void CreateBindGroups(void) {
 			break;
 		case JOY_4AXIS:
 			mapper.sticks.stick[mapper.sticks.num_groups++]=new C4AxisBindGroup(joyno,joyno);
-			new CStickBindGroup(joyno+1U,joyno+1U,true);
+			stickbindgroups.push_back(new CStickBindGroup(joyno+1U,joyno+1U,true));
 			break;
 		case JOY_4AXIS_2:
 			mapper.sticks.stick[mapper.sticks.num_groups++]=new C4AxisBindGroup(joyno+1U,joyno);
-			new CStickBindGroup(joyno,joyno+1U,true);
+			stickbindgroups.push_back(new CStickBindGroup(joyno,joyno+1U,true));
 			break;
 		case JOY_FCS:
 			mapper.sticks.stick[mapper.sticks.num_groups++]=new CFCSBindGroup(joyno,joyno);
-			new CStickBindGroup(joyno+1U,joyno+1U,true);
+			stickbindgroups.push_back(new CStickBindGroup(joyno+1U,joyno+1U,true));
 			break;
 		case JOY_CH:
 			mapper.sticks.stick[mapper.sticks.num_groups++]=new CCHBindGroup(joyno,joyno);
-			new CStickBindGroup(joyno+1U,joyno+1U,true);
+			stickbindgroups.push_back(new CStickBindGroup(joyno+1U,joyno+1U,true));
 			break;
 		case JOY_2AXIS:
 		default:
 			mapper.sticks.stick[mapper.sticks.num_groups++]=new CStickBindGroup(joyno,joyno);
 			if((joyno+1U) < mapper.sticks.num) {
+				delete mapper.sticks.stick[mapper.sticks.num_groups];
 				mapper.sticks.stick[mapper.sticks.num_groups++]=new CStickBindGroup(joyno+1U,joyno+1U);
 			} else {
-				new CStickBindGroup(joyno+1U,joyno+1U,true);
+				stickbindgroups.push_back(new CStickBindGroup(joyno+1U,joyno+1U,true));
 			}
 			break;
 		}
@@ -2617,6 +2619,10 @@ static void MAPPER_Destroy(Section *sec) {
 	for (auto & ptr : keybindgroups)
 		delete ptr;
 	keybindgroups.clear();
+
+	for (auto & ptr : stickbindgroups)
+		delete ptr;
+	stickbindgroups.clear();
 
 	// Free any allocated sticks
 	for (int i = 0; i < MAXSTICKS; ++i) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2823,8 +2823,12 @@ int main(int argc, char* argv[]) {
 			}
 		}
 
-		/* Init the keyMapper */
-		if (control->cmdline->FindExist("-startmapper")) MAPPER_RunInternal();
+		// Apply key bindings only after all subsystems have added them
+		MAPPER_BindKeys();
+		// With the default key binds in place, render the mapper UI if requested
+		if (control->cmdline->FindExist("-startmapper"))
+			MAPPER_DisplayUI();
+
 		/* Start up main machine */
 		control->StartUp();
 		/* Shutdown everything */


### PR DESCRIPTION
I found that some default key bindings, like "ctrl + F11 / F12" (to adjust cycle count), all of a sudden stopped working.

It turns out the mapper needs to be initialized _after_ all of DOSBox's subsystems (cpu.cpp, in the above case) have started up and submitted their default mappings.  Only then, you can init the mapper and it will apply all the requested bindings.

(_My opinion_: this is backwards given one would assume you need to initialize something /before/ you can use it)

So it turns out initializing the mapper as the last step in _sdlmain.cpp_, just before launch is the right place to initialize it.  Unfortunately re-adding it here means we're now double-initializing the mapper (because  `AddInitFunction(&ReloadMapper)` has already kicked it off early in the process).  So to avoid this early initialization, we now use a simple static bool.  I've improved the comments explaining this critical gotcha. 

Also adds another tracking list to mop up the remaining potential leaks, which was caught by clang's runtime analyzer after this change.