### PR TITLE
Use ISO date format for ccache keys

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -53,8 +53,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date +%Y%M%d)"
-          echo "::set-output name=yesterday::$(date --date=yesterday +%Y%M%d)"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
       - uses:  actions/cache@v1
         id:    cache-ccache
         with:
@@ -192,8 +192,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date +%Y%M%d)"
-          echo "::set-output name=yesterday::$(date --date=yesterday +%Y%M%d)"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
       - uses:  actions/cache@v1
         id:    cache-ccache
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,8 +44,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date +%Y%M%d)"
-          echo "::set-output name=yesterday::$(date --date=yesterday +%Y%M%d)"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
       - uses:  actions/cache@v1
         id:    cache-ccache
         with:
@@ -77,8 +77,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date +%Y%M%d)"
-          echo "::set-output name=yesterday::$(date --date=yesterday +%Y%M%d)"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
       - uses:  actions/cache@v1
         id:    cache-ccache
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,8 +33,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date +%Y%M%d)"
-          echo "::set-output name=yesterday::$(date --date=yesterday +%Y%M%d)"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
       - uses:  actions/cache@v1
         id:    cache-ccache
         with:
@@ -69,8 +69,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date +%Y%M%d)"
-          echo "::set-output name=yesterday::$(date --date=yesterday +%Y%M%d)"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
       - uses:  actions/cache@v1
         id:    cache-ccache
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,8 +65,8 @@ jobs:
         run: |
           mkdir -p "${CCACHE_DIR}"
           echo "::set-output name=dir::$CCACHE_DIR"
-          echo "::set-output name=today::$(date +%Y%M%d)"
-          echo "::set-output name=yesterday::$(date --date=yesterday +%Y%M%d)"
+          echo "::set-output name=today::$(date -I)"
+          echo "::set-output name=yesterday::$(date --date=yesterday -I)"
       - uses:  actions/cache@v1
         id:    cache-ccache
         with:


### PR DESCRIPTION
Move from the format string to simply `-I` (ISO-date), which fixes the following:

![2020-03-25_08-09](https://user-images.githubusercontent.com/1557255/77552229-81b90400-6e70-11ea-92da-e8f9ea3d14a5.png)
![2020-03-25_08-10](https://user-images.githubusercontent.com/1557255/77552233-81b90400-6e70-11ea-9c67-b88630cbd78b.png)

To ISO-date:

![2020-03-25_08-11](https://user-images.githubusercontent.com/1557255/77552395-b62cc000-6e70-11ea-847b-a8d324b4ca1e.png)