### PR TITLE
Use ccache if available

### DIFF
--- a/scripts/automator/build/clang-defaults
+++ b/scripts/automator/build/clang-defaults
@@ -1,6 +1,6 @@
 # Tool overrides
-cc="clang${postfix}"
-cxx="clang++${postfix}"
+cc="${ccache}clang${postfix}"
+cxx="${ccache}clang++${postfix}"
 
 # Flag additions
 TYPES+=(debug warnmore profile)

--- a/scripts/automator/build/compiler-defaults
+++ b/scripts/automator/build/compiler-defaults
@@ -13,3 +13,19 @@ libs=("")
 # Builds for all compilers
 TYPES=(release)
 cflags_release=("${cflags[@]}" -DNDEBUG)
+
+# Use ccache if it's available
+if command -v ccache &> /dev/null; then
+	ccache="ccache "
+	# share the cache results
+	export CCACHE_UMASK="002"
+	# compress cache results
+	if [[ -z "${CCACHE_HARDLINK:-}" ]]; then
+		export CCACHE_COMPRESS=1
+	fi
+	# cache pre-compiled headers
+	export CCACHE_SLOPPINESS="time_macros"
+	cflags+=(-fpch-preprocess)
+else
+	ccache=""
+fi

--- a/scripts/automator/build/gcc-defaults
+++ b/scripts/automator/build/gcc-defaults
@@ -1,7 +1,7 @@
 # Tool overrides
 ar="gcc-ar${postfix}"
-cc="gcc${postfix}"
-cxx="g++${postfix}"
+cc="${ccache}gcc${postfix}"
+cxx="${ccache}g++${postfix}"
 ld="gcc${postfix}"
 ranlib="gcc-ranlib${postfix}"
 

--- a/scripts/automator/build/os-defaults
+++ b/scripts/automator/build/os-defaults
@@ -8,7 +8,7 @@ dependencies=(ldd "${executable}")
 function pre_build() {
 	cd ../..
 	underline "Environment"
-	echo "[$("${CC}" --version | head -1)]"
+	echo "[$(${CC} --version | head -1)]"
 	for v in "${VARIABLES[@]}"; do
 		vupper=$(upper "${v}")
 		echo "${vupper}=\"$(eval echo \$"${vupper}")\""


### PR DESCRIPTION
This makes the build script aware of ccache, and will use it if available. 

It does this by prefixing the cc and cxx variables with `ccache`, without the need for users to perform the more invasive level of installation (by symlinking gcc to cache), which package managers like 'apt' do not do for users.

It also enables a couple extra features offered by ccache such as making use of precompiled headers (and caching those), and compressing the cache results to save disk space and reduce write wear on SSDs.
