### PR TITLE
Turn on CI jobs for pull_request event

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,9 +1,12 @@
 name: Code analysis
-on: push
+on: [push, pull_request]
+
 jobs:
+
   run_linters:
     name: Script linters
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,11 +1,12 @@
 name: Linux builds
-on: push
+on: [push, pull_request]
 
 jobs:
 
   build_ubuntu:
     name: ${{ matrix.conf.name }}
     runs-on: ${{ matrix.conf.os }}
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     strategy:
       matrix:
         conf:
@@ -44,6 +45,7 @@ jobs:
   build_linux_release_dynamic:
     name: Release build (dynamic)
     runs-on: ubuntu-16.04
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     steps:
       - uses: actions/checkout@v1
       - run:  sudo apt-get update

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,11 +1,12 @@
 name: macOS builds
-on: push
+on: [push, pull_request]
 
 jobs:
 
   build_macos:
     name: ${{ matrix.conf.name }}
     runs-on: macos-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     strategy:
       matrix:
         conf:
@@ -33,6 +34,7 @@ jobs:
   build_macos_release:
     name: Release build
     runs-on: macos-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     steps:
       - uses: actions/checkout@v1
       - name: Install C++ compiler and libraries

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,11 +1,12 @@
 name: Windows builds
-on: push
+on: [push, pull_request]
 
 jobs:
 
   build_windows_msys2:
     name: ${{ matrix.conf.compiler }} ${{ matrix.conf.bits }}-bit
     runs-on: windows-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     strategy:
       # Because Clang depends on GCC, we run the Clang-32/64bit jobs
       # first to create combined caches that include both Clang and GCC.
@@ -74,6 +75,7 @@ jobs:
   build_windows_vs:
     name: MSVC 32-bit
     runs-on: windows-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     strategy:
       matrix:
         type: [Debug]
@@ -100,6 +102,7 @@ jobs:
   build_windows_vs_release:
     name: Release build
     runs-on: windows-latest
+    if: github.event_name != 'pull_request' || contains('dreamer,krcroft,ant-222', github.actor) == false
     steps:
       - uses:  actions/checkout@v1
       - name:  Install packages


### PR DESCRIPTION
This will trigger CI jobs automatically when pull-request is
created/updated. Until now we used only push event, as it was enough to
handle all automatic jobs from repository maintainers, but this does not
work for pull requests triggered by external collaborators.

We can't simply turn on new event, as it results in duplicate jobs when
PR is created by maintainer, so additional "if" filter is needed to
prevent duplicates from running. GitHub still shows "empty jobs" in some
parts of UI, but at least they don't run and fight for resources.

Unfortunately, GitHub Actions "if" functionality is fairly limited at
the moment:

- it does not work on workflows, only specific jobs
- it does not support array literals (that's why maintainer list is
  passed as a string)
- it can't access workflow env variables (that's why maintainer list is
  duplicated)
- it does not support regular expressions
- seems to have problem with using unary "!" operator and nested boolean
  expressions…
- … and official documentation is pretty misleading by suggesting it
  can do many of those things :(

that's why this "if" line looks like it does and is duplicated in every
workflow.