### PR TITLE
Add clang-format configuration files and a helper script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,283 @@
+# This file uses configuration options available in clang-format 8.0.
+#
+# More detailed description of all options:
+# https://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# 
+# Note that version of clang-format provided by your distribution might be
+# newer and provide additional options, that won't work in 8.x.
+#
+# This style definition should only be understood as a hint
+# for writing new code. The rules are still work-in-progress and do
+# not yet exactly match the style we have in the existing code.
+
+
+# Use tabs, but only for indentation (lining up blocks of code).
+# Use space for indenting continuations (lining up long statements broken
+# into several lines.
+#
+UseTab: ForIndentation
+TabWidth: 8
+IndentWidth: 8
+ContinuationIndentWidth: 8
+
+ColumnLimit: 80
+
+# C/C++ Language specifics
+#
+Language: Cpp
+Standard: Cpp11 # in clang-format 11.x: c++11
+
+# The extra indent or outdent of class access modifiers, e.g. public:
+#
+AccessModifierOffset: -8
+
+# Align parameters on the open bracket
+#
+# someLongFunction(argument1,
+#                  argument2);
+#
+AlignAfterOpenBracket: Align
+
+# If true, aligns consecutive C/C++ preprocessor macros.
+#
+# This will align the C/C++ preprocessor macros of consecutive lines. This will
+# result in formattings like
+#
+#    #define SHORT_NAME       42
+#    #define LONGER_NAME      0x007f
+#    #define EVEN_LONGER_NAME (2)
+#    #define foo(x)           (x * x)
+#    #define bar(y, z)        (y + z)
+#
+# TODO Uncomment this line during update to clang-format 9.0
+# AlignConsecutiveMacros: true
+
+# Allow short functions defined inside a class to be put on a single line
+#
+# class Foo {
+# 	void f() { foo(); }
+# };
+#
+AllowShortFunctionsOnASingleLine: InlineOnly
+
+# Short case labels in switch can be contracted to a single line
+#
+# switch (x) {
+# case 42: return x;
+# };
+#
+AllowShortCaseLabelsOnASingleLine: true
+
+# Always place parameter declarations in a separate line:
+#
+# template <typename T>
+# T foo() …
+#
+# NOT:
+#
+# template <typename T> T foo() …
+#
+AlwaysBreakTemplateDeclarations: Yes
+
+# If true, always break before multiline string literals.
+#
+# This option means to make multiline string assignments nicely
+# lined-up and reduce unnecessary breaks in string literal, e.g.:
+#
+# // true:
+# very_long_var_name =
+#         "bbbb"
+#         "cccc";
+# shortname =
+#         "dddd"
+#         "eeee";
+#
+# // false:
+# very_long_var_name = "bbbb"
+#                      "cccc";
+# shortname = "dddd"
+#             "eeee";
+#
+# TODO Test interaction with C++11 raw string literals
+#
+# AlwaysBreakBeforeMultilineStrings: true
+
+# Attach braces to surrounding context except break before braces on function
+# definitions (also known as K&R indentation style). This is C-derived style,
+# but it works very well in C++ edge cases (C++ constructors).
+#
+# void foo()
+# {
+# 	if (true) {
+# 	} else {
+# 	}
+# }
+#
+# Our custom rules are the same as "BreakBeforeBraces: Linux", except
+# additional customization for C++ constructs.
+#
+# Classes are formatted the same way as structs.
+# Multiline C++11 lambda expressions are formatted like blocks of code.
+#
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+
+# When set to false, a function declaration's or function definition's
+# parameters (but not function calls) will either all be on the same line
+# or will have one line each.
+#
+# void f(int xxxxxxxxxxxxxxxxxxx,
+#        int yyyyyyyyyyyyyyyyyyyy,
+#        int zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz)
+# {
+# 	// …
+# }
+#
+# void g(int x, int y, int z)
+# {
+# 	// …
+# }
+#
+BinPackParameters: false
+
+# Emulates dosbox-staging constructor formatting rules; initializer list
+# is treated as continuation, therefore initializers are indented with spaces.
+#
+# Constructor()
+#         : initializer1(),
+#           initializer2()
+# {}
+#
+BreakConstructorInitializers: BeforeColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 8
+
+# Use the same indentation level as for the switch statement.
+# Switch statement body is always indented one level more than case labels;
+# this is followin K&R C-style (case labels are really just goto labels).
+#
+# switch (foo) {
+# case 1:
+# 	bar();
+# 	break;
+# default:
+# 	baz();
+# }
+#
+IndentCaseLabels: false
+
+# Don't insert a space after a cast
+#
+# x = (int32)y;    NOT    x = (int32) y;
+#
+SpaceAfterCStyleCast: false
+
+# Insert spaces before and after assignment operators
+#
+# int a = 5;    NOT    int a=5;
+# a += 42;             a+=42;
+#
+SpaceBeforeAssignmentOperators: true
+
+# Put a space before opening parentheses only after control statement keywords.
+#
+# void f()
+# {
+#         if (true) {
+#                 f();
+#         }
+# }
+#
+SpaceBeforeParens: ControlStatements
+
+# Don't insert spaces inside empty '()'
+#
+SpaceInEmptyParentheses: false
+
+# The number of spaces before trailing line comments (// - comments).
+# This does not affect trailing block comments (/* - comments).
+#
+SpacesBeforeTrailingComments: 1
+
+# Don't insert spaces in casts
+#
+# x = (int32) y;  NOT   x = ( int32 ) y;
+#
+SpacesInCStyleCastParentheses: false
+
+# Don't insert spaces after '(' or before ')'
+#
+# f(arg);         NOT    f( arg );
+#
+SpacesInParentheses: false
+
+# Don't insert spaces after '[' or before ']'
+#
+# int a[5];       NOT    int a[ 5 ];
+#
+SpacesInSquareBrackets: false
+
+# Insert a space after '{' and before '}' in struct initializers
+#
+# This is native C++11 style, but it looks very weird.
+# TODO Investigate if it has any tangible benefits.
+#
+# Cpp11BracedListStyle: false
+
+# A list of macros that should be interpreted as foreach loops instead of as
+# function calls.
+#
+# TODO Currently unused, but left as an example in case we'll need such macros.
+#
+# ForEachMacros:
+#   - 'for_each_abbrev'
+#   - 'list_for_each_dir'
+
+# The maximum number of consecutive empty lines to keep.
+#
+MaxEmptyLinesToKeep: 1
+
+# No empty line at the start of a block.
+#
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# Line breaking penalties
+#
+# This decides what order things should be done if a line is too long
+#
+# clang-format iterates through various versions the long line can be formatted 
+# and selects the one with smallest penalty score.
+#
+# Small ExcessCharacter penalty prevents breaking line is longer than
+# column limit by only few characters.
+#
+PenaltyBreakAssignment: 100
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 110
+PenaltyExcessCharacter: 3
+PenaltyReturnTypeOnItsOwnLine: 200
+
+# Don't sort "#include" declarations.
+#
+# clang-format has very rich customization options for grouping and sorting
+# "include" directives, but there are still edge cases, so we still need to
+# rely on developers doing this manually.
+#
+# See https://github.com/dreamer/dosbox-staging/issues/196 for details.
+#
+SortIncludes: false

