### PR TITLE
Cleanup sdlmain

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -73,7 +73,7 @@ public:
 	void Init();
 	void ShutDown();
 	void StartUp();
-	bool PrintConfig(char const * const configfilename) const;
+	bool PrintConfig(const std::string &filename) const;
 	bool ParseConfigFile(char const * const configfilename);
 	void ParseEnv(char ** envp);
 	bool SecureMode() const { return secure_mode; }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2584,8 +2584,8 @@ static void launcheditor() {
 	Cross::GetPlatformConfigName(file);
 	path += file;
 	FILE* f = fopen(path.c_str(),"r");
-	if(!f && !control->PrintConfig(path.c_str())) {
-		printf("tried creating %s. but failed.\n",path.c_str());
+	if (!f && !control->PrintConfig(path)) {
+		printf("tried creating %s. but failed.\n", path.c_str());
 		exit(1);
 	}
 	if(f) fclose(f);
@@ -2674,8 +2674,8 @@ static void printconfiglocation() {
 	path += file;
 
 	FILE* f = fopen(path.c_str(),"r");
-	if(!f && !control->PrintConfig(path.c_str())) {
-		printf("tried creating %s. but failed",path.c_str());
+	if (!f && !control->PrintConfig(path)) {
+		printf("tried creating %s. but failed", path.c_str());
 		exit(1);
 	}
 	if(f) fclose(f);
@@ -2828,7 +2828,7 @@ int main(int argc, char* argv[]) {
 			Cross::CreatePlatformConfigDir(config_path);
 			Cross::GetPlatformConfigName(config_file);
 			config_combined = config_path + config_file;
-			if (control->PrintConfig(config_combined.c_str())) {
+			if (control->PrintConfig(config_combined)) {
 				LOG_MSG("CONFIG: Generating default configuration.\n"
 					"CONFIG: Writing it to %s",
 					config_combined.c_str());
@@ -2863,7 +2863,7 @@ int main(int argc, char* argv[]) {
 		Cross::CreatePlatformConfigDir(config_path);
 		Cross::GetPlatformConfigName(config_file);
 		config_combined = config_path + config_file;
-		if (control->PrintConfig(config_combined.c_str())) {
+		if (control->PrintConfig(config_combined)) {
 			LOG_MSG("CONFIG: Generating default configuration.\n"
 				"CONFIG: Writing it to %s",
 				config_combined.c_str());

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1031,10 +1031,10 @@ dosurface:
 			case 32: retFlags = GFX_CAN_32; break;
 		}
 		retFlags |= GFX_SCALING;
-		SDL_RendererInfo rendererInfo;
-		SDL_GetRendererInfo(sdl.renderer, &rendererInfo);
-		LOG_MSG("Using driver \"%s\" for texture renderer", rendererInfo.name);
-		if (rendererInfo.flags & SDL_RENDERER_ACCELERATED)
+		SDL_RendererInfo rinfo;
+		SDL_GetRendererInfo(sdl.renderer, &rinfo);
+		LOG_MSG("SDL: Using driver \"%s\" for texture renderer", rinfo.name);
+		if (rinfo.flags & SDL_RENDERER_ACCELERATED)
 			retFlags |= GFX_HARDWARE;
 		break;
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -394,20 +394,19 @@ extern bool CPU_CycleAutoAdjust;
 bool startup_state_numlock=false;
 bool startup_state_capslock=false;
 
-void GFX_SetTitle(Bit32s cycles,int frameskip,bool paused){
-	char title[200] = { 0 };
+void GFX_SetTitle(Bit32s cycles, int /*frameskip*/, bool paused)
+{
+	char title[200] = {0};
 	static Bit32s internal_cycles = 0;
-	static int internal_frameskip = 0;
-	if (cycles != -1) internal_cycles = cycles;
-	if (frameskip != -1) internal_frameskip = frameskip;
-	if(CPU_CycleAutoAdjust) {
-		sprintf(title,"DOSBox %s, CPU speed: max %3d%% cycles, Frameskip %2d, Program: %8s",VERSION,internal_cycles,internal_frameskip,RunningProgram);
-	} else {
-		sprintf(title,"DOSBox %s, CPU speed: %8d cycles, Frameskip %2d, Program: %8s",VERSION,internal_cycles,internal_frameskip,RunningProgram);
-	}
+	if (cycles != -1)
+		internal_cycles = cycles;
 
-	if (paused) strcat(title," PAUSED");
-	SDL_SetWindowTitle(sdl.window,title);
+	const char *msg = CPU_CycleAutoAdjust
+	                          ? "%8s, max %d%%, dosbox-staging%s"
+	                          : "%8s, %d cycles/ms, dosbox-staging%s";
+	snprintf(title, sizeof(title), msg, RunningProgram, internal_cycles,
+	         paused ? " (PAUSED)" : "");
+	SDL_SetWindowTitle(sdl.window, title);
 }
 
 static unsigned char logo[32*32*4]= {
@@ -2032,7 +2031,7 @@ static void GUI_StartUp(Section * sec) {
 
 	// FIXME the code updated sdl.desktop.bpp in here (has effect in setting up scalers)
 
-	SDL_SetWindowTitle(sdl.window, "DOSBox");
+	SDL_SetWindowTitle(sdl.window, "dosbox-staging");
 	SetIcon();
 
 	const bool tiny_fullresolution = splash_image.width > sdl.desktop.full.width ||

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -821,7 +821,6 @@ static void GetAvailableArea(int &width, int &height)
 static bool InitPp(Bit16u avw, Bit16u avh)
 {
 	bool   ok;
-	double newpar;
 	/* TODO: consider reading apsect importance from the .ini-file */
 	ok = pp_getscale(
 		sdl.draw.width, sdl.draw.height,
@@ -832,13 +831,12 @@ static bool InitPp(Bit16u avw, Bit16u avh)
 		&sdl.ppscale_y
 	) == 0;
 	if (ok) {
-		newpar = ( double )sdl.ppscale_y / sdl.ppscale_x;
-		LOG_MSG( "Pixel-perfect scaling:\n"
-			"%ix%i (%#4.3g) --[%ix%i]--> %ix%i (%#4.3g)",
-			sdl.draw.width, sdl.draw.height, sdl.draw.pixel_aspect,
-			sdl.ppscale_x,  sdl.ppscale_y,
-			sdl.ppscale_x * sdl.draw.width, sdl.ppscale_y * sdl.draw.height,
-			newpar);
+		const double newpar = (double)sdl.ppscale_y / sdl.ppscale_x;
+		LOG_MSG("MAIN: Pixel-perfect scaling (%dx%d): "
+		        "%dx%d (PAR %#.3g) -> %dx%d (PAR %#.3g)",
+		        sdl.ppscale_x, sdl.ppscale_y, sdl.draw.width, sdl.draw.height,
+		        sdl.draw.pixel_aspect, sdl.ppscale_x * sdl.draw.width,
+		        sdl.ppscale_y * sdl.draw.height, newpar);
 	}
 	return ok;
 }
@@ -865,10 +863,13 @@ Bitu GFX_SetSize(Bitu width, Bitu height, Bitu flags,
 
 	avw = width;
 	avh = height;
-	GetAvailableArea(avw, avh);	
-	LOG_MSG("Input image: %ix%i DW: %i DH: %i PAR: %5.3g",
-	        (int)width, (int)height, sdl.double_h, sdl.double_w, pixel_aspect );
-	LOG_MSG("Available area: %ix%i", avw, avh);
+	GetAvailableArea(avw, avh);
+	LOG_MSG("MAIN: Emulated resolution: %dx%d,%s%s pixel aspect ratio: %#.2f",
+	        (int)width, (int)height,
+	        sdl.double_w ? " double-width," : "",
+		sdl.double_h ? " double-height," : "",
+		pixel_aspect);
+	LOG_MSG("MAIN: Emulator resolution: %dx%d", avw, avh);
 	if (sdl.scaling_mode == SmPerfect) {
 		if (!InitPp(avw, avh)) {
 			LOG_MSG("Failed to initialise pixel-perfect mode, reverting to surface.");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -602,9 +602,6 @@ static SDL_Window * GFX_SetSDLWindowMode(Bit16u width, Bit16u height, bool fulls
 	 * some window managers. For now, the following may work up to some
 	 * level. On X11, SDL_VIDEO_X11_LEGACY_FULLSCREEN=1 can also help,
 	 * although it has its own issues.
-	 * Suggestion: Use the desktop res if possible, with output=surface
-	 * if one is not interested in scaling.
-	 * On Android, desktop res is the only way.
 	 */
 	if (fullscreen) {
 		SDL_DisplayMode displayMode;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2780,12 +2780,6 @@ int main(int argc, char* argv[]) {
 	LOG_MSG("Copyright 2002-2020 DOSBox Team, published under GNU GPL.");
 	LOG_MSG("---");
 
-	/* Init SDL */
-	/* Or debian/ubuntu with older libsdl version as they have done this themselves, but then differently.
-	 * with this variable they will work correctly. I've only tested the 1.2.14 behaviour against the windows version
-	 * of libsdl
-	 */
-	putenv(const_cast<char*>("SDL_DISABLE_LOCK_KEYS=1"));
 	if (SDL_Init_Wrapper() < 0)
 		E_Exit("Can't init SDL %s", SDL_GetError());
 	sdl.inited = true;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -303,7 +303,7 @@ struct SDL_Block {
 	SDL_Window *window = nullptr;
 	SDL_Renderer *renderer = nullptr;
 	std::string render_driver = "";
-	int displayNumber;
+	int display_number = 0;
 	struct {
 		SDL_Surface *input_surface = nullptr;
 		SDL_Texture *texture = nullptr;
@@ -565,7 +565,7 @@ static SDL_Window * GFX_SetSDLWindowMode(Bit16u width, Bit16u height, bool fulls
 
 		// Using undefined position will take care of placing and restoring the
 		// window by WM.
-		const int sdl_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.displayNumber);
+		const int sdl_pos = SDL_WINDOWPOS_UNDEFINED_DISPLAY(sdl.display_number);
 		sdl.window = SDL_CreateWindow("", sdl_pos, sdl_pos, width, height, flags);
 
 		if (!sdl.window) {
@@ -1586,7 +1586,7 @@ void GFX_Start() {
 
 void GFX_ObtainDisplayDimensions() {
 	SDL_Rect displayDimensions;
-	SDL_GetDisplayBounds(sdl.displayNumber, &displayDimensions);
+	SDL_GetDisplayBounds(sdl.display_number, &displayDimensions);
 	sdl.desktop.full.width = displayDimensions.w;
 	sdl.desktop.full.height = displayDimensions.h;
 }
@@ -1890,11 +1890,14 @@ static void GUI_StartUp(Section * sec) {
 	//      correctly and is causing serious bugs.
 	// sdl.desktop.vsync = section->Get_bool("vsync");
 
-	sdl.displayNumber = section->Get_int("display");
-	if ((sdl.displayNumber < 0) || (sdl.displayNumber >= SDL_GetNumVideoDisplays())) {
-		sdl.displayNumber = 0;
-		LOG_MSG("SDL:Display number out of bounds, switching back to 0");
+	const int display = section->Get_int("display");
+	if ((display >= 0) && (display < SDL_GetNumVideoDisplays())) {
+		sdl.display_number = display;
+	} else {
+		LOG_MSG("SDL: Display number out of bounds, using display 0");
+		sdl.display_number = 0;
 	}
+
 	sdl.desktop.full.display_res = sdl.desktop.full.fixed && (!sdl.desktop.full.width || !sdl.desktop.full.height);
 	if (sdl.desktop.full.display_res) {
 		GFX_ObtainDisplayDimensions();
@@ -2387,16 +2390,22 @@ void Config_Add_SDL() {
 	sdl_sec->AddInitFunction(&MAPPER_StartUp);
 	Prop_bool* Pbool;
 	Prop_string* Pstring;
-	Prop_int* Pint;
+	Prop_int *Pint; // use pint for new properties
+	Prop_int *pint;
 	Prop_multival* Pmulti;
 	Section_prop* Psection;
 
 	constexpr auto always = Property::Changeable::Always;
 	constexpr auto deprecated = Property::Changeable::Deprecated;
+	constexpr auto on_start = Property::Changeable::OnlyAtStart;
 
 	Pbool = sdl_sec->Add_bool("fullscreen", always, false);
 	Pbool->Set_help("Start DOSBox directly in fullscreen.\n"
 	                "Press Alt-Enter to switch back to window.");
+
+	pint = sdl_sec->Add_int("display", on_start, 0);
+	pint->Set_help("Number of display to use; values depend on OS and user "
+	               "settings.");
 
 	Pbool = sdl_sec->Add_bool("vsync", deprecated, false);
 	Pbool->Set_help("Vertical sync setting not implemented (setting ignored)");
@@ -2812,9 +2821,11 @@ int main(int argc, char* argv[]) {
 			Cross::CreatePlatformConfigDir(config_path);
 			Cross::GetPlatformConfigName(config_file);
 			config_combined = config_path + config_file;
-			if(control->PrintConfig(config_combined.c_str())) {
-				LOG_MSG("CONFIG: Generating default configuration.\nWriting it to %s",config_combined.c_str());
-				//Load them as well. Makes relative paths much easier
+			if (control->PrintConfig(config_combined.c_str())) {
+				LOG_MSG("CONFIG: Generating default configuration.\n"
+					"CONFIG: Writing it to %s",
+					config_combined.c_str());
+				// Load them as well. Makes relative paths much easier
 				control->ParseConfigFile(config_combined.c_str());
 			}
 		}
@@ -2845,9 +2856,11 @@ int main(int argc, char* argv[]) {
 		Cross::CreatePlatformConfigDir(config_path);
 		Cross::GetPlatformConfigName(config_file);
 		config_combined = config_path + config_file;
-		if(control->PrintConfig(config_combined.c_str())) {
-			LOG_MSG("CONFIG: Generating default configuration.\nWriting it to %s",config_combined.c_str());
-			//Load them as well. Makes relative paths much easier
+		if (control->PrintConfig(config_combined.c_str())) {
+			LOG_MSG("CONFIG: Generating default configuration.\n"
+				"CONFIG: Writing it to %s",
+				config_combined.c_str());
+			// Load them as well. Makes relative paths much easier
 			control->ParseConfigFile(config_combined.c_str());
 		} else {
 			LOG_MSG("CONFIG: Using default settings. Create a configfile to change them");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -279,8 +279,7 @@ struct SDL_Block {
 		bool bilinear;
 		bool packed_pixel;
 		bool paletted_texture;
-		bool pixel_buffer_object;
-
+		bool pixel_buffer_object = false;
 		bool use_shader;
 		GLuint program_object;
 		const char *shader_src;
@@ -1990,6 +1989,9 @@ static void GUI_StartUp(Section * sec) {
 			glBufferDataARB = (PFNGLBUFFERDATAARBPROC)SDL_GL_GetProcAddress("glBufferDataARB");
 			glMapBufferARB = (PFNGLMAPBUFFERARBPROC)SDL_GL_GetProcAddress("glMapBufferARB");
 			glUnmapBufferARB = (PFNGLUNMAPBUFFERARBPROC)SDL_GL_GetProcAddress("glUnmapBufferARB");
+
+			// FIXME: according to Khronos documentation, the correct way to
+			//        query GL_EXTENSIONS is using glGetStringi from OpenGL 3.0
 			const char * gl_ext = (const char *)glGetString (GL_EXTENSIONS);
 			if(gl_ext && *gl_ext){
 				sdl.opengl.packed_pixel=(strstr(gl_ext,"EXT_packed_pixels") != NULL);
@@ -2005,7 +2007,9 @@ static void GUI_StartUp(Section * sec) {
 #ifdef DB_DISABLE_DBO
 			sdl.opengl.pixel_buffer_object = false;
 #endif
-			LOG_MSG("OpenGL extension: pixel_bufer_object %d",sdl.opengl.pixel_buffer_object);
+			LOG_MSG("OPENGL: Pixel buffer object extension: %s",
+			        sdl.opengl.pixel_buffer_object ? "available"
+			                                       : "missing");
 		}
 	} /* OPENGL is requested end */
 #endif	//OPENGL

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -333,6 +333,19 @@ static SDL_Block sdl;
 
 static void CleanupSDLResources();
 
+static constexpr char version_msg[] = R"(dosbox (dosbox-staging), version %s
+Copyright (C) 2020 The dosbox-staging team.
+License GPLv2+: GNU GPL version 2 or later <https://www.gnu.org/licenses/gpl-2.0.html>
+
+This is free software, and you are welcome to change and redistribute it
+under certain conditions; please read the COPYING file thoroughly before
+doing so.  There is NO WARRANTY, to the extent permitted by law.
+
+This program (dosbox-staging) is modified version of DOSBox.
+Copyright (C) 2020 The DOSBox Team, published under GNU GPLv2+
+Read AUTHORS file for more details.
+)";
+
 #if C_OPENGL
 static char const shader_src_default[] =
 	"varying vec2 v_texCoord;\n"
@@ -2760,16 +2773,15 @@ int main(int argc, char* argv[]) {
 			SetConsoleTitle("DOSBox Status Window");
 		}
 #endif  //defined(WIN32) && !(C_DEBUG)
+
 		if (control->cmdline->FindExist("-version") ||
-		    control->cmdline->FindExist("--version") ) {
-			printf("\nDOSBox version %s, copyright 2002-2020 DOSBox Team.\n\n",VERSION);
-			printf("DOSBox is written by the DOSBox Team (See AUTHORS file))\n");
-			printf("DOSBox comes with ABSOLUTELY NO WARRANTY.  This is free software,\n");
-			printf("and you are welcome to redistribute it under certain conditions;\n");
-			printf("please read the COPYING file thoroughly before doing so.\n\n");
+		    control->cmdline->FindExist("--version")) {
+			printf(version_msg, VERSION);
 			return 0;
 		}
-		if(control->cmdline->FindExist("-printconf")) printconfiglocation();
+
+		if (control->cmdline->FindExist("-printconf"))
+			printconfiglocation();
 
 #if C_DEBUG
 		DEBUG_SetupConsole();
@@ -2779,10 +2791,7 @@ int main(int argc, char* argv[]) {
 	SetConsoleCtrlHandler((PHANDLER_ROUTINE) ConsoleEventHandler,TRUE);
 #endif
 
-
-	/* Display Welcometext in the console */
-	LOG_MSG("DOSBox version %s",VERSION);
-	LOG_MSG("Copyright 2002-2020 DOSBox Team, published under GNU GPL.");
+	LOG_MSG("dosbox-staging version %s", VERSION);
 	LOG_MSG("---");
 
 	if (SDL_Init_Wrapper() < 0)

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -297,8 +297,8 @@ private:
 			name = config_path + name;
 		}
 		WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_WHICH"),name.c_str());
-		if (!control->PrintConfig(name.c_str())) {
-			WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_ERROR"),name.c_str());
+		if (!control->PrintConfig(name)) {
+			WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_ERROR"), name.c_str());
 		}
 		return;
 	}

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -719,10 +719,11 @@ string Section_line::GetPropValue(string const& /* _property*/) const {
 	return NO_SUCH_PROPERTY;
 }
 
-bool Config::PrintConfig(char const * const configfilename) const {
+bool Config::PrintConfig(const std::string &filename) const
+{
 	char temp[50];
 	char helpline[256];
-	FILE* outfile = fopen(configfilename,"w+t");
+	FILE *outfile = fopen(filename.c_str(), "w+t");
 	if (outfile == NULL) return false;
 
 	/* Print start of configfile and add a return to improve readibility. */
@@ -800,7 +801,6 @@ bool Config::PrintConfig(char const * const configfilename) const {
 	fclose(outfile);
 	return true;
 }
-
 
 Section_prop* Config::AddSection_prop(char const * const _name,void (*_initfunction)(Section*),bool canchange) {
 	Section_prop* blah = new Section_prop(_name);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -617,7 +617,7 @@ void SHELL_Init() {
 		"\033[44;1m\xC9\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
 		"\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
 		"\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBB\n"
-		"\xBA \033[32mWelcome to DOSBox %-48s\033[37m \xBA\n"
+		"\xBA \033[32mWelcome to dosbox-staging %-40s\033[37m \xBA\n"
 		"\xBA                                                                    \xBA\n"
 //		"\xBA DOSBox runs real and protected mode games.                         \xBA\n"
 		"\xBA For a short introduction for new users type: \033[33mINTRO\033[37m                 \xBA\n"
@@ -651,7 +651,7 @@ void SHELL_Init() {
 	        "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBC\033[0m\n"
 	        //"\n" //Breaks the startup message if you type a mount and a drive change.
 	);
-	MSG_Add("SHELL_STARTUP_SUB","\n\n\033[32;1mDOSBox %s Command Shell\033[0m\n\n");
+	MSG_Add("SHELL_STARTUP_SUB","\033[32;1mdosbox-staging %s\033[0m\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP","Displays/changes the current directory.\n");
 	MSG_Add("SHELL_CMD_CHDIR_HELP_LONG","CHDIR [drive:][path]\n"
 	        "CHDIR [..]\n"


### PR DESCRIPTION
A bag of small improvements to sdlmain code:

- Some log cleanups for the most often printed lines
- Window title change to make it shorter
- `--version` info update
- Restoring `sdl.display` property