### PR TITLE
Add AUTOTYPE to DOSBox's programs

### DIFF
--- a/.github/workflows/pvs-studio.yml
+++ b/.github/workflows/pvs-studio.yml
@@ -70,7 +70,7 @@ jobs:
           path: pvs-report
       - name: Summarize report
         env:
-          MAX_BUGS: 510
+          MAX_BUGS: 505
         run: |
           echo "Full report is included in build Artifacts"
           echo

--- a/.pvs-suppress
+++ b/.pvs-suppress
@@ -2,6 +2,14 @@
     "version": 1,
     "warnings": [
         {
+            "CodeCurrent": 432032057,
+            "CodeNext": 36027430,
+            "CodePrev": 0,
+            "ErrorCode": "V801",
+            "FileName": "sdl_mapper.cpp",
+            "Message": "Decreased performance. It is better to redefine the first function argument as a reference. Consider replacing 'const .. sequence' with 'const .. &sequence'."
+        },
+        {
             "CodeCurrent": 4109900279,
             "CodeNext": 355817,
             "CodePrev": 1212132082,

--- a/README
+++ b/README
@@ -1012,6 +1012,34 @@ KEYB [keyboardlayoutcode [codepage [codepagefile]]]
          keyb
 
 
+AUTOTYPE [-list] [-w WAIT] [-p PACE] button_1 [button_2 [...]]
+
+  Types the button sequence on your behalf, as if entered manually.
+
+  It can be used to reliably skip intros, answer Q&A style questions that
+  some games ask on startup, or to script a simple demo.
+  
+  Typing is initially delayed by the WAIT time, which defaults to 2 seconds.
+  The delay between keystrokes is defined by the PACE time, which defaults
+  to 0.5 seconds.
+  
+  The comma character "," adds an extra delay similar to modern phone numbers.
+
+  -list: prints all available button names.
+
+  Examples:
+    autotype -w 3 -p 0.7 up enter , right enter
+    autotype -w 1.3 esc esc esc enter p l a y e r enter
+    autotype -p 1 e x i t enter
+
+  Sample batch file for Microprose F-19 Steath Fighter:
+
+    autotype n 1
+    f19.com
+
+  It types 'n' when asked if you have a joystick and '1' to select VGA mode.
+  The game then proceeds to load with these settings applied.
+
 
 For more information use the /? command line switch with the programs.
 

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -19,6 +19,11 @@
 #ifndef DOSBOX_MAPPER_H
 #define DOSBOX_MAPPER_H
 
+#include <string>
+#include <vector>
+#include "setup.h"
+#include "types.h"
+
 enum MapKeys {
 	MK_f1,MK_f2,MK_f3,MK_f4,MK_f5,MK_f6,MK_f7,MK_f8,MK_f9,MK_f10,MK_f11,MK_f12,
 	MK_return,MK_kpminus,MK_scrolllock,MK_printscreen,MK_pause,MK_home
@@ -32,7 +37,10 @@ void MAPPER_StartUp(Section * sec);
 void MAPPER_Run(bool pressed);
 void MAPPER_DisplayUI();
 void MAPPER_LosingFocus(void);
-
+std::vector<std::string> MAPPER_GetEventNames(const std::string &prefix);
+void MAPPER_AutoType(std::vector<std::string> &sequence,
+                     const uint32_t wait_ms,
+                     const uint32_t pacing_ms);
 
 #define MMOD1 0x1
 #define MMOD2 0x2

--- a/include/support.h
+++ b/include/support.h
@@ -23,8 +23,11 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstdio>
 #include <ctype.h>
+#include <limits>
+#include <stdexcept>
 #include <string.h>
 #include <string>
 
@@ -35,8 +38,26 @@
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
 #endif
 
-// Convert a string to double, returning true or false depending on susccess
-bool str_to_double(const std::string& input, double &value);
+/*
+ *  Converts a string to a finite number (such as float or double).
+ *  Returns the number or quiet_NaN, if it could not be parsed.
+ *  This function does not attemp to capture exceptions that may
+ *  be thrown from std::stod(...)
+ */
+template<typename T>
+T to_finite(const std::string& input) {
+	T result = std::numeric_limits<T>::quiet_NaN();
+	size_t bytes_read = 0;
+	try {
+		const double interim = std::stod(input, &bytes_read);
+		if (!input.empty() && bytes_read == input.size())
+			result = static_cast<T>(interim);
+	}
+	// handle exceptions that stod may throw
+	catch (std::invalid_argument e) {}
+	catch (std::out_of_range e) {}
+	return result;
+}
 
 // Returns the filename with the prior path stripped.
 // Works with both \ and / directory delimeters.

--- a/include/support.h
+++ b/include/support.h
@@ -35,6 +35,9 @@
 #define strncasecmp(a, b, n) _strnicmp(a, b, n)
 #endif
 
+// Convert a string to double, returning true or false depending on susccess
+bool str_to_double(const std::string& input, double &value);
+
 // Returns the filename with the prior path stripped.
 // Works with both \ and / directory delimeters.
 std::string get_basename(const std::string& filename);

--- a/include/support.h
+++ b/include/support.h
@@ -46,6 +46,7 @@
  */
 template<typename T>
 T to_finite(const std::string& input) {
+	// Defensively set NaN from the get-go
 	T result = std::numeric_limits<T>::quiet_NaN();
 	size_t bytes_read = 0;
 	try {
@@ -53,9 +54,9 @@ T to_finite(const std::string& input) {
 		if (!input.empty() && bytes_read == input.size())
 			result = static_cast<T>(interim);
 	}
-	// handle exceptions that stod may throw
-	catch (std::invalid_argument e) {}
-	catch (std::out_of_range e) {}
+	// Capture expected exceptions stod may throw
+	catch (std::invalid_argument &e) {}
+	catch (std::out_of_range &e) {}
 	return result;
 }
 

--- a/src/dos/Makefile.am
+++ b/src/dos/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 noinst_LIBRARIES = libdos.a
 EXTRA_DIST = dos_codepages.h dos_keyboard_layout_data.h
 libdos_a_SOURCES = dos.cpp dos_devices.cpp dos_execute.cpp dos_files.cpp dos_ioctl.cpp dos_memory.cpp \
-                   dos_misc.cpp dos_classes.cpp dos_programs.cpp dos_tables.cpp \
+                   dos_misc.cpp dos_classes.cpp program_autotype.cpp dos_programs.cpp dos_tables.cpp \
 		   drives.cpp drive_virtual.cpp drive_local.cpp drive_cache.cpp drive_fat.cpp \
 		   drive_iso.cpp dev_con.h dos_mscdex.cpp dos_keyboard_layout.cpp \
 		   cdrom.h cdrom.cpp cdrom_image.cpp \

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -39,6 +39,7 @@
 #include "inout.h"
 #include "dma.h"
 #include "shell.h"
+#include "program_autotype.h"
 
 #if defined(WIN32)
 #ifndef S_ISDIR
@@ -1564,7 +1565,6 @@ static void KEYB_ProgramStart(Program * * make) {
 	*make=new KEYB;
 }
 
-
 void DOS_SetupPrograms(void) {
 	/*Add Messages */
 
@@ -1771,6 +1771,7 @@ void DOS_SetupPrograms(void) {
 	MSG_Add("PROGRAM_KEYB_INVCPFILE","None or invalid codepage file for layout %s\n\n");
 
 	/*regular setup*/
+	PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
 	PROGRAMS_MakeFile("MOUNT.COM",MOUNT_ProgramStart);
 	PROGRAMS_MakeFile("MEM.COM",MEM_ProgramStart);
 	PROGRAMS_MakeFile("LOADFIX.COM",LOADFIX_ProgramStart);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -686,7 +686,7 @@ public:
 			else {
 				Bit8u rombuf[65536];
 				Bits cfound_at=-1;
-				if (cart_cmd!="") {
+				if (!cart_cmd.empty()) {
 					/* read cartridge data into buffer */
 					fseek(usefile_1,0x200L, SEEK_SET);
 					if (fread(rombuf, 1, rombytesize_1-0x200, usefile_1) < rombytesize_1 - 0x200) {
@@ -817,7 +817,7 @@ public:
 				for (auto &disk : diskSwap)
 					disk.reset();
 
-				if (cart_cmd=="") {
+				if (cart_cmd.empty()) {
 					Bit32u old_int18=mem_readd(0x60);
 					/* run cartridge setup */
 					SegSet16(ds,romseg);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -110,7 +110,7 @@ public:
 				while ( (idx = value.find("Z:\\")) != std::string::npos ||
 					(idx = value.find("z:\\")) != std::string::npos  )
 					value.replace(idx,3,tempenv);
-				line = value;
+				line = std::move(value);
 			}
 			if (!line.size()) line = tempenv;
 			first_shell->SetEnv("PATH",line.c_str());
@@ -1275,7 +1275,7 @@ public:
 				std::string homedir(temp_line);
 				Cross::ResolveHomedir(homedir);
 				if (!stat(homedir.c_str(),&test)) {
-					temp_line = homedir;
+					temp_line = std::move(homedir);
 				} else {
 					// convert dosbox filename to system filename
 					char fullname[CROSS_LEN];

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1181,7 +1181,6 @@ public:
 		}
 
 		char drive;
-		std::string label;
 		std::vector<std::string> paths;
 		std::string umount;
 		/* Check for unmounting */
@@ -1365,9 +1364,7 @@ public:
 					// Tear-down all prior drives when we hit a problem
 					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE"));
 					for (auto pImgDisk : imgDisks) {
-						if (pImgDisk) {
-							delete pImgDisk;
-						}
+						delete pImgDisk;
 					}
 					return;
 				}

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -46,8 +46,8 @@ void AUTOTYPE::PrintKeys() {
 		}
 
 		// Setup our rows and columns
-		const size_t console_width = 72;
-		const size_t columns = console_width / max_length;
+		const size_t wrap_width = 72; // confortable columns not pushed to the edge
+		const size_t columns = wrap_width / max_length;
 		const size_t rows = ceil_udivide(names.size(), columns);
 
 		// Build the string output by rows and columns

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
- * Copyright (C) 2020-2020 The dosbox-staging team
+ * Copyright (C) 2020-2020  The dosbox-staging team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -13,7 +13,7 @@
 #include "program_autotype.h"
 
 void AUTOTYPE::PrintUsage() {
-	WriteOut(
+	WriteOut_NoParsing(
 		"\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] button_1 [button_2 [...]] \n\n"
 		"Where:\n"
 		"  -list:   prints all available button names.\n"
@@ -41,7 +41,7 @@ void AUTOTYPE::PrintKeys() {
 
 		// Sanity check to avoid dividing by 0
 		if (!max_length) {
-			WriteOut("AUTOTYPE: The mapper has no key bindings\n");
+			WriteOut_NoParsing("AUTOTYPE: The mapper has no key bindings\n");
 			return;
 		}
 
@@ -51,15 +51,12 @@ void AUTOTYPE::PrintKeys() {
 		const size_t rows = ceil_udivide(names.size(), columns);
 
 		// Build the string output by rows and columns
-		std::stringstream ss;
 		auto name = names.begin();
 		for (size_t row = 0; row < rows; ++row) {
 			for (size_t i = row; i < names.size(); i += rows)
-				ss << std::setw(max_length + 1) << name[i];
-			ss << std::endl;
+				WriteOut("  %-*s", max_length, name[i].c_str());
+			WriteOut_NoParsing("\n");
 		}
-			
-		WriteOut(ss.str().c_str());
 }
 
 /*
@@ -147,7 +144,7 @@ void AUTOTYPE::Run() {
 	std::vector<std::string> sequence;
 	cmd->FillVector(sequence);
 	if (sequence.empty()) {
-		WriteOut("AUTOTYPE: button sequence is empty\n");
+		WriteOut_NoParsing("AUTOTYPE: button sequence is empty\n");
 		return;
 	}
 	MAPPER_AutoType(sequence, wait_ms, pace_ms);

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -12,51 +12,63 @@
 #include "programs.h"
 #include "program_autotype.h"
 
-void AUTOTYPE::PrintUsage() {
-	WriteOut_NoParsing(
-		"\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] button_1 [button_2 [...]] \n\n"
-		"Where:\n"
-		"  -list:   prints all available button names.\n"
-		"  -w WAIT: seconds before typing begins. Two second default; max of 30.\n"
-		"  -p PACE: seconds between each keystroke. Half-second default; max of 10.\n"
-		"\n"
-		"  The sequence is comprised of one or more space-separated buttons.\n"
-		"  Autotyping begins after WAIT seconds, and each button is entered \n"
-		"  every PACE seconds. The , character inserts an extra PACE delay.\n"
-		"\n"
-		"Some examples:\n"
-		"  \033[32;1mAUTOTYPE\033[0m -w 1 -p 0.3 up enter , right enter\n"
-		"  \033[32;1mAUTOTYPE\033[0m -p 0.2 1 3 , , enter\n"
-		"  \033[32;1mAUTOTYPE\033[0m -w 1.3 esc esc esc enter p l a y e r enter\n");
+void AUTOTYPE::PrintUsage()
+{
+	constexpr const char *msg =
+	        "\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] "
+	        "button_1 [button_2 [...]] \n\n"
+	        "Where:\n"
+	        "  -list:   prints all available button names.\n"
+	        "  -w WAIT: seconds before typing begins. Two second default; "
+	        "max of 30.\n"
+	        "  -p PACE: seconds between each keystroke. Half-second "
+	        "default; max of 10.\n"
+	        "\n"
+	        "  The sequence is comprised of one or more space-separated "
+	        "buttons.\n"
+	        "  Autotyping begins after WAIT seconds, and each button is "
+	        "entered \n"
+	        "  every PACE seconds. The , character inserts an extra PACE "
+	        "delay.\n"
+	        "\n"
+	        "Some examples:\n"
+	        "  \033[32;1mAUTOTYPE\033[0m -w 1 -p 0.3 up enter , right "
+	        "enter\n"
+	        "  \033[32;1mAUTOTYPE\033[0m -p 0.2 f1 kp_8 , , enter\n"
+	        "  \033[32;1mAUTOTYPE\033[0m -w 1.3 esc enter , p l a y e r "
+	        "enter\n";
+	WriteOut_NoParsing(msg);
 }
 
 // Prints the key-names for the mapper's currently-bound events.
-void AUTOTYPE::PrintKeys() {
-		const std::vector<std::string> names = MAPPER_GetEventNames("key_");
+void AUTOTYPE::PrintKeys()
+{
+	const std::vector<std::string> names = MAPPER_GetEventNames("key_");
 
-		// Keep track of the longest key name
-		size_t max_length = 0;
-		for (const auto &name : names)
-			max_length = (std::max)(name.length(), max_length);
+	// Keep track of the longest key name
+	size_t max_length = 0;
+	for (const auto &name : names)
+		max_length = (std::max)(name.length(), max_length);
 
-		// Sanity check to avoid dividing by 0
-		if (!max_length) {
-			WriteOut_NoParsing("AUTOTYPE: The mapper has no key bindings\n");
-			return;
-		}
+	// Sanity check to avoid dividing by 0
+	if (!max_length) {
+		WriteOut_NoParsing(
+		        "AUTOTYPE: The mapper has no key bindings\n");
+		return;
+	}
 
-		// Setup our rows and columns
-		const size_t wrap_width = 72; // confortable columns not pushed to the edge
-		const size_t columns = wrap_width / max_length;
-		const size_t rows = ceil_udivide(names.size(), columns);
+	// Setup our rows and columns
+	const size_t wrap_width = 72; // confortable columns not pushed to the edge
+	const size_t columns = wrap_width / max_length;
+	const size_t rows = ceil_udivide(names.size(), columns);
 
-		// Build the string output by rows and columns
-		auto name = names.begin();
-		for (size_t row = 0; row < rows; ++row) {
-			for (size_t i = row; i < names.size(); i += rows)
-				WriteOut("  %-*s", max_length, name[i].c_str());
-			WriteOut_NoParsing("\n");
-		}
+	// Build the string output by rows and columns
+	auto name = names.begin();
+	for (size_t row = 0; row < rows; ++row) {
+		for (size_t i = row; i < names.size(); i += rows)
+			WriteOut("  %-*s", max_length, name[i].c_str());
+		WriteOut_NoParsing("\n");
+	}
 }
 
 /*
@@ -65,49 +77,53 @@ void AUTOTYPE::PrintKeys() {
  *  - flag is the command-line flag, ie: -d or -delay
  *  - default is the default value if the flag doesn't exist
  *  - value will be populated with the default or provided value
- * 
+ *
  *  Returns:
  *    true if 'value' is set to the default or read from the arg.
  *    false if the argument was used but could not be parsed.
  */
-bool AUTOTYPE::ReadDoubleArg(const std::string &name, 
-                             const char        *flag,
-                             const double      &def_value,
-                             const double      &min_value,
-                             const double      &max_value,
-                             double            &value) {
+bool AUTOTYPE::ReadDoubleArg(const std::string &name,
+                             const char *flag,
+                             const double &def_value,
+                             const double &min_value,
+                             const double &max_value,
+                             double &value)
+{
 	bool result = false;
 	std::string str_value;
+
 	// Is the user trying to set this flag?
 	if (cmd->FindString(flag, str_value, true)) {
-
 		// Can the user's value be parsed?
 		const double user_value = to_finite<double>(str_value);
 		if (std::isfinite(user_value)) {
 			result = true;
+
 			// Clamp the user's value if needed
 			value = clamp(user_value, min_value, max_value);
 
-			// Inform them if we had to clamp their value 
-			if (std::fabs(user_value - value) > std::numeric_limits<double>::epsilon())
-				WriteOut("AUTOTYPE: bounding %s value of %.2f to %.2f\n",
+			// Inform them if we had to clamp their value
+			if (std::fabs(user_value - value) >
+			    std::numeric_limits<double>::epsilon())
+				WriteOut("AUTOTYPE: bounding %s value of %.2f "
+				         "to %.2f\n",
 				         name.c_str(), user_value, value);
-		// Otherwise inform them we couldn't parse their value
-		} else {
-			WriteOut("AUTOTYPE: %s value '%s' is not a valid floating point number\n",
+
+		} else { // Otherwise we couldn't parse their value
+			WriteOut("AUTOTYPE: %s value '%s' is not a valid "
+			         "floating point number\n",
 			         name.c_str(), str_value.c_str());
 		}
-	// Otherwise the user hasn't set this flag, so use the default
-	} else {
+	} else { // Otherwise thay haven't passed this flag
 		value = def_value;
 		result = true;
 	}
 	return result;
 }
 
-void AUTOTYPE::Run() {
-
-	//Hack To allow long commandlines
+void AUTOTYPE::Run()
+{
+	// Hack To allow long commandlines
 	ChangeToLongCmd();
 
 	// Usage
@@ -121,13 +137,13 @@ void AUTOTYPE::Run() {
 		PrintKeys();
 		return;
 	}
-	
+
 	// Get the wait delay in milliseconds
 	double wait_s;
 	constexpr double def_wait_s = 2.0;
 	constexpr double min_wait_s = 0.0;
 	constexpr double max_wait_s = 30.0;
-	if (!ReadDoubleArg("WAIT", "-w", def_wait_s, min_wait_s,max_wait_s, wait_s))
+	if (!ReadDoubleArg("WAIT", "-w", def_wait_s, min_wait_s, max_wait_s, wait_s))
 		return;
 	const auto wait_ms = static_cast<uint32_t>(wait_s * 1000);
 
@@ -150,6 +166,7 @@ void AUTOTYPE::Run() {
 	MAPPER_AutoType(sequence, wait_ms, pace_ms);
 }
 
-void AUTOTYPE_ProgramStart(Program * *make) {
-    *make = new AUTOTYPE;
+void AUTOTYPE_ProgramStart(Program **make)
+{
+	*make = new AUTOTYPE;
 }

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -83,15 +83,15 @@ bool AUTOTYPE::ReadDoubleArg(const std::string &name,
 	std::string str_value;
 	// Is the user trying to set this flag?
 	if (cmd->FindString(flag, str_value, true)) {
-		double user_value;
 
 		// Can the user's value be parsed?
-		if (str_to_double(str_value, user_value)) {
+		const double user_value = to_finite<double>(str_value);
+		if (std::isfinite(user_value)) {
 			result = true;
 			// Clamp the user's value if needed
 			value = clamp(user_value, min_value, max_value);
 
-			// If we had to clamp the users value, then inform them
+			// Inform them if we had to clamp their value 
 			if (std::fabs(user_value - value) > std::numeric_limits<double>::epsilon())
 				WriteOut("AUTOTYPE: bounding %s value of %.2f to %.2f\n",
 				         name.c_str(), user_value, value);

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -1,0 +1,158 @@
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <sstream>
+
+#include "support.h"
+#include "mapper.h"
+#include "dosbox.h"
+#include "programs.h"
+#include "program_autotype.h"
+
+void AUTOTYPE::PrintUsage() {
+	WriteOut(
+		"\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] button_1 [button_2 [...]] \n\n"
+		"Where:\n"
+		"  -list:   prints all available button names.\n"
+		"  -w WAIT: seconds before typing begins. Two second default; max of 30.\n"
+		"  -p PACE: seconds between each keystroke. Half-second default; max of 10.\n"
+		"\n"
+		"  The sequence is comprised of one or more space-separated buttons.\n"
+		"  Autotyping begins after WAIT seconds, and each button is entered \n"
+		"  every PACE seconds. The , character inserts an extra PACE delay.\n"
+		"\n"
+		"Some examples:\n"
+		"  \033[32;1mAUTOTYPE\033[0m -w 1 -p 0.3 up enter , right enter\n"
+		"  \033[32;1mAUTOTYPE\033[0m -p 0.2 1 3 , , enter\n"
+		"  \033[32;1mAUTOTYPE\033[0m -w 1.3 esc esc esc enter p l a y e r enter\n");
+}
+
+// Prints the key-names for the mapper's currently-bound events.
+void AUTOTYPE::PrintKeys() {
+		const std::vector<std::string> names = MAPPER_GetEventNames("key_");
+
+		// Keep track of the longest key name
+		size_t max_length = 0;
+		for (const auto &name : names)
+			max_length = (std::max)(name.length(), max_length);
+
+		// Sanity check to avoid dividing by 0
+		if (!max_length) {
+			WriteOut("AUTOTYPE: The mapper has no key bindings\n");
+			return;
+		}
+
+		// Setup our rows and columns
+		const size_t console_width = 72;
+		const size_t columns = console_width / max_length;
+		const size_t rows = ceil_udivide(names.size(), columns);
+
+		// Build the string output by rows and columns
+		std::stringstream ss;
+		auto name = names.begin();
+		for (size_t row = 0; row < rows; ++row) {
+			for (size_t i = row; i < names.size(); i += rows)
+				ss << std::setw(max_length + 1) << name[i];
+			ss << std::endl;
+		}
+			
+		WriteOut(ss.str().c_str());
+}
+
+/*
+ *  Reads a floating point argument from command line, where:
+ *  - name is a human description for the flag, ie: DELAY
+ *  - flag is the command-line flag, ie: -d or -delay
+ *  - default is the default value if the flag doesn't exist
+ *  - value will be populated with the default or provided value
+ * 
+ *  Returns:
+ *    true if 'value' is set to the default or read from the arg.
+ *    false if the argument was used but could not be parsed.
+ */
+bool AUTOTYPE::ReadDoubleArg(const std::string &name, 
+                             const char        *flag,
+                             const double      &def_value,
+                             const double      &min_value,
+                             const double      &max_value,
+                             double            &value) {
+	bool result = false;
+	std::string str_value;
+	// Is the user trying to set this flag?
+	if (cmd->FindString(flag, str_value, true)) {
+		double user_value;
+
+		// Can the user's value be parsed?
+		if (str_to_double(str_value, user_value)) {
+			result = true;
+			// Clamp the user's value if needed
+			value = clamp(user_value, min_value, max_value);
+
+			// If we had to clamp the users value, then inform them
+			if (std::fabs(user_value - value) > std::numeric_limits<double>::epsilon())
+				WriteOut("AUTOTYPE: bounding %s value of %.2f to %.2f\n",
+				         name.c_str(), user_value, value);
+		// Otherwise inform them we couldn't parse their value
+		} else {
+			WriteOut("AUTOTYPE: %s value '%s' is not a valid floating point number\n",
+			         name.c_str(), str_value.c_str());
+		}
+	// Otherwise the user hasn't set this flag, so use the default
+	} else {
+		value = def_value;
+		result = true;
+	}
+	return result;
+}
+
+void AUTOTYPE::Run() {
+
+	//Hack To allow long commandlines
+	ChangeToLongCmd();
+
+	// Usage
+	if (!cmd->GetCount()) {
+		PrintUsage();
+		return;
+	}
+
+	// Print available keys
+	if (cmd->FindExist("-list", false)) {
+		PrintKeys();
+		return;
+	}
+	
+	// Get the wait delay in milliseconds
+	double wait_s;
+	constexpr double def_wait_s = 2.0;
+	constexpr double min_wait_s = 0.0;
+	constexpr double max_wait_s = 30.0;
+	if (!ReadDoubleArg("WAIT", "-w", def_wait_s, min_wait_s,max_wait_s, wait_s))
+		return;
+	const auto wait_ms = static_cast<uint32_t>(wait_s * 1000);
+
+	// Get the inter-key pacing in milliseconds
+	double pace_s;
+	constexpr double def_pace_s = 0.5;
+	constexpr double min_pace_s = 0.0;
+	constexpr double max_pace_s = 10.0;
+	if (!ReadDoubleArg("PACE", "-p", def_pace_s, min_pace_s, max_pace_s, pace_s))
+		return;
+	const auto pace_ms = static_cast<uint32_t>(pace_s * 1000);
+
+	// Get the button sequence
+	std::vector<std::string> sequence;
+	cmd->FillVector(sequence);
+	if (sequence.empty()) {
+		WriteOut("AUTOTYPE: button sequence is empty\n");
+		return;
+	}
+	MAPPER_AutoType(sequence, wait_ms, pace_ms);
+}
+
+void AUTOTYPE_ProgramStart(Program * *make) {
+    *make = new AUTOTYPE;
+}

--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -1,3 +1,23 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Copyright (C) 2020-2020 The dosbox-staging team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #include <algorithm>
 #include <cmath>
 #include <iomanip>

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
- * Copyright (C) 2020-2020 The dosbox-staging team
+ * Copyright (C) 2020-2020  The dosbox-staging team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -1,0 +1,17 @@
+#include "programs.h"
+
+class AUTOTYPE : public Program {
+	public:
+		void Run();
+	private:
+		void PrintUsage();
+		void PrintKeys();
+		bool ReadDoubleArg(const std::string &name, 
+                           const char        *flag,
+                           const double      &def_value,
+                           const double      &min_value,
+                           const double      &max_value,
+                           double            &value);
+};
+
+void AUTOTYPE_ProgramStart(Program * *make);

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -18,6 +18,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#ifndef DOSBOX_PROGRAM_AUTOTYPE_H
+#define DOSBOX_PROGRAM_AUTOTYPE_H
+
+#include <string>
+
 #include "programs.h"
 
 class AUTOTYPE : public Program {
@@ -36,3 +41,5 @@ private:
 };
 
 void AUTOTYPE_ProgramStart(Program **make);
+
+#endif /* DOSBOX_PROGRAM_AUTOTYPE_H */

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -1,17 +1,18 @@
 #include "programs.h"
 
 class AUTOTYPE : public Program {
-	public:
-		void Run();
-	private:
-		void PrintUsage();
-		void PrintKeys();
-		bool ReadDoubleArg(const std::string &name, 
-                           const char        *flag,
-                           const double      &def_value,
-                           const double      &min_value,
-                           const double      &max_value,
-                           double            &value);
+public:
+	void Run();
+
+private:
+	void PrintUsage();
+	void PrintKeys();
+	bool ReadDoubleArg(const std::string &name,
+	                   const char *flag,
+	                   const double &def_value,
+	                   const double &min_value,
+	                   const double &max_value,
+	                   double &value);
 };
 
-void AUTOTYPE_ProgramStart(Program * *make);
+void AUTOTYPE_ProgramStart(Program **make);

--- a/src/dos/program_autotype.h
+++ b/src/dos/program_autotype.h
@@ -1,3 +1,23 @@
+/*
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Copyright (C) 2020-2020 The dosbox-staging team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #include "programs.h"
 
 class AUTOTYPE : public Program {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -130,7 +130,9 @@ public:
 	Bits GetValue() {
 		return current_value;
 	}
-	const char * GetName() const { return entry; }
+	const char * GetName(void) const {
+		 return entry;
+	}
 	virtual bool IsTrigger() = 0;
 	CBindList bindlist;
 protected:

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -252,17 +252,18 @@ struct SDL_Block {
 	bool wait_on_error;
 	struct {
 		struct {
-			Bit16u width, height;
-			bool fixed;
-			bool display_res;
+			Bit16u width = 0;
+			Bit16u height = 0;
+			bool fixed = false;
+			bool display_res = false;
 		} full;
 		struct {
 			uint16_t width = 0; // TODO convert to int
 			uint16_t height = 0; // TODO convert to int
 			bool use_original_size = true;
 		} window;
-		Bit8u bpp;
-		bool fullscreen;
+		Bit8u bpp = 0;
+		bool fullscreen = false;
 		bool vsync = false;
 		SCREEN_TYPES type;
 		SCREEN_TYPES want_type;

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -35,17 +35,6 @@
 #include "support.h"
 #include "video.h"
 
-bool str_to_double(const std::string& input, double &value) {
-    bool result = false;
-    size_t bytes_read = 0;
-    try {
-        value = std::stod(input, &bytes_read);
-        if (bytes_read == input.size())
-            result = true;
-    } catch (std::invalid_argument &) {}
-    return result;
-}
-
 std::string get_basename(const std::string& filename) {
 	// Guard against corner cases: '', '/', '\', 'a'
 	if (filename.length() <= 1)

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -21,18 +21,30 @@
 #include <assert.h>
 #include <cctype>
 #include <ctype.h>
+#include <cstring>
 #include <functional>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
-#include <cstring>
-  
+#include <stdexcept>
+
 #include "dosbox.h"
 #include "cross.h"
 #include "debug.h"
 #include "support.h"
 #include "video.h"
+
+bool str_to_double(const std::string& input, double &value) {
+    bool result = false;
+    size_t bytes_read = 0;
+    try {
+        value = std::stod(input, &bytes_read);
+        if (bytes_read == input.size())
+            result = true;
+    } catch (std::invalid_argument &) {}
+    return result;
+}
 
 std::string get_basename(const std::string& filename) {
 	// Guard against corner cases: '', '/', '\', 'a'

--- a/vs/dosbox.vcxproj
+++ b/vs/dosbox.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="..\src\dos\drive_local.cpp" />
     <ClCompile Include="..\src\dos\drive_overlay.cpp" />
     <ClCompile Include="..\src\dos\drive_virtual.cpp" />
+    <ClCompile Include="..\src\dos\program_autotype.cpp" />
     <ClCompile Include="..\src\fpu\fpu.cpp" />
     <ClCompile Include="..\src\gui\midi.cpp" />
     <ClCompile Include="..\src\gui\render.cpp" />
@@ -346,6 +347,7 @@
     <ClInclude Include="..\src\dos\Ntddcdrm.h" />
     <ClInclude Include="..\src\dos\Ntddscsi.h" />
     <ClInclude Include="..\src\dos\Ntddstor.h" />
+    <ClInclude Include="..\src\dos\program_autotype.h" />
     <ClInclude Include="..\src\fpu\fpu_instructions.h" />
     <ClInclude Include="..\src\fpu\fpu_instructions_x86.h" />
     <ClInclude Include="..\src\gui\midi_win32.h" />


### PR DESCRIPTION
AUTOTYPE performs scripted keyboard entry into the running DOS program.

Some immediate uses included:
- Answering hardware-setup questions for games that ask on every launch (https://github.com/dreamer/dosbox-staging/wiki/AUTOTYPE-Candidates)
- Pressing `enter` or `esc` to satisfy the NeverLock or intro banners 
- Typing pre-determined answers into startup copy-protection screens
- Conduct a simple demo.

`autotype` is typically run in a batch file, immediately before the command that starts the game. Like any program, autotype's arguments (and the key sequence) can be customized at runtime via standard batch variables.

It allows for delaying input by any number of fractional seconds, likewise the pacing between keystrokes can be customized. It uses the comma , to allow for additional delays similar to modern phone numbers.

It uses key_* names as defined by the mapper to avoid using SDL scancode, which are unstable across platforms[1].  It also uses the mapper names to use any custom key bindings the user's defined.

![2020-04-02_21-27](https://user-images.githubusercontent.com/1557255/78324457-9a3cb480-7529-11ea-8098-dbef6578d9aa.png)

[1] https://wiki.libsdl.org/SDL_GetScancodeName

"Warning: The returned name is by design not stable across platforms, e.g. the name for SDL_SCANCODE_LGUI is "Left GUI" under Linux but "Left Windows" under Microsoft Windows, and some scancodes like SDL_SCANCODE_NONUSBACKSLASH don't have any name at all. There are even scancodes that share names, e.g. SDL_SCANCODE_RETURN and SDL_SCANCODE_RETURN2 (both called "Return"). This function is therefore unsuitable for creating a stable cross-platform two-way mapping between strings and
scancodes."