--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -1,0 +1,173 @@
+#!/bin/bash -e
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2020  Patryk Obara <patryk.obara@gmail.com>
+
+readonly SCRIPT=$(basename "$0")
+
+print_usage () {
+	echo "usage: $SCRIPT [-V|--verify|-d|--diff|-a|--amend] [<commit>]"
+	echo
+	echo "Fixes formatting of C and C++ files, that were touched by "
+	echo "commits since <commit>.  Changes are limited only to files and "
+	echo "lines that were modified. If a file was moved/renamed and only "
+	echo "slightly modified (less than 10%), then it's not reformatted."
+	echo
+	echo "If no <commit> is passed, then default is HEAD~1 - which means "
+	echo "that only lines touched by the latest commit will be fixed, "
+	echo "therefore usage of this script is simply:"
+	echo
+	echo "  $ ./$SCRIPT"
+	echo
+	echo "Files are formatted only if .clang-format file is located in one "
+	echo "of the parent directories of the source file."
+	echo
+	echo "Optional parameter --diff (or --verify) displays diff of what was "
+	echo "formatted and exits with a failure status if diff is not empty"
+	echo "(this option is intended for CI usage):"
+	echo
+	echo "  $ ./$SCRIPT --diff"
+	echo
+	echo "Optional parameter --amend will amend the latest commit for you."
+	echo
+	echo "  $ ./$SCRIPT --amend"
+	echo
+	echo "If you want to format a whole file instead then use clang-format "
+	echo "directly, e.g.:"
+	echo
+	echo "  $ clang-format path/to/file.cpp"
+}
+
+main () {
+	case $1 in
+		-h|-help|--help) print_usage ;;
+		-d|--diff)       handle_dependencies ; shift ; format "$@" ; assert_empty_diff ;;
+		-V|--verify)     handle_dependencies ; shift ; format "$@" ; assert_empty_diff ;;
+		-a|--amend)      handle_dependencies ; shift ; format "$@" ; amend ;;
+		*)               handle_dependencies ; format "$@" ; show_tip ;;
+	esac
+}
+
+handle_dependencies () {
+	assert_min_version git 1007010 "Use git in version 1.7.10 or newer."
+	assert_min_version clang-format 8000000 "Use clang-format in version 8.0.0 or newer."
+}
+
+assert_min_version () {
+	if ! check_min_version "$1" "$2" ; then
+		echo "$3"
+		exit 1
+	fi
+}
+
+check_min_version () {
+	$1 --version
+	$1 --version \
+		| sed -e "s|.* \([0-9]*\)\.\([0-9]*\)\.\([0-9]*\).*|\1 \2 \3|" \
+		| test_version "$2"
+	return "${PIPESTATUS[2]}"
+}
+
+test_version () {
+	read -r major minor patch
+	local -r version=$((major * 1000000 + minor * 1000 + patch))
+	test "$1" -le "$version"
+}
+
+format () {
+	local -r since_ref=${1:-HEAD~1}
+	pushd "$(git rev-parse --show-toplevel)" > /dev/null
+	echo "Using paths relative to: $(pwd)"
+	find_cpp_files "$since_ref" | run_clang_format
+	popd > /dev/null
+}
+
+assert_empty_diff () {
+	if [ -n "$(git_diff HEAD)" ] ; then
+		git_diff HEAD
+		echo
+		echo "clang-format formatted some code for you."
+		echo
+		echo "Run 'git commit -a --amend' to save the result."
+		exit 1
+	fi
+}
+
+show_tip () {
+	if [ -n "$(git_diff HEAD)" ] ; then
+		echo
+		echo "clang-format formatted some code for you."
+		echo
+		echo "Run 'git diff' to see what changed."
+		echo "Run 'git commit -a --amend' to save the result."
+		exit 0
+	fi
+}
+
+amend () {
+	git commit -a --amend
+}
+
+git_diff () {
+	git diff --no-ext-diff "$@"
+}
+
+find_cpp_files () {
+	set +e
+	list_changed_files "$1" | grep -E "\.(h|hpp|c|cpp|cc)$"
+	set -e
+}
+
+list_changed_files () {
+	git_diff \
+		--no-renames \
+		--diff-filter=AMrcd \
+		--find-renames=90% \
+		--find-copies=90% \
+		--name-only \
+		"$1"
+}
+
+run_clang_format () {
+	while read -r src_file ; do
+		prepare_clang_params "$src_file" \
+			| xargs --no-run-if-empty --verbose clang-format -i
+	done
+}
+
+git_diff_to_clang_line_range () {
+	local -r file=$1
+	git_diff --ignore-space-at-eol -U0 HEAD~1 "$file" \
+		| grep -E "^@@" \
+		| filter_line_range \
+		| to_clang_line_range
+}
+
+prepare_clang_params () {
+	local -r file=$1
+	local -r range=$(git_diff_to_clang_line_range "$file")
+	# print file name only when there are any lines detected, otherwise
+	# clang-format would process the whole file
+	if [ -n "$range" ]; then
+		echo "$range \"$file\""
+	fi
+}
+
+# expects line in diff format: "@@ -<line range> +<line range> @@ <context>"
+# where <line range> is either <line_number> or <line_number>,<offset>
+#
+filter_line_range () {
+	sed -e 's|@@ .* +\([0-9]\+\),\?\([0-9]\+\)\? @@.*|\1 \2|'
+}
+
+to_clang_line_range () {
+	while read -r from_line offset ; do
+		local to_line=$(( from_line + offset ))
+		if [[ $from_line -gt 0 && $from_line -le $to_line ]] ; then
+			echo "-lines=$from_line:$to_line"
+		fi
+	done
+}
+
+main "$@"

--- a/src/libs/.clang-format
+++ b/src/libs/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
Decided to move clang-format part out of contributing guidelines draft, as I consider this part fairly done. It's already very helpful, especially when configured with developer's editor - instructions for popular editors (Vim, Emacs, Visual Studio, some others) are here: https://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormat.html

Two tiny differences from our convention are about formatting of constructor initializer list:
- when initializer list is short enough to fit after constructor declaration, formatter will use one line
- we used tab (+2 spaces for second and later line) for indentation of initializers, clang-format uses 8 spaces (+2 for second and later line). It looks the same, except formatting will be now consistent with our formatting of parameters in function declarations and function calls.

One bigger difference, that is not available in 8.0 (but will be available after upgrade to 9.0) is formatting of macro definitions - eventually, we'll want `AlignConsecutiveMacros: true` ([description](https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html)).

Other details of what and why are in git commit messages, so I'll just paste them here:
```
commit cf6dbc3bc33cea2747818200276de1a4e68585bb
Author: Patryk Obara <dreamer.tan@gmail.com>
Date:   Mon Mar 30 06:47:11 2020 +0200

    Implement script for re-formatting recent commits
    
    This script is intended to be used in two situations:
    
    - When user can't configure clang-format in code editor or IDE
    - Potentially to be used in CI in the future
    
    Normal usecase is to run this script after commit, then review and
    add formatted code, and amend the commit, e.g.:
    
      git commit -m "Edit some C++ code"
      ./scripts/format-commit.sh
      git add -p  # select formatting changes you want to use
      git commit --amend
    
    Run:
    
      ./scripts/format-commit.sh --help
    
    to learn about other options.

commit 6fff29854351a5f71b4817abe242892c818f85c0
Author: Patryk Obara <dreamer.tan@gmail.com>
Date:   Sun Mar 29 05:55:18 2020 +0200

    Add clang-format rules
    
    Rules are defined for all C/C++ code, except src/libs.
    
    These rules are designed to emulate kernel coding convention with some
    adaptations for C++11. Configuration file uses options available in
    clang-format 8.0 (the newest version in 10.0) to provide compatibility
    with older environments and operating systems.  Some options are
    commented out and marked with TODOs - those need to be investigated and
    enabled/disabled during upgrade to clang-format 9.0.
    
    DOSBox codebase is a mix of various styles with only few consistent
    rules seen throughout the codebase, these clang-format rules preserve
    some of existing conventions and conciously break with others.
    
    Some unwritten upstream rules, that are now encoded in clang-format:
    
    - Using tab for indentation.
    - K&R-like indentation for control statements.
    - Indentation rules for structs, classes, and non-anonymous enums.
    - Case labels in switch statements are aligned the same way goto
      statements would be (also K&R rule).
    
    Some formatting aspects that were not followed consistently throughout
    old DOSBox code, but are now encoded in clang-format:
    
    - Space placing in control statements and function calls (makes the code
      much more readable).
    - Control statements (if-else, while) must be broken into multiple lines
      (makes the code more readable, helps with debugging, reading compiler
      logs and static analysis reports).
    
    Some unwritten upstream rules, that are now changed by these rules:
    
    - Placing opening function bracket in the same line as function
      declaration (not in line with K&R).  This rule makes it hard to make
      constructor formatting consistent - old code dealt with it by not
      formatting initializer lists at all.  Unformatted initializer list can
      result in lines hundreds of lines long and make it hard to add/remove
      class fields while assuring correct initialization order.
      In new clang-format rules K&R indentation is followed, allowing
      initalizer lists to be formatted one initializer per line (which makes
      it much easier to read and edit.
```