### PR TITLE
Update clang-format rules to 9.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # This file uses configuration options available in clang-format 8.0.
 #
 # More detailed description of all options:
-# https://releases.llvm.org/8.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 # 
 # Note that version of clang-format provided by your distribution might be
 # newer and provide additional options, that won't work in 8.x.
@@ -43,14 +43,13 @@ AlignAfterOpenBracket: Align
 # This will align the C/C++ preprocessor macros of consecutive lines. This will
 # result in formattings like
 #
-#    #define SHORT_NAME       42
-#    #define LONGER_NAME      0x007f
-#    #define EVEN_LONGER_NAME (2)
-#    #define foo(x)           (x * x)
-#    #define bar(y, z)        (y + z)
+# #define SHORT_NAME       42
+# #define LONGER_NAME      0x007f
+# #define EVEN_LONGER_NAME (2)
+# #define foo(x)           (x * x)
+# #define bar(y, z)        (y + z)
 #
-# TODO Uncomment this line during update to clang-format 9.0
-# AlignConsecutiveMacros: true
+AlignConsecutiveMacros: true
 
 # Allow short functions defined inside a class to be put on a single line
 #
@@ -161,6 +160,7 @@ BinPackParameters: false
 #           initializer2()
 # {}
 #
+AllowAllConstructorInitializersOnNextLine: false
 BreakConstructorInitializers: BeforeColon
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8

--- a/scripts/format-commit.sh
+++ b/scripts/format-commit.sh
@@ -51,7 +51,7 @@ main () {
 
 handle_dependencies () {
 	assert_min_version git 1007010 "Use git in version 1.7.10 or newer."
-	assert_min_version clang-format 8000000 "Use clang-format in version 8.0.0 or newer."
+	assert_min_version clang-format 9000000 "Use clang-format in version 9.0.0 or newer."
 }
 
 assert_min_version () {


### PR DESCRIPTION
```
Set AllowAllConstructorInitializersOnNextLine to false. This prevents
formatting problem when initializer list is long enough to be wrapped
once, but all initializers fitted into the next line.

Turn on AlignConsecutiveMacros option.
```

It's somewhat inconvenient to me, as I'm still stuck on 8.0 on one of my computers for another month, but I'll deal with it.  Formatting improvements warrant merging this in, and only few OSes miss clang-format 9 at this point.