### PR TITLE
fixup! Add AUTOTYPE to DOSBox's programs

### DIFF
--- a/src/dos/program_autotype.cpp
+++ b/src/dos/program_autotype.cpp
@@ -86,7 +86,7 @@ void AUTOTYPE::PrintKeys()
 	auto name = names.begin();
 	for (size_t row = 0; row < rows; ++row) {
 		for (size_t i = row; i < names.size(); i += rows)
-			WriteOut("  %-*s", max_length, name[i].c_str());
+			WriteOut("  %-*s", static_cast<int>(max_length), name[i].c_str());
 		WriteOut_NoParsing("\n");
 	}
 }


### PR DESCRIPTION
Fixes a field-width issue flagged by Coverity:

> Field width argument "max_length" to format specifier "%-*s" was expected to have type "int" but has type "unsigned long".